### PR TITLE
Address 9 API audit reviewer observations

### DIFF
--- a/apps/api/src/config/database.ts
+++ b/apps/api/src/config/database.ts
@@ -3,14 +3,9 @@ import { Pool } from "pg";
 import { env } from "./env.js";
 import * as schema from "@/db/schema/index.js";
 import * as relations from "@/db/schema/relations.js";
+import type { Logger } from "@/types/logger.js";
 
 const fullSchema = { ...schema, ...relations };
-
-interface Logger {
-  info(msg: string): void;
-  error(msg: string): void;
-  error(obj: unknown, msg: string): void;
-}
 
 // Create connection pool
 // Tests use unique phone numbers for isolation, not separate databases

--- a/apps/api/src/controllers/auth.controller.ts
+++ b/apps/api/src/controllers/auth.controller.ts
@@ -1,4 +1,9 @@
 import type { FastifyRequest, FastifyReply } from "fastify";
+import type {
+  RequestCodeInput,
+  VerifyCodeInput,
+  CompleteProfileInput,
+} from "@tripful/shared/schemas";
 import { validatePhoneNumber } from "@/utils/phone.js";
 import { InvalidCodeError } from "../errors.js";
 
@@ -17,7 +22,7 @@ export const authController = {
    * @returns Success response with message
    */
   async requestCode(
-    request: FastifyRequest<{ Body: { phoneNumber: string } }>,
+    request: FastifyRequest<{ Body: RequestCodeInput }>,
     reply: FastifyReply,
   ) {
     // Body is validated by Fastify route schema
@@ -88,7 +93,7 @@ export const authController = {
    * @returns Success response with user and requiresProfile flag
    */
   async verifyCode(
-    request: FastifyRequest<{ Body: { phoneNumber: string; code: string } }>,
+    request: FastifyRequest<{ Body: VerifyCodeInput }>,
     reply: FastifyReply,
   ) {
     // Body is validated by Fastify route schema
@@ -182,9 +187,7 @@ export const authController = {
    * @returns Success response with updated user
    */
   async completeProfile(
-    request: FastifyRequest<{
-      Body: { displayName: string; timezone?: string };
-    }>,
+    request: FastifyRequest<{ Body: CompleteProfileInput }>,
     reply: FastifyReply,
   ) {
     // Body is validated by Fastify route schema

--- a/apps/api/src/controllers/trip.controller.ts
+++ b/apps/api/src/controllers/trip.controller.ts
@@ -1,5 +1,10 @@
 import type { FastifyRequest, FastifyReply } from "fastify";
-import type { CreateTripInput, UpdateTripInput } from "@tripful/shared/schemas";
+import type {
+  CreateTripInput,
+  UpdateTripInput,
+  AddCoOrganizerInput,
+  PaginationInput,
+} from "@tripful/shared/schemas";
 import { TripNotFoundError, PermissionDeniedError } from "../errors.js";
 
 /**
@@ -73,22 +78,15 @@ export const tripController = {
    * @returns Success response with user's trips
    */
   async getUserTrips(
-    request: FastifyRequest<{
-      Querystring: { page?: string; limit?: string };
-    }>,
+    request: FastifyRequest<{ Querystring: PaginationInput }>,
     reply: FastifyReply,
   ) {
     try {
       const { tripService } = request.server;
       const userId = request.user.sub;
 
-      // Parse pagination query params
-      const query = request.query;
-      const page = Math.max(1, parseInt(query.page ?? "1", 10) || 1);
-      const limit = Math.min(
-        100,
-        Math.max(1, parseInt(query.limit ?? "20", 10) || 20),
-      );
+      // Pagination params are validated and coerced by Fastify route schema
+      const { page, limit } = request.query;
 
       const result = await tripService.getUserTrips(userId, page, limit);
 
@@ -289,7 +287,7 @@ export const tripController = {
   async addCoOrganizer(
     request: FastifyRequest<{
       Params: { id: string };
-      Body: { phoneNumber: string };
+      Body: AddCoOrganizerInput;
     }>,
     reply: FastifyReply,
   ): Promise<void> {

--- a/apps/api/src/db/migrations/0003_deep_sinister_six.sql
+++ b/apps/api/src/db/migrations/0003_deep_sinister_six.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS "members_trip_user_idx";

--- a/apps/api/src/db/migrations/meta/0003_snapshot.json
+++ b/apps/api/src/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,414 @@
+{
+  "id": "8aa67c26-9f4b-4f6b-b9fe-168a87e58870",
+  "prevId": "07669621-48df-4a49-b84c-c470c9417f42",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "rsvp_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'no_response'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "members_trip_id_idx": {
+          "name": "members_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "members_user_id_idx": {
+          "name": "members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "members_trip_id_trips_id_fk": {
+          "name": "members_trip_id_trips_id_fk",
+          "tableFrom": "members",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "members_user_id_users_id_fk": {
+          "name": "members_user_id_users_id_fk",
+          "tableFrom": "members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "members_trip_user_unique": {
+          "name": "members_trip_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trip_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trips": {
+      "name": "trips",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_timezone": {
+          "name": "preferred_timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allow_members_to_add_events": {
+          "name": "allow_members_to_add_events",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cancelled": {
+          "name": "cancelled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trips_created_by_idx": {
+          "name": "trips_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trips_created_by_users_id_fk": {
+          "name": "trips_created_by_users_id_fk",
+          "tableFrom": "trips",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_photo_url": {
+          "name": "profile_photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_phone_number_idx": {
+          "name": "users_phone_number_idx",
+          "columns": [
+            {
+              "expression": "phone_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_phone_number_unique": {
+          "name": "users_phone_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_codes": {
+      "name": "verification_codes",
+      "schema": "",
+      "columns": {
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(20)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "char(6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_codes_expires_at_idx": {
+          "name": "verification_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.rsvp_status": {
+      "name": "rsvp_status",
+      "schema": "public",
+      "values": [
+        "going",
+        "not_going",
+        "maybe",
+        "no_response"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1770434924678,
       "tag": "0002_mysterious_hercules",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1770472832210,
+      "tag": "0003_deep_sinister_six",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -124,7 +124,6 @@ export const members = pgTable(
   (table) => ({
     tripIdIdx: index("members_trip_id_idx").on(table.tripId),
     userIdIdx: index("members_user_id_idx").on(table.userId),
-    tripUserIdx: index("members_trip_user_idx").on(table.tripId, table.userId),
     tripUserUnique: unique("members_trip_user_unique").on(
       table.tripId,
       table.userId,

--- a/apps/api/src/plugins/auth-service.ts
+++ b/apps/api/src/plugins/auth-service.ts
@@ -9,7 +9,7 @@ import { AuthService } from "@/services/auth.service.js";
  */
 export default fp(
   async function authServicePlugin(fastify: FastifyInstance) {
-    const authService = new AuthService(fastify);
+    const authService = new AuthService(fastify.db, fastify);
     fastify.decorate("authService", authService);
   },
   {

--- a/apps/api/src/plugins/health-service.ts
+++ b/apps/api/src/plugins/health-service.ts
@@ -1,6 +1,7 @@
 import fp from "fastify-plugin";
 import type { FastifyInstance } from "fastify";
-import { healthService } from "@/services/health.service.js";
+import { HealthService } from "@/services/health.service.js";
+import { testConnection } from "@/config/database.js";
 
 /**
  * Health service plugin
@@ -8,6 +9,7 @@ import { healthService } from "@/services/health.service.js";
  */
 export default fp(
   async function healthServicePlugin(fastify: FastifyInstance) {
+    const healthService = new HealthService(testConnection);
     fastify.decorate("healthService", healthService);
   },
   {

--- a/apps/api/src/plugins/permissions-service.ts
+++ b/apps/api/src/plugins/permissions-service.ts
@@ -8,7 +8,7 @@ import { PermissionsService } from "@/services/permissions.service.js";
  */
 export default fp(
   async function permissionsServicePlugin(fastify: FastifyInstance) {
-    const permissionsService = new PermissionsService();
+    const permissionsService = new PermissionsService(fastify.db);
     fastify.decorate("permissionsService", permissionsService);
   },
   {

--- a/apps/api/src/plugins/trip-service.ts
+++ b/apps/api/src/plugins/trip-service.ts
@@ -8,7 +8,7 @@ import { TripService } from "@/services/trip.service.js";
  */
 export default fp(
   async function tripServicePlugin(fastify: FastifyInstance) {
-    const tripService = new TripService();
+    const tripService = new TripService(fastify.db, fastify.permissionsService);
     fastify.decorate("tripService", tripService);
   },
   {

--- a/apps/api/src/routes/auth.routes.ts
+++ b/apps/api/src/routes/auth.routes.ts
@@ -10,6 +10,11 @@ import {
   verifyCodeSchema,
   completeProfileSchema,
 } from "@tripful/shared/schemas";
+import type {
+  RequestCodeInput,
+  VerifyCodeInput,
+  CompleteProfileInput,
+} from "@tripful/shared/schemas";
 
 /**
  * Authentication Routes
@@ -23,7 +28,7 @@ export async function authRoutes(fastify: FastifyInstance) {
    * Request a verification code via SMS
    * Rate limited to 5 requests per phone number per hour
    */
-  fastify.post(
+  fastify.post<{ Body: RequestCodeInput }>(
     "/request-code",
     {
       schema: {
@@ -39,7 +44,7 @@ export async function authRoutes(fastify: FastifyInstance) {
    * Verify a code and authenticate user
    * Rate limited to 10 attempts per phone number per 15 minutes
    */
-  fastify.post(
+  fastify.post<{ Body: VerifyCodeInput }>(
     "/verify-code",
     {
       schema: {
@@ -55,7 +60,7 @@ export async function authRoutes(fastify: FastifyInstance) {
    * Complete user profile with display name and timezone
    * Requires authentication via JWT token
    */
-  fastify.post<{ Body: { displayName: string; timezone?: string } }>(
+  fastify.post<{ Body: CompleteProfileInput }>(
     "/complete-profile",
     {
       schema: {

--- a/apps/api/src/routes/trip.routes.ts
+++ b/apps/api/src/routes/trip.routes.ts
@@ -9,6 +9,13 @@ import {
   createTripSchema,
   updateTripSchema,
   addCoOrganizerSchema,
+  paginationSchema,
+} from "@tripful/shared/schemas";
+import type {
+  PaginationInput,
+  CreateTripInput,
+  UpdateTripInput,
+  AddCoOrganizerInput,
 } from "@tripful/shared/schemas";
 
 // Reusable param schemas
@@ -37,9 +44,12 @@ export async function tripRoutes(fastify: FastifyInstance) {
    * Get user's trips
    * Requires authentication only (not complete profile)
    */
-  fastify.get<{ Querystring: { page?: string; limit?: string } }>(
+  fastify.get<{ Querystring: PaginationInput }>(
     "/",
     {
+      schema: {
+        querystring: paginationSchema,
+      },
       preHandler: authenticate,
     },
     tripController.getUserTrips,
@@ -74,7 +84,7 @@ export async function tripRoutes(fastify: FastifyInstance) {
      * POST /
      * Create a new trip
      */
-    scope.post(
+    scope.post<{ Body: CreateTripInput }>(
       "/",
       {
         schema: {
@@ -89,7 +99,7 @@ export async function tripRoutes(fastify: FastifyInstance) {
      * Update trip details
      * Only organizers can update trips
      */
-    scope.put(
+    scope.put<{ Params: { id: string }; Body: UpdateTripInput }>(
       "/:id",
       {
         schema: {
@@ -105,7 +115,7 @@ export async function tripRoutes(fastify: FastifyInstance) {
      * Cancel trip (soft delete)
      * Only organizers can cancel trips
      */
-    scope.delete(
+    scope.delete<{ Params: { id: string } }>(
       "/:id",
       {
         schema: {
@@ -120,7 +130,7 @@ export async function tripRoutes(fastify: FastifyInstance) {
      * Add co-organizer to trip
      * Only organizers can add co-organizers
      */
-    scope.post(
+    scope.post<{ Params: { id: string }; Body: AddCoOrganizerInput }>(
       "/:id/co-organizers",
       {
         schema: {
@@ -136,7 +146,7 @@ export async function tripRoutes(fastify: FastifyInstance) {
      * Remove co-organizer from trip
      * Only organizers can remove co-organizers
      */
-    scope.delete(
+    scope.delete<{ Params: { id: string; userId: string } }>(
       "/:id/co-organizers/:userId",
       {
         schema: {
@@ -152,7 +162,7 @@ export async function tripRoutes(fastify: FastifyInstance) {
      * Only organizers can upload cover images
      * Note: No body schema for multipart routes
      */
-    scope.post(
+    scope.post<{ Params: { id: string } }>(
       "/:id/cover-image",
       {
         schema: {
@@ -167,7 +177,7 @@ export async function tripRoutes(fastify: FastifyInstance) {
      * Delete cover image from trip
      * Only organizers can delete cover images
      */
-    scope.delete(
+    scope.delete<{ Params: { id: string } }>(
       "/:id/cover-image",
       {
         schema: {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -9,20 +9,17 @@ import { closeDatabase, testConnection } from "./config/database.js";
 
 const app = await buildApp({
   fastify: {
-    logger:
-      env.NODE_ENV === "development"
-        ? {
-            transport: { target: "pino-pretty" },
-            level: "debug",
-          }
-        : {
-            level: env.LOG_LEVEL,
-            redact: [
-              "req.headers.authorization",
-              "req.headers.cookie",
-              "req.body.phoneNumber",
-            ],
-          },
+    logger: {
+      level: env.NODE_ENV === "development" ? "debug" : env.LOG_LEVEL,
+      redact: [
+        "req.headers.authorization",
+        "req.headers.cookie",
+        "req.body.phoneNumber",
+      ],
+      ...(env.NODE_ENV === "development" && {
+        transport: { target: "pino-pretty" },
+      }),
+    },
     requestIdHeader: "x-request-id",
     requestIdLogLabel: "reqId",
     connectionTimeout: 30000,

--- a/apps/api/src/services/health.service.ts
+++ b/apps/api/src/services/health.service.ts
@@ -1,14 +1,19 @@
-import { testConnection } from "@/config/database.js";
 import type { HealthCheckResponse } from "@/types/index.js";
 
-export const healthService = {
+/**
+ * Health Service
+ * Checks database connectivity and returns system status
+ */
+export class HealthService {
+  constructor(private testConnection: () => Promise<boolean>) {}
+
   async getStatus(): Promise<HealthCheckResponse> {
-    const dbConnected = await testConnection();
+    const dbConnected = await this.testConnection();
 
     return {
       status: "ok",
       timestamp: new Date().toISOString(),
       database: dbConnected ? "connected" : "disconnected",
     };
-  },
-};
+  }
+}

--- a/apps/api/src/services/sms.service.ts
+++ b/apps/api/src/services/sms.service.ts
@@ -1,7 +1,4 @@
-interface Logger {
-  info(msg: string): void;
-  info(obj: Record<string, unknown>, msg: string): void;
-}
+import type { Logger } from "@/types/logger.js";
 
 /**
  * SMS Service Interface
@@ -43,9 +40,3 @@ export class MockSMSService implements ISMSService {
     }
   }
 }
-
-/**
- * Singleton instance of the SMS service
- * Use this instance throughout the application
- */
-export const smsService = new MockSMSService();

--- a/apps/api/src/services/upload.service.ts
+++ b/apps/api/src/services/upload.service.ts
@@ -162,9 +162,3 @@ export class UploadService implements IUploadService {
     }
   }
 }
-
-/**
- * Singleton instance of the upload service
- * Use this instance throughout the application
- */
-export const uploadService = new UploadService();

--- a/apps/api/src/types/index.ts
+++ b/apps/api/src/types/index.ts
@@ -10,7 +10,8 @@ import type { IPermissionsService } from "@/services/permissions.service.js";
 import type { IUploadService } from "@/services/upload.service.js";
 import type { ISMSService } from "@/services/sms.service.js";
 
-type FullSchema = typeof schema & typeof relations;
+export type FullSchema = typeof schema & typeof relations;
+export type AppDatabase = NodePgDatabase<FullSchema>;
 
 export interface HealthCheckResponse {
   status: "ok" | "error";

--- a/apps/api/src/types/logger.ts
+++ b/apps/api/src/types/logger.ts
@@ -1,0 +1,6 @@
+export interface Logger {
+  info(msg: string): void;
+  info(obj: Record<string, unknown>, msg: string): void;
+  error(msg: string): void;
+  error(obj: unknown, msg: string): void;
+}

--- a/apps/api/tests/unit/auth.service.test.ts
+++ b/apps/api/tests/unit/auth.service.test.ts
@@ -5,9 +5,12 @@ import jwt from "@fastify/jwt";
 import { db } from "@/config/database.js";
 import { users, verificationCodes } from "@/db/schema/index.js";
 import { eq } from "drizzle-orm";
-import { authService, AuthService } from "@/services/auth.service.js";
+import { AuthService } from "@/services/auth.service.js";
 import { env } from "@/config/env.js";
 import { generateUniquePhone } from "../test-utils.js";
+
+// Create service instance with db for testing
+const authService = new AuthService(db);
 
 describe("auth.service", () => {
   // Use unique phone numbers per test run to enable parallel execution
@@ -514,7 +517,7 @@ describe("auth.service", () => {
       });
       await app.ready();
 
-      testAuthService = new AuthService(app);
+      testAuthService = new AuthService(db, app);
 
       // Create test user
       const user = await authService.getOrCreateUser(testPhoneNumber);
@@ -544,7 +547,7 @@ describe("auth.service", () => {
       });
       await app.ready();
 
-      testAuthService = new AuthService(app);
+      testAuthService = new AuthService(db, app);
 
       // Create test user with default values (empty displayName)
       const user = await authService.getOrCreateUser(testPhoneNumber);
@@ -565,7 +568,7 @@ describe("auth.service", () => {
       });
       await app.ready();
 
-      testAuthService = new AuthService(app);
+      testAuthService = new AuthService(db, app);
 
       // Create test user
       const user = await authService.getOrCreateUser(testPhoneNumber);
@@ -595,7 +598,7 @@ describe("auth.service", () => {
       });
       await app.ready();
 
-      testAuthService = new AuthService(app);
+      testAuthService = new AuthService(db, app);
 
       const user = await authService.getOrCreateUser(testPhoneNumber);
       const beforeGenerate = Math.floor(Date.now() / 1000);
@@ -612,7 +615,7 @@ describe("auth.service", () => {
     });
 
     it("should throw error when FastifyInstance not available", () => {
-      const serviceWithoutFastify = new AuthService();
+      const serviceWithoutFastify = new AuthService(db);
       const mockUser = {
         id: testUserId,
         phoneNumber: testPhoneNumber,
@@ -637,7 +640,7 @@ describe("auth.service", () => {
       });
       await app.ready();
 
-      testAuthService = new AuthService(app);
+      testAuthService = new AuthService(db, app);
 
       // Create user with empty displayName
       const user = await authService.getOrCreateUser(testPhoneNumber);
@@ -670,7 +673,7 @@ describe("auth.service", () => {
       });
       await app.ready();
 
-      testAuthService = new AuthService(app);
+      testAuthService = new AuthService(db, app);
 
       // Create user and generate token
       const user = await authService.getOrCreateUser(testPhoneNumber);
@@ -704,7 +707,7 @@ describe("auth.service", () => {
       });
       await app.ready();
 
-      testAuthService = new AuthService(app);
+      testAuthService = new AuthService(db, app);
 
       // Create user and generate token with 1ms expiry
       const user = await authService.getOrCreateUser(testPhoneNumber);
@@ -728,7 +731,7 @@ describe("auth.service", () => {
       });
       await app.ready();
 
-      testAuthService = new AuthService(app);
+      testAuthService = new AuthService(db, app);
 
       const invalidToken = "this.is.not.a.valid.jwt";
 
@@ -746,7 +749,7 @@ describe("auth.service", () => {
       });
       await app.ready();
 
-      testAuthService = new AuthService(app);
+      testAuthService = new AuthService(db, app);
 
       // Create a token with different secret
       const differentSecretApp = Fastify({ logger: false });
@@ -779,7 +782,7 @@ describe("auth.service", () => {
       });
       await app.ready();
 
-      testAuthService = new AuthService(app);
+      testAuthService = new AuthService(db, app);
 
       const malformedToken = "not-a-token";
 
@@ -789,7 +792,7 @@ describe("auth.service", () => {
     });
 
     it("should throw error when FastifyInstance not available", () => {
-      const serviceWithoutFastify = new AuthService();
+      const serviceWithoutFastify = new AuthService(db);
 
       expect(() => serviceWithoutFastify.verifyToken("any-token")).toThrow(
         "FastifyInstance not available",
@@ -805,7 +808,7 @@ describe("auth.service", () => {
       });
       await app.ready();
 
-      testAuthService = new AuthService(app);
+      testAuthService = new AuthService(db, app);
 
       // Create user with empty displayName
       const user = await authService.getOrCreateUser(testPhoneNumber);
@@ -839,7 +842,7 @@ describe("auth.service", () => {
       });
       await app.ready();
 
-      testAuthService = new AuthService(app);
+      testAuthService = new AuthService(db, app);
 
       // Create user with full profile
       const user = await authService.getOrCreateUser(testPhoneNumber);
@@ -882,7 +885,7 @@ describe("auth.service", () => {
       });
       await app.ready();
 
-      testAuthService = new AuthService(app);
+      testAuthService = new AuthService(db, app);
 
       // 1. Generate and store verification code
       const code = authService.generateCode();

--- a/apps/api/tests/unit/permissions.service.test.ts
+++ b/apps/api/tests/unit/permissions.service.test.ts
@@ -2,8 +2,11 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { db } from "@/config/database.js";
 import { users, trips, members } from "@/db/schema/index.js";
 import { eq, or } from "drizzle-orm";
-import { permissionsService } from "@/services/permissions.service.js";
+import { PermissionsService } from "@/services/permissions.service.js";
 import { generateUniquePhone } from "../test-utils.js";
+
+// Create service instance with db for testing
+const permissionsService = new PermissionsService(db);
 
 describe("permissions.service", () => {
   // Use unique test data for each test run to enable parallel execution

--- a/apps/api/tests/unit/trip.service.test.ts
+++ b/apps/api/tests/unit/trip.service.test.ts
@@ -2,9 +2,14 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { db } from "@/config/database.js";
 import { trips, members, users, type User } from "@/db/schema/index.js";
 import { eq, and } from "drizzle-orm";
-import { tripService, type TripSummary } from "@/services/trip.service.js";
+import { TripService, type TripSummary } from "@/services/trip.service.js";
+import { PermissionsService } from "@/services/permissions.service.js";
 import { generateUniquePhone } from "../test-utils.js";
 import type { CreateTripInput } from "@tripful/shared/schemas";
+
+// Create service instances with db for testing
+const permissionsService = new PermissionsService(db);
+const tripService = new TripService(db, permissionsService);
 
 describe("trip.service", () => {
   // Use unique phone numbers per test run to enable parallel execution

--- a/apps/api/tests/unit/upload.service.test.ts
+++ b/apps/api/tests/unit/upload.service.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { existsSync, readdirSync, unlinkSync, rmSync } from "node:fs";
 import { resolve } from "node:path";
-import { uploadService } from "@/services/upload.service.js";
+import { UploadService } from "@/services/upload.service.js";
+
+// Create service instance for testing
+const uploadService = new UploadService();
 
 describe("upload.service", () => {
   const testUploadsDir = resolve(process.cwd(), "uploads");

--- a/shared/schemas/index.ts
+++ b/shared/schemas/index.ts
@@ -42,7 +42,9 @@ export {
   createTripSchema,
   updateTripSchema,
   addCoOrganizerSchema,
+  paginationSchema,
   type CreateTripInput,
   type UpdateTripInput,
   type AddCoOrganizerInput,
+  type PaginationInput,
 } from "./trip";

--- a/shared/schemas/trip.ts
+++ b/shared/schemas/trip.ts
@@ -114,7 +114,19 @@ export const addCoOrganizerSchema = z.object({
   phoneNumber: phoneNumberSchema,
 });
 
+/**
+ * Validates pagination query parameters
+ * - page: integer >= 1, defaults to 1
+ * - limit: integer 1-100, defaults to 20
+ * Uses z.coerce to handle string query params from URLs
+ */
+export const paginationSchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
+
 // Inferred TypeScript types from schemas
 export type CreateTripInput = z.infer<typeof createTripSchema>;
 export type UpdateTripInput = z.infer<typeof updateTripSchema>;
 export type AddCoOrganizerInput = z.infer<typeof addCoOrganizerSchema>;
+export type PaginationInput = z.infer<typeof paginationSchema>;


### PR DESCRIPTION
## Summary

- **Remove redundant index**: Drop `tripUserIdx` composite index that duplicated the `tripUserUnique` constraint
- **DuplicateMemberError**: Catch PostgreSQL unique violations (23505) in `addCoOrganizers` instead of letting them bubble as 500s
- **Zod pagination**: Add `paginationSchema` to shared schemas; `GET /api/trips` now validates querystring via Fastify route schema instead of manual `parseInt`/`Math.max`/`Math.min`
- **Dev log redaction**: Move `redact` array to top-level logger config so it applies in both dev (pino-pretty) and production modes
- **Constructor injection**: All services (`AuthService`, `TripService`, `PermissionsService`, `HealthService`) now receive `db` via constructor instead of importing the singleton directly
- **Consolidated Logger**: Single `Logger` interface in `src/types/logger.ts`, imported by `sms.service.ts` and `database.ts`
- **Remove singletons**: Delete `export const xxxService = new XxxService()` from all service files; plugins are the single source of instantiation
- **Shared types in routes/controllers**: Route registration generics and controller handler signatures use Zod-inferred types (`RequestCodeInput`, `CreateTripInput`, `PaginationInput`, etc.) instead of inline type literals

## Test plan

- [x] `pnpm typecheck` — clean across all 3 packages
- [x] `pnpm test` — all 842 tests pass
- [x] `pnpm lint` — clean
- [x] Manual: verified dev server starts and log redaction config is correctly applied
- [ ] Verify migration applies cleanly on fresh database (`pnpm db:migrate`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)