### PR TITLE
Fix React Hook Form + Zod audit findings

### DIFF
--- a/apps/web/src/app/(auth)/complete-profile/page.tsx
+++ b/apps/web/src/app/(auth)/complete-profile/page.tsx
@@ -126,11 +126,11 @@ export default function CompleteProfilePage() {
                     </FormLabel>
                     <Select
                       onValueChange={field.onChange}
-                      {...(field.value ? { defaultValue: field.value } : {})}
+                      value={field.value ?? ""}
                       disabled={isSubmitting}
                     >
                       <FormControl>
-                        <SelectTrigger className="h-12 text-base border-slate-300 focus:border-blue-500 focus:ring-blue-500">
+                        <SelectTrigger ref={field.ref} onBlur={field.onBlur} className="h-12 text-base border-slate-300 focus:border-blue-500 focus:ring-blue-500">
                           <SelectValue placeholder="Select your timezone" />
                         </SelectTrigger>
                       </FormControl>

--- a/apps/web/src/app/(auth)/verify/page.test.tsx
+++ b/apps/web/src/app/(auth)/verify/page.test.tsx
@@ -290,13 +290,9 @@ describe("VerifyPage", () => {
     await user.click(resendButton);
 
     await waitFor(() => {
-      const successMessage = screen.queryByText((content, element) => {
-        return (
-          element?.getAttribute("data-slot") === "form-message" &&
-          content.includes("new code has been sent")
-        );
-      });
-      expect(successMessage).toBeTruthy();
+      expect(
+        screen.getByText(/new code has been sent/i),
+      ).toBeDefined();
     });
   });
 

--- a/apps/web/src/app/(auth)/verify/page.tsx
+++ b/apps/web/src/app/(auth)/verify/page.tsx
@@ -26,6 +26,7 @@ function VerifyPageContent() {
   const { verify, login } = useAuth();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isResending, setIsResending] = useState(false);
+  const [resendSuccess, setResendSuccess] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const form = useForm<VerifyCodeInput>({
@@ -64,10 +65,9 @@ function VerifyPageContent() {
   async function handleResendCode() {
     try {
       setIsResending(true);
+      setResendSuccess(null);
       await login(phoneNumber);
-      form.setError("code", {
-        message: "A new code has been sent to your phone",
-      });
+      setResendSuccess("A new code has been sent to your phone");
       form.setValue("code", "");
     } catch (error) {
       form.setError("code", {
@@ -113,6 +113,10 @@ function VerifyPageContent() {
                         disabled={isSubmitting}
                         maxLength={6}
                         {...field}
+                        onChange={(e) => {
+                          field.onChange(e);
+                          setResendSuccess(null);
+                        }}
                         ref={(e) => {
                           field.ref(e);
                           inputRef.current = e;
@@ -123,6 +127,11 @@ function VerifyPageContent() {
                       Check your SMS messages for the code
                     </FormDescription>
                     <FormMessage />
+                    {resendSuccess && (
+                      <p className="text-sm text-emerald-600">
+                        {resendSuccess}
+                      </p>
+                    )}
                   </FormItem>
                 )}
               />

--- a/apps/web/src/components/trip/__tests__/create-trip-dialog.test.tsx
+++ b/apps/web/src/components/trip/__tests__/create-trip-dialog.test.tsx
@@ -723,10 +723,10 @@ describe("CreateTripDialog", () => {
 
       await navigateToStep2(user);
 
-      const checkbox = screen.getByLabelText(
-        /allow members to add events/i,
-      ) as HTMLInputElement;
-      expect(checkbox.checked).toBe(true);
+      const checkbox = screen.getByRole("checkbox", {
+        name: /allow members to add events/i,
+      });
+      expect(checkbox.getAttribute("data-state")).toBe("checked");
     });
 
     it("can be toggled off", async () => {
@@ -737,14 +737,14 @@ describe("CreateTripDialog", () => {
 
       await navigateToStep2(user);
 
-      const checkbox = screen.getByLabelText(
-        /allow members to add events/i,
-      ) as HTMLInputElement;
-      expect(checkbox.checked).toBe(true);
+      const checkbox = screen.getByRole("checkbox", {
+        name: /allow members to add events/i,
+      });
+      expect(checkbox.getAttribute("data-state")).toBe("checked");
 
       await user.click(checkbox);
 
-      expect(checkbox.checked).toBe(false);
+      expect(checkbox.getAttribute("data-state")).toBe("unchecked");
     });
 
     it("can be toggled back on", async () => {
@@ -755,15 +755,15 @@ describe("CreateTripDialog", () => {
 
       await navigateToStep2(user);
 
-      const checkbox = screen.getByLabelText(
-        /allow members to add events/i,
-      ) as HTMLInputElement;
+      const checkbox = screen.getByRole("checkbox", {
+        name: /allow members to add events/i,
+      });
 
       await user.click(checkbox);
-      expect(checkbox.checked).toBe(false);
+      expect(checkbox.getAttribute("data-state")).toBe("unchecked");
 
       await user.click(checkbox);
-      expect(checkbox.checked).toBe(true);
+      expect(checkbox.getAttribute("data-state")).toBe("checked");
     });
 
     it("submits correct value when unchecked", async () => {
@@ -1131,10 +1131,10 @@ describe("CreateTripDialog", () => {
       ) as HTMLTextAreaElement;
       expect(descriptionInputAfterBack.value).toBe("Test description");
 
-      const checkboxAfterBack = screen.getByLabelText(
-        /allow members to add events/i,
-      ) as HTMLInputElement;
-      expect(checkboxAfterBack.checked).toBe(false);
+      const checkboxAfterBack = screen.getByRole("checkbox", {
+        name: /allow members to add events/i,
+      });
+      expect(checkboxAfterBack.getAttribute("data-state")).toBe("unchecked");
     });
   });
 

--- a/apps/web/src/components/trip/__tests__/edit-trip-dialog.test.tsx
+++ b/apps/web/src/components/trip/__tests__/edit-trip-dialog.test.tsx
@@ -180,10 +180,10 @@ describe("EditTripDialog", () => {
       await user.click(screen.getByRole("button", { name: /continue/i }));
 
       await waitFor(() => {
-        const checkbox = screen.getByLabelText(
-          /allow members to add events/i,
-        ) as HTMLInputElement;
-        expect(checkbox.checked).toBe(true);
+        const checkbox = screen.getByRole("checkbox", {
+          name: /allow members to add events/i,
+        });
+        expect(checkbox.getAttribute("data-state")).toBe("checked");
       });
     });
 

--- a/apps/web/src/components/ui/checkbox.tsx
+++ b/apps/web/src/components/ui/checkbox.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import * as React from "react"
+import { CheckIcon } from "lucide-react"
+import { Checkbox as CheckboxPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     globals: true,
-    setupFiles: [],
+    setupFiles: ["./vitest.setup.ts"],
     exclude: [
       "**/node_modules/**",
       "**/dist/**",

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -1,0 +1,6 @@
+// Polyfill ResizeObserver for jsdom (required by Radix UI components)
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};


### PR DESCRIPTION
## Summary
- Add `field.ref` and `field.onBlur` to all `SelectTrigger` components for proper RHF registration
- Migrate native `<input type="checkbox">` to shadcn `<Checkbox>` with full Radix field binding
- Replace inline error `<div>` boxes with `form.setError("root")` in trip dialogs
- Align co-organizer error color to `text-destructive` (matching `FormMessage`)
- Use dedicated `resendSuccess` state on verify page instead of misusing `form.setError` for success messages

## Test plan
- [x] `pnpm typecheck` — no TypeScript errors
- [x] `pnpm lint` — no lint errors
- [x] `pnpm test` — all 385 tests pass (16 files)
- [ ] Manual: Create trip dialog — verify timezone Select is focusable/blurrable
- [ ] Manual: Edit trip dialog — verify checkbox toggles correctly with new shadcn component
- [ ] Manual: Verify page — resend code shows green success message, clears on typing

🤖 Generated with [Claude Code](https://claude.com/claude-code)