### PR TITLE
API security hardening: headers, cookies, lockout, file validation, audit logging

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,9 @@ jobs:
         if: github.event_name == 'pull_request'
         run: pnpm turbo typecheck --affected
 
+      - name: Dependency audit
+        run: pnpm audit --audit-level=high
+
   # Step 3: Unit Tests (API)
   unit-tests:
     name: Unit Tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ Required: `DATABASE_URL` and `JWT_SECRET` (minimum 32 characters).
 - **TypeScript**: Strict mode enabled across all packages
 - **Formatting**: Prettier runs automatically via pre-commit hooks
 - **Linting**: ESLint with TypeScript plugin (auto-fix available)
+- **Dependency Audit**: `pnpm audit --audit-level=high` runs in CI; Dependabot creates PRs for vulnerable dependencies
 - **Pre-commit**: GitGuardian scans for secrets (requires Docker running)
 
 ### Testing Requirements

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -37,6 +37,7 @@
     "fastify": "^5.2.0",
     "fastify-plugin": "^5.1.0",
     "fastify-type-provider-zod": "^4.0.2",
+    "file-type": "^21.3.0",
     "libphonenumber-js": "^1.12.36",
     "pg": "^8.13.1",
     "zod": "^3.24.1"

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -90,7 +90,16 @@ export async function buildApp(
 
   // Register helmet (security headers)
   await app.register(helmet, {
-    contentSecurityPolicy: false,
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'none'"],
+        frameAncestors: ["'none'"],
+      },
+    },
+    strictTransportSecurity: {
+      maxAge: 31536000, // 1 year
+      includeSubDomains: true,
+    },
     crossOriginResourcePolicy: { policy: "cross-origin" },
   });
 
@@ -183,6 +192,7 @@ export async function buildApp(
         code: "NOT_FOUND",
         message: `Route ${request.method} ${request.url} not found`,
       },
+      requestId: request.id,
     });
   });
 

--- a/apps/api/src/controllers/accommodation.controller.ts
+++ b/apps/api/src/controllers/accommodation.controller.ts
@@ -4,6 +4,7 @@ import type {
   UpdateAccommodationInput,
 } from "@tripful/shared/schemas";
 import { AccommodationNotFoundError, TripNotFoundError } from "../errors.js";
+import { auditLog } from "@/utils/audit.js";
 
 /**
  * Accommodation Controller
@@ -280,6 +281,11 @@ export const accommodationController = {
 
       // Call service to delete accommodation (soft delete)
       await request.server.accommodationService.deleteAccommodation(userId, id);
+
+      auditLog(request, "accommodation.delete", {
+        resourceType: "accommodation",
+        resourceId: id,
+      });
 
       // Return success response
       return reply.status(200).send({

--- a/apps/api/src/controllers/auth.controller.ts
+++ b/apps/api/src/controllers/auth.controller.ts
@@ -143,7 +143,9 @@ export const authController = {
       // Set httpOnly cookie with token
       reply.setCookie("auth_token", token, {
         httpOnly: true,
-        secure: request.server.config.COOKIE_SECURE,
+        secure:
+          request.server.config.NODE_ENV === "production" ||
+          request.server.config.COOKIE_SECURE,
         sameSite: "lax",
         path: "/",
         maxAge: 7 * 24 * 60 * 60, // 7 days in seconds
@@ -221,7 +223,9 @@ export const authController = {
       // Set httpOnly cookie with token
       reply.setCookie("auth_token", token, {
         httpOnly: true,
-        secure: request.server.config.COOKIE_SECURE,
+        secure:
+          request.server.config.NODE_ENV === "production" ||
+          request.server.config.COOKIE_SECURE,
         sameSite: "lax",
         path: "/",
         maxAge: 7 * 24 * 60 * 60, // 7 days in seconds

--- a/apps/api/src/controllers/event.controller.ts
+++ b/apps/api/src/controllers/event.controller.ts
@@ -4,6 +4,7 @@ import type {
   UpdateEventInput,
 } from "@tripful/shared/schemas";
 import { EventNotFoundError, TripNotFoundError } from "../errors.js";
+import { auditLog } from "@/utils/audit.js";
 
 /**
  * Event Controller
@@ -301,6 +302,11 @@ export const eventController = {
 
       // Call service to delete event (soft delete)
       await request.server.eventService.deleteEvent(userId, id);
+
+      auditLog(request, "event.delete", {
+        resourceType: "event",
+        resourceId: id,
+      });
 
       // Return success response
       return reply.status(200).send({

--- a/apps/api/src/controllers/invitation.controller.ts
+++ b/apps/api/src/controllers/invitation.controller.ts
@@ -4,6 +4,7 @@ import type {
   UpdateRsvpInput,
 } from "@tripful/shared/schemas";
 import { PermissionDeniedError } from "../errors.js";
+import { auditLog } from "@/utils/audit.js";
 
 /**
  * Invitation Controller
@@ -43,6 +44,12 @@ export const invitationController = {
         tripId,
         phoneNumbers,
       );
+
+      auditLog(request, "invitation.created", {
+        resourceType: "trip",
+        resourceId: tripId,
+        metadata: { count: result.invitations.length },
+      });
 
       // Return success response with 201 status
       return reply.status(201).send({
@@ -155,6 +162,11 @@ export const invitationController = {
       // Call service to revoke invitation
       await request.server.invitationService.revokeInvitation(userId, id);
 
+      auditLog(request, "invitation.revoked", {
+        resourceType: "invitation",
+        resourceId: id,
+      });
+
       // Return success response
       return reply.status(200).send({
         success: true,
@@ -210,6 +222,12 @@ export const invitationController = {
         tripId,
         memberId,
       );
+
+      auditLog(request, "member.removed", {
+        resourceType: "trip",
+        resourceId: tripId,
+        metadata: { memberId },
+      });
 
       return reply.status(204).send();
     } catch (error) {
@@ -267,6 +285,12 @@ export const invitationController = {
 
       // Update RSVP via service
       const member = await invitationService.updateRsvp(userId, tripId, status);
+
+      auditLog(request, "member.rsvp_updated", {
+        resourceType: "trip",
+        resourceId: tripId,
+        metadata: { status },
+      });
 
       // Return success response
       return reply.status(200).send({

--- a/apps/api/src/controllers/trip.controller.ts
+++ b/apps/api/src/controllers/trip.controller.ts
@@ -6,6 +6,7 @@ import type {
   PaginationInput,
 } from "@tripful/shared/schemas";
 import { TripNotFoundError, PermissionDeniedError } from "../errors.js";
+import { auditLog } from "@/utils/audit.js";
 
 /**
  * Trip Controller
@@ -38,6 +39,11 @@ export const tripController = {
 
       // Create trip via service
       const trip = await tripService.createTrip(userId, data);
+
+      auditLog(request, "trip.create", {
+        resourceType: "trip",
+        resourceId: trip.id,
+      });
 
       // Return success response with 201 status
       return reply.status(201).send({
@@ -201,6 +207,11 @@ export const tripController = {
         data,
       );
 
+      auditLog(request, "trip.update", {
+        resourceType: "trip",
+        resourceId: id,
+      });
+
       // Return success response
       return reply.status(200).send({
         success: true,
@@ -252,6 +263,11 @@ export const tripController = {
 
       // Call service to cancel trip (soft delete)
       await request.server.tripService.cancelTrip(id, userId);
+
+      auditLog(request, "trip.cancel", {
+        resourceType: "trip",
+        resourceId: id,
+      });
 
       // Return success response
       return reply.status(200).send({
@@ -310,6 +326,11 @@ export const tripController = {
         phoneNumber,
       ]);
 
+      auditLog(request, "trip.co_organizer_added", {
+        resourceType: "trip",
+        resourceId: id,
+      });
+
       // Return success response
       return reply.status(200).send({
         success: true,
@@ -364,6 +385,12 @@ export const tripController = {
         userId,
         coOrgUserId,
       );
+
+      auditLog(request, "trip.co_organizer_removed", {
+        resourceType: "trip",
+        resourceId: id,
+        metadata: { targetUserId: coOrgUserId },
+      });
 
       // Return success response
       return reply.status(200).send({

--- a/apps/api/src/db/migrations/0008_brainy_wind_dancer.sql
+++ b/apps/api/src/db/migrations/0008_brainy_wind_dancer.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "verification_codes" ADD COLUMN "failed_attempts" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "verification_codes" ADD COLUMN "locked_until" timestamp with time zone;

--- a/apps/api/src/db/migrations/meta/0008_snapshot.json
+++ b/apps/api/src/db/migrations/meta/0008_snapshot.json
@@ -1,0 +1,1213 @@
+{
+  "id": "2d49d422-d41b-457e-82ad-3d20a724ffdd",
+  "prevId": "59906ad0-9b76-4dd9-8537-5f91c37c9064",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accommodations": {
+      "name": "accommodations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "check_in": {
+          "name": "check_in",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_out": {
+          "name": "check_out",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "links": {
+          "name": "links",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accommodations_trip_id_idx": {
+          "name": "accommodations_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_created_by_idx": {
+          "name": "accommodations_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_check_in_idx": {
+          "name": "accommodations_check_in_idx",
+          "columns": [
+            {
+              "expression": "check_in",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_deleted_at_idx": {
+          "name": "accommodations_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accommodations_trip_id_trips_id_fk": {
+          "name": "accommodations_trip_id_trips_id_fk",
+          "tableFrom": "accommodations",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accommodations_created_by_users_id_fk": {
+          "name": "accommodations_created_by_users_id_fk",
+          "tableFrom": "accommodations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "accommodations_deleted_by_users_id_fk": {
+          "name": "accommodations_deleted_by_users_id_fk",
+          "tableFrom": "accommodations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meetup_location": {
+          "name": "meetup_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meetup_time": {
+          "name": "meetup_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_day": {
+          "name": "all_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_optional": {
+          "name": "is_optional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "links": {
+          "name": "links",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_trip_id_idx": {
+          "name": "events_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_created_by_idx": {
+          "name": "events_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_start_time_idx": {
+          "name": "events_start_time_idx",
+          "columns": [
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_deleted_at_idx": {
+          "name": "events_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_trip_id_trips_id_fk": {
+          "name": "events_trip_id_trips_id_fk",
+          "tableFrom": "events",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_created_by_users_id_fk": {
+          "name": "events_created_by_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_deleted_by_users_id_fk": {
+          "name": "events_deleted_by_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_phone": {
+          "name": "invitee_phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitations_trip_id_idx": {
+          "name": "invitations_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_invitee_phone_idx": {
+          "name": "invitations_invitee_phone_idx",
+          "columns": [
+            {
+              "expression": "invitee_phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_trip_id_trips_id_fk": {
+          "name": "invitations_trip_id_trips_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_id_users_id_fk": {
+          "name": "invitations_inviter_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitations_trip_phone_unique": {
+          "name": "invitations_trip_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trip_id",
+            "invitee_phone"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member_travel": {
+      "name": "member_travel",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "travel_type": {
+          "name": "travel_type",
+          "type": "member_travel_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_travel_trip_id_idx": {
+          "name": "member_travel_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_member_id_idx": {
+          "name": "member_travel_member_id_idx",
+          "columns": [
+            {
+              "expression": "member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_time_idx": {
+          "name": "member_travel_time_idx",
+          "columns": [
+            {
+              "expression": "time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_deleted_at_idx": {
+          "name": "member_travel_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_travel_trip_id_trips_id_fk": {
+          "name": "member_travel_trip_id_trips_id_fk",
+          "tableFrom": "member_travel",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_travel_member_id_members_id_fk": {
+          "name": "member_travel_member_id_members_id_fk",
+          "tableFrom": "member_travel",
+          "tableTo": "members",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_travel_deleted_by_users_id_fk": {
+          "name": "member_travel_deleted_by_users_id_fk",
+          "tableFrom": "member_travel",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "rsvp_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'no_response'"
+        },
+        "is_organizer": {
+          "name": "is_organizer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "members_trip_id_idx": {
+          "name": "members_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "members_user_id_idx": {
+          "name": "members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "members_trip_id_trips_id_fk": {
+          "name": "members_trip_id_trips_id_fk",
+          "tableFrom": "members",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "members_user_id_users_id_fk": {
+          "name": "members_user_id_users_id_fk",
+          "tableFrom": "members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "members_trip_user_unique": {
+          "name": "members_trip_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trip_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trips": {
+      "name": "trips",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_timezone": {
+          "name": "preferred_timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allow_members_to_add_events": {
+          "name": "allow_members_to_add_events",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cancelled": {
+          "name": "cancelled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trips_created_by_idx": {
+          "name": "trips_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trips_created_by_users_id_fk": {
+          "name": "trips_created_by_users_id_fk",
+          "tableFrom": "trips",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_photo_url": {
+          "name": "profile_photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handles": {
+          "name": "handles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_phone_number_idx": {
+          "name": "users_phone_number_idx",
+          "columns": [
+            {
+              "expression": "phone_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_phone_number_unique": {
+          "name": "users_phone_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification_codes": {
+      "name": "verification_codes",
+      "schema": "",
+      "columns": {
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(20)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "char(6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failed_attempts": {
+          "name": "failed_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_codes_expires_at_idx": {
+          "name": "verification_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.event_type": {
+      "name": "event_type",
+      "schema": "public",
+      "values": [
+        "travel",
+        "meal",
+        "activity"
+      ]
+    },
+    "public.invitation_status": {
+      "name": "invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "declined",
+        "failed"
+      ]
+    },
+    "public.member_travel_type": {
+      "name": "member_travel_type",
+      "schema": "public",
+      "values": [
+        "arrival",
+        "departure"
+      ]
+    },
+    "public.rsvp_status": {
+      "name": "rsvp_status",
+      "schema": "public",
+      "values": [
+        "going",
+        "not_going",
+        "maybe",
+        "no_response"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1770958644081,
       "tag": "0007_heavy_deathstrike",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1771099542635,
+      "tag": "0008_brainy_wind_dancer",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -8,6 +8,7 @@ import {
   char,
   date,
   boolean,
+  integer,
   pgEnum,
   unique,
   jsonb,
@@ -42,6 +43,8 @@ export const verificationCodes = pgTable(
     phoneNumber: varchar("phone_number", { length: 20 }).primaryKey(),
     code: char("code", { length: 6 }).notNull(),
     expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    failedAttempts: integer("failed_attempts").notNull().default(0),
+    lockedUntil: timestamp("locked_until", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/apps/api/src/errors.ts
+++ b/apps/api/src/errors.ts
@@ -94,3 +94,4 @@ export const LastOrganizerError = createError(
 
 // Generic
 export const InvalidCodeError = createError("INVALID_CODE", "%s", 400);
+export const AccountLockedError = createError("ACCOUNT_LOCKED", "%s", 429);

--- a/apps/api/src/middleware/error.middleware.ts
+++ b/apps/api/src/middleware/error.middleware.ts
@@ -17,6 +17,8 @@ export async function errorHandler(
     },
   });
 
+  const requestId = request.id;
+
   // Zod validation errors from fastify-type-provider-zod
   if (hasZodFastifySchemaValidationErrors(error)) {
     return reply.status(400).send({
@@ -26,6 +28,7 @@ export async function errorHandler(
         message: "Invalid request data",
         details: error.validation,
       },
+      requestId,
     });
   }
 
@@ -38,6 +41,7 @@ export async function errorHandler(
         message: "Invalid request data",
         details: error.validation,
       },
+      requestId,
     });
   }
 
@@ -52,6 +56,7 @@ export async function errorHandler(
           rateLimitError.customRateLimitMessage ||
           "Too many requests. Please try again later.",
       },
+      requestId,
     });
   }
 
@@ -63,6 +68,7 @@ export async function errorHandler(
         code: "UNAUTHORIZED",
         message: "Invalid or expired token",
       },
+      requestId,
     });
   }
 
@@ -84,6 +90,7 @@ export async function errorHandler(
         code: "VALIDATION_ERROR",
         message: "Image must be under 5MB. Please choose a smaller file",
       },
+      requestId,
     });
   }
 
@@ -98,6 +105,7 @@ export async function errorHandler(
         code: "VALIDATION_ERROR",
         message: "No file uploaded",
       },
+      requestId,
     });
   }
 
@@ -109,6 +117,7 @@ export async function errorHandler(
         code: "DATABASE_CONSTRAINT_VIOLATION",
         message: "Database constraint violation",
       },
+      requestId,
     });
   }
 
@@ -120,6 +129,7 @@ export async function errorHandler(
         code: error.code,
         message: error.message,
       },
+      requestId,
     });
   }
 
@@ -132,5 +142,6 @@ export async function errorHandler(
       message: exposeDetails ? error.message : "An unexpected error occurred",
       ...(exposeDetails && { stack: error.stack }),
     },
+    requestId,
   });
 }

--- a/apps/api/src/plugins/upload-service.ts
+++ b/apps/api/src/plugins/upload-service.ts
@@ -1,14 +1,23 @@
+import { resolve } from "node:path";
 import fp from "fastify-plugin";
 import type { FastifyInstance } from "fastify";
 import { UploadService } from "@/services/upload.service.js";
+import { LocalStorageService } from "@/services/storage.service.js";
 
 /**
  * Upload service plugin
- * Creates an UploadService instance and decorates it on the Fastify instance
+ * Creates a LocalStorageService and UploadService, decorating the Fastify instance
  */
 export default fp(
   async function uploadServicePlugin(fastify: FastifyInstance) {
-    const uploadService = new UploadService();
+    const uploadsDir = resolve(
+      import.meta.dirname,
+      "..",
+      "..",
+      fastify.config.UPLOAD_DIR,
+    );
+    const storage = new LocalStorageService(uploadsDir);
+    const uploadService = new UploadService(storage);
     fastify.decorate("uploadService", uploadService);
   },
   {

--- a/apps/api/src/services/storage.service.ts
+++ b/apps/api/src/services/storage.service.ts
@@ -1,0 +1,106 @@
+import { writeFileSync, unlinkSync, mkdirSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Storage Service Interface
+ * Abstracts file storage operations to allow swapping between
+ * local filesystem, S3, R2, or other storage backends.
+ */
+export interface IStorageService {
+  /**
+   * Uploads a file to storage
+   * @param file - The file buffer
+   * @param filename - The generated filename (e.g., UUID-based)
+   * @param mimetype - The MIME type (used for Content-Type in cloud storage)
+   * @returns The URL or path to access the uploaded file
+   */
+  upload(file: Buffer, filename: string, mimetype: string): Promise<string>;
+
+  /**
+   * Deletes a file from storage
+   * @param url - The URL or path of the file to delete
+   */
+  delete(url: string): Promise<void>;
+
+  /**
+   * Generates a signed URL for temporary access (optional, cloud storage only)
+   * @param key - The storage key or path
+   * @param expiresIn - Expiration time in seconds
+   * @returns A signed URL with temporary access
+   */
+  getSignedUrl?(key: string, expiresIn: number): Promise<string>;
+}
+
+/**
+ * Local filesystem storage implementation
+ * Stores files in a local directory and serves them via static file routes.
+ */
+export class LocalStorageService implements IStorageService {
+  private readonly uploadsDir: string;
+
+  constructor(uploadsDir: string) {
+    this.uploadsDir = uploadsDir;
+    this.ensureUploadsDirExists();
+  }
+
+  private ensureUploadsDirExists(): void {
+    if (!existsSync(this.uploadsDir)) {
+      mkdirSync(this.uploadsDir, { recursive: true });
+    }
+  }
+
+  async upload(
+    file: Buffer,
+    filename: string,
+    _mimetype: string,
+  ): Promise<string> {
+    this.ensureUploadsDirExists();
+    const filePath = resolve(this.uploadsDir, filename);
+    writeFileSync(filePath, file);
+    return `/uploads/${filename}`;
+  }
+
+  async delete(url: string): Promise<void> {
+    const filename = url.split("/").pop();
+    if (!filename) {
+      return;
+    }
+
+    const filePath = resolve(this.uploadsDir, filename);
+
+    // Security check: prevent path traversal attacks
+    if (!filePath.startsWith(this.uploadsDir)) {
+      return;
+    }
+
+    try {
+      if (existsSync(filePath)) {
+        unlinkSync(filePath);
+      }
+    } catch {
+      // Silently handle errors (idempotent deletion)
+    }
+  }
+}
+
+/**
+ * S3/R2 storage implementation (placeholder)
+ * To be implemented when moving to cloud storage.
+ */
+export class S3StorageService implements IStorageService {
+  async upload(
+    _file: Buffer,
+    _filename: string,
+    _mimetype: string,
+  ): Promise<string> {
+    throw new Error("S3StorageService not implemented");
+  }
+
+  async delete(_url: string): Promise<void> {
+    throw new Error("S3StorageService not implemented");
+  }
+
+  async getSignedUrl(_key: string, _expiresIn: number): Promise<string> {
+    throw new Error("S3StorageService not implemented");
+  }
+}

--- a/apps/api/src/utils/audit.ts
+++ b/apps/api/src/utils/audit.ts
@@ -1,0 +1,24 @@
+import type { FastifyRequest } from "fastify";
+
+export function auditLog(
+  request: FastifyRequest,
+  action: string,
+  detail?: {
+    resourceType?: string;
+    resourceId?: string;
+    metadata?: Record<string, unknown>;
+  },
+) {
+  request.log.info(
+    {
+      audit: true,
+      action,
+      userId: request.user?.sub,
+      resourceType: detail?.resourceType,
+      resourceId: detail?.resourceId,
+      ip: request.ip,
+      ...detail?.metadata,
+    },
+    `audit: ${action}`,
+  );
+}

--- a/apps/api/tests/integration/auth.complete-profile.test.ts
+++ b/apps/api/tests/integration/auth.complete-profile.test.ts
@@ -237,7 +237,7 @@ describe("POST /api/auth/complete-profile", () => {
       expect(response.statusCode).toBe(400);
 
       const body = JSON.parse(response.body);
-      expect(body).toEqual({
+      expect(body).toMatchObject({
         success: false,
         error: {
           code: "VALIDATION_ERROR",
@@ -387,7 +387,7 @@ describe("POST /api/auth/complete-profile", () => {
       expect(response.statusCode).toBe(401);
 
       const body = JSON.parse(response.body);
-      expect(body).toEqual({
+      expect(body).toMatchObject({
         success: false,
         error: {
           code: "UNAUTHORIZED",

--- a/apps/api/tests/integration/auth.lockout.test.ts
+++ b/apps/api/tests/integration/auth.lockout.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, afterEach } from "vitest";
+import type { FastifyInstance } from "fastify";
+import { buildApp } from "../helpers.js";
+import { db } from "@/config/database.js";
+import { verificationCodes } from "@/db/schema/index.js";
+import { eq } from "drizzle-orm";
+import { generateUniquePhone } from "../test-utils.js";
+
+describe("POST /api/auth/verify-code - Account Lockout", () => {
+  let app: FastifyInstance;
+
+  afterEach(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  async function insertCode(phoneNumber: string, code: string) {
+    await db.insert(verificationCodes).values({
+      phoneNumber,
+      code,
+      expiresAt: new Date(Date.now() + 5 * 60 * 1000),
+    });
+  }
+
+  async function sendVerify(phoneNumber: string, code: string) {
+    return app.inject({
+      method: "POST",
+      url: "/api/auth/verify-code",
+      payload: { phoneNumber, code },
+    });
+  }
+
+  it("should lock account after 5 failed attempts", async () => {
+    app = await buildApp();
+    const phoneNumber = generateUniquePhone();
+    const correctCode = "123456";
+    const wrongCode = "999999";
+
+    await insertCode(phoneNumber, correctCode);
+
+    // Make 5 wrong attempts
+    for (let i = 0; i < 5; i++) {
+      const res = await sendVerify(phoneNumber, wrongCode);
+      expect(res.statusCode).toBe(400);
+      const body = JSON.parse(res.body);
+      expect(body.error.code).toBe("INVALID_CODE");
+    }
+
+    // 6th attempt should be locked
+    const lockedRes = await sendVerify(phoneNumber, wrongCode);
+    expect(lockedRes.statusCode).toBe(429);
+    const lockedBody = JSON.parse(lockedRes.body);
+    expect(lockedBody.error.code).toBe("ACCOUNT_LOCKED");
+    expect(lockedBody.error.message).toMatch(/Too many failed attempts/);
+    expect(lockedBody.error.message).toMatch(/minute/);
+  });
+
+  it("should reject correct code while locked", async () => {
+    app = await buildApp();
+    const phoneNumber = generateUniquePhone();
+    const correctCode = "123456";
+    const wrongCode = "999999";
+
+    await insertCode(phoneNumber, correctCode);
+
+    // Lock the account
+    for (let i = 0; i < 5; i++) {
+      await sendVerify(phoneNumber, wrongCode);
+    }
+
+    // Even the correct code should be rejected while locked
+    const res = await sendVerify(phoneNumber, correctCode);
+    expect(res.statusCode).toBe(429);
+    const body = JSON.parse(res.body);
+    expect(body.error.code).toBe("ACCOUNT_LOCKED");
+  });
+
+  it("should unlock after cooldown period expires", async () => {
+    app = await buildApp();
+    const phoneNumber = generateUniquePhone();
+    const correctCode = "123456";
+    const wrongCode = "999999";
+
+    await insertCode(phoneNumber, correctCode);
+
+    // Lock the account
+    for (let i = 0; i < 5; i++) {
+      await sendVerify(phoneNumber, wrongCode);
+    }
+
+    // Manually set lockedUntil to the past to simulate cooldown expiry
+    await db
+      .update(verificationCodes)
+      .set({ lockedUntil: new Date(Date.now() - 1000) })
+      .where(eq(verificationCodes.phoneNumber, phoneNumber));
+
+    // Should now accept the correct code
+    const res = await sendVerify(phoneNumber, correctCode);
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.success).toBe(true);
+  });
+
+  it("should reset failed attempts on successful verification", async () => {
+    app = await buildApp();
+    const phoneNumber = generateUniquePhone();
+    const correctCode = "123456";
+    const wrongCode = "999999";
+
+    await insertCode(phoneNumber, correctCode);
+
+    // Make 3 wrong attempts (not enough to lock)
+    for (let i = 0; i < 3; i++) {
+      const res = await sendVerify(phoneNumber, wrongCode);
+      expect(res.statusCode).toBe(400);
+    }
+
+    // Verify failedAttempts is 3
+    const [record] = await db
+      .select()
+      .from(verificationCodes)
+      .where(eq(verificationCodes.phoneNumber, phoneNumber))
+      .limit(1);
+    expect(record.failedAttempts).toBe(3);
+
+    // Successful verification should reset attempts
+    const res = await sendVerify(phoneNumber, correctCode);
+    expect(res.statusCode).toBe(200);
+
+    // Code is deleted after success, so we can't check failedAttempts directly
+    // But we verify it worked and didn't lock
+    expect(JSON.parse(res.body).success).toBe(true);
+  });
+
+  it("should not share lockout state between phone numbers", async () => {
+    app = await buildApp();
+    const phone1 = generateUniquePhone();
+    const phone2 = generateUniquePhone();
+    const correctCode = "123456";
+    const wrongCode = "999999";
+
+    await insertCode(phone1, correctCode);
+    await insertCode(phone2, correctCode);
+
+    // Lock phone1
+    for (let i = 0; i < 5; i++) {
+      await sendVerify(phone1, wrongCode);
+    }
+
+    // phone1 should be locked
+    const lockedRes = await sendVerify(phone1, correctCode);
+    expect(lockedRes.statusCode).toBe(429);
+
+    // phone2 should still work
+    const okRes = await sendVerify(phone2, correctCode);
+    expect(okRes.statusCode).toBe(200);
+    expect(JSON.parse(okRes.body).success).toBe(true);
+  });
+
+  it("should reset lockout when requesting a new code", async () => {
+    app = await buildApp();
+    const phoneNumber = generateUniquePhone();
+    const wrongCode = "999999";
+
+    await insertCode(phoneNumber, "123456");
+
+    // Lock the account
+    for (let i = 0; i < 5; i++) {
+      await sendVerify(phoneNumber, wrongCode);
+    }
+
+    // Confirm locked
+    const lockedRes = await sendVerify(phoneNumber, wrongCode);
+    expect(lockedRes.statusCode).toBe(429);
+
+    // Request a new code (simulates storeCode which resets lockout)
+    const requestRes = await app.inject({
+      method: "POST",
+      url: "/api/auth/request-code",
+      payload: { phoneNumber },
+    });
+    expect(requestRes.statusCode).toBe(200);
+
+    // New code should work (fixed code is "123456" in test environment)
+    const verifyRes = await sendVerify(phoneNumber, "123456");
+    expect(verifyRes.statusCode).toBe(200);
+    expect(JSON.parse(verifyRes.body).success).toBe(true);
+  });
+
+  it("should give fresh 5 attempts after lockout expires", async () => {
+    app = await buildApp();
+    const phoneNumber = generateUniquePhone();
+    const correctCode = "123456";
+    const wrongCode = "999999";
+
+    await insertCode(phoneNumber, correctCode);
+
+    // Lock the account
+    for (let i = 0; i < 5; i++) {
+      await sendVerify(phoneNumber, wrongCode);
+    }
+
+    // Simulate lockout expiry
+    await db
+      .update(verificationCodes)
+      .set({ lockedUntil: new Date(Date.now() - 1000) })
+      .where(eq(verificationCodes.phoneNumber, phoneNumber));
+
+    // Should get 4 more wrong attempts before locking again
+    for (let i = 0; i < 4; i++) {
+      const res = await sendVerify(phoneNumber, wrongCode);
+      expect(res.statusCode).toBe(400);
+    }
+
+    // 5th wrong attempt after unlock should lock again
+    const lockRes = await sendVerify(phoneNumber, wrongCode);
+    expect(lockRes.statusCode).toBe(400);
+
+    // 6th should be locked
+    const lockedRes = await sendVerify(phoneNumber, wrongCode);
+    expect(lockedRes.statusCode).toBe(429);
+  });
+
+  it("should track failed attempts in database", async () => {
+    app = await buildApp();
+    const phoneNumber = generateUniquePhone();
+    const wrongCode = "999999";
+
+    await insertCode(phoneNumber, "123456");
+
+    // Make 3 wrong attempts
+    for (let i = 0; i < 3; i++) {
+      await sendVerify(phoneNumber, wrongCode);
+    }
+
+    // Check database state
+    const [record] = await db
+      .select()
+      .from(verificationCodes)
+      .where(eq(verificationCodes.phoneNumber, phoneNumber))
+      .limit(1);
+
+    expect(record.failedAttempts).toBe(3);
+    expect(record.lockedUntil).toBeNull();
+
+    // Make 2 more wrong attempts to trigger lockout
+    for (let i = 0; i < 2; i++) {
+      await sendVerify(phoneNumber, wrongCode);
+    }
+
+    // Check database state — should be locked
+    const [lockedRecord] = await db
+      .select()
+      .from(verificationCodes)
+      .where(eq(verificationCodes.phoneNumber, phoneNumber))
+      .limit(1);
+
+    expect(lockedRecord.failedAttempts).toBe(5);
+    expect(lockedRecord.lockedUntil).toBeInstanceOf(Date);
+    expect(lockedRecord.lockedUntil!.getTime()).toBeGreaterThan(Date.now());
+  });
+});

--- a/apps/api/tests/integration/auth.me-logout.test.ts
+++ b/apps/api/tests/integration/auth.me-logout.test.ts
@@ -108,7 +108,7 @@ describe("GET /api/auth/me", () => {
       expect(response.statusCode).toBe(401);
 
       const body = JSON.parse(response.body);
-      expect(body).toEqual({
+      expect(body).toMatchObject({
         success: false,
         error: {
           code: "UNAUTHORIZED",
@@ -192,7 +192,7 @@ describe("GET /api/auth/me", () => {
       expect(response.statusCode).toBe(401);
 
       const body = JSON.parse(response.body);
-      expect(body).toEqual({
+      expect(body).toMatchObject({
         success: false,
         error: {
           code: "UNAUTHORIZED",
@@ -274,7 +274,7 @@ describe("POST /api/auth/logout", () => {
       expect(response.statusCode).toBe(401);
 
       const body = JSON.parse(response.body);
-      expect(body).toEqual({
+      expect(body).toMatchObject({
         success: false,
         error: {
           code: "UNAUTHORIZED",
@@ -393,7 +393,7 @@ describe("POST /api/auth/logout", () => {
       expect(getMeResponse2.statusCode).toBe(401);
 
       const body = JSON.parse(getMeResponse2.body);
-      expect(body).toEqual({
+      expect(body).toMatchObject({
         success: false,
         error: {
           code: "UNAUTHORIZED",

--- a/apps/api/tests/integration/auth.middleware.test.ts
+++ b/apps/api/tests/integration/auth.middleware.test.ts
@@ -171,7 +171,7 @@ describe("Authentication Middleware", () => {
       expect(response.statusCode).toBe(401);
 
       const body = JSON.parse(response.body);
-      expect(body).toEqual({
+      expect(body).toMatchObject({
         success: false,
         error: {
           code: "UNAUTHORIZED",
@@ -194,7 +194,7 @@ describe("Authentication Middleware", () => {
       expect(response.statusCode).toBe(401);
 
       const body = JSON.parse(response.body);
-      expect(body).toEqual({
+      expect(body).toMatchObject({
         success: false,
         error: {
           code: "UNAUTHORIZED",
@@ -245,7 +245,7 @@ describe("Authentication Middleware", () => {
         expect(response.statusCode).toBe(401);
 
         const body = JSON.parse(response.body);
-        expect(body).toEqual({
+        expect(body).toMatchObject({
           success: false,
           error: {
             code: "UNAUTHORIZED",
@@ -276,7 +276,7 @@ describe("Authentication Middleware", () => {
       expect(response.statusCode).toBe(401);
 
       const body = JSON.parse(response.body);
-      expect(body).toEqual({
+      expect(body).toMatchObject({
         success: false,
         error: {
           code: "UNAUTHORIZED",
@@ -360,7 +360,7 @@ describe("Authentication Middleware", () => {
       expect(response.statusCode).toBe(403);
 
       const body = JSON.parse(response.body);
-      expect(body).toEqual({
+      expect(body).toMatchObject({
         success: false,
         error: {
           code: "PROFILE_INCOMPLETE",
@@ -404,7 +404,7 @@ describe("Authentication Middleware", () => {
       expect(response.statusCode).toBe(403);
 
       const body = JSON.parse(response.body);
-      expect(body).toEqual({
+      expect(body).toMatchObject({
         success: false,
         error: {
           code: "PROFILE_INCOMPLETE",
@@ -428,7 +428,7 @@ describe("Authentication Middleware", () => {
       expect(response.statusCode).toBe(401);
 
       const body = JSON.parse(response.body);
-      expect(body).toEqual({
+      expect(body).toMatchObject({
         success: false,
         error: {
           code: "UNAUTHORIZED",

--- a/apps/api/tests/integration/auth.request-code.test.ts
+++ b/apps/api/tests/integration/auth.request-code.test.ts
@@ -166,7 +166,7 @@ describe("POST /api/auth/request-code", () => {
       expect(response.statusCode).toBe(400);
 
       const body = JSON.parse(response.body);
-      expect(body).toEqual({
+      expect(body).toMatchObject({
         success: false,
         error: {
           code: "VALIDATION_ERROR",
@@ -234,7 +234,7 @@ describe("POST /api/auth/request-code", () => {
         expect(response.statusCode).toBe(400);
 
         const body = JSON.parse(response.body);
-        expect(body).toEqual({
+        expect(body).toMatchObject({
           success: false,
           error: {
             code: "VALIDATION_ERROR",
@@ -265,8 +265,8 @@ describe("POST /api/auth/request-code", () => {
       expect(body.error).toHaveProperty("code", "VALIDATION_ERROR");
       expect(body.error).toHaveProperty("message");
 
-      // Ensure no extra top-level properties
-      expect(Object.keys(body)).toEqual(["success", "error"]);
+      // Ensure no extra top-level properties (requestId added by error middleware)
+      expect(Object.keys(body)).toEqual(["success", "error", "requestId"]);
     });
   });
 
@@ -321,7 +321,7 @@ describe("POST /api/auth/request-code", () => {
       expect(response.statusCode).toBe(429);
 
       const body = JSON.parse(response.body);
-      expect(body).toEqual({
+      expect(body).toMatchObject({
         success: false,
         error: {
           code: "RATE_LIMIT_EXCEEDED",

--- a/apps/api/tests/integration/auth.verify-code.test.ts
+++ b/apps/api/tests/integration/auth.verify-code.test.ts
@@ -260,7 +260,7 @@ describe("POST /api/auth/verify-code", () => {
       expect(response.statusCode).toBe(400);
 
       const body = JSON.parse(response.body);
-      expect(body).toEqual({
+      expect(body).toMatchObject({
         success: false,
         error: {
           code: "VALIDATION_ERROR",
@@ -284,7 +284,7 @@ describe("POST /api/auth/verify-code", () => {
       expect(response.statusCode).toBe(400);
 
       const body = JSON.parse(response.body);
-      expect(body).toEqual({
+      expect(body).toMatchObject({
         success: false,
         error: {
           code: "VALIDATION_ERROR",
@@ -316,7 +316,7 @@ describe("POST /api/auth/verify-code", () => {
         expect(response.statusCode).toBe(400);
 
         const body = JSON.parse(response.body);
-        expect(body).toEqual({
+        expect(body).toMatchObject({
           success: false,
           error: {
             code: "VALIDATION_ERROR",
@@ -378,7 +378,7 @@ describe("POST /api/auth/verify-code", () => {
       expect(response.statusCode).toBe(400);
 
       const body = JSON.parse(response.body);
-      expect(body).toEqual({
+      expect(body).toMatchObject({
         success: false,
         error: {
           code: "INVALID_CODE",
@@ -412,7 +412,7 @@ describe("POST /api/auth/verify-code", () => {
       expect(response.statusCode).toBe(400);
 
       const body = JSON.parse(response.body);
-      expect(body).toEqual({
+      expect(body).toMatchObject({
         success: false,
         error: {
           code: "INVALID_CODE",
@@ -441,7 +441,7 @@ describe("POST /api/auth/verify-code", () => {
       expect(response.statusCode).toBe(400);
 
       const body = JSON.parse(response.body);
-      expect(body).toEqual({
+      expect(body).toMatchObject({
         success: false,
         error: {
           code: "INVALID_CODE",

--- a/apps/api/tests/integration/rate-limit.middleware.test.ts
+++ b/apps/api/tests/integration/rate-limit.middleware.test.ts
@@ -105,7 +105,7 @@ describe("Rate Limit Middleware", () => {
       expect(response.statusCode).toBe(429);
 
       const body = JSON.parse(response.body);
-      expect(body).toEqual({
+      expect(body).toMatchObject({
         success: false,
         error: {
           code: "RATE_LIMIT_EXCEEDED",
@@ -143,7 +143,7 @@ describe("Rate Limit Middleware", () => {
       expect(response.statusCode).toBe(429);
 
       const body = JSON.parse(response.body);
-      expect(body).toEqual({
+      expect(body).toMatchObject({
         success: false,
         error: {
           code: "RATE_LIMIT_EXCEEDED",
@@ -237,8 +237,8 @@ describe("Rate Limit Middleware", () => {
         "Too many verification code requests. Please try again later.",
       );
 
-      // Ensure no extra properties
-      expect(Object.keys(body)).toEqual(["success", "error"]);
+      // Ensure no extra properties (requestId added by error middleware)
+      expect(Object.keys(body)).toEqual(["success", "error", "requestId"]);
       expect(Object.keys(body.error)).toEqual(["code", "message"]);
     });
   });

--- a/apps/api/tests/integration/trip.routes.test.ts
+++ b/apps/api/tests/integration/trip.routes.test.ts
@@ -359,7 +359,7 @@ describe("POST /api/trips", () => {
       expect(response.statusCode).toBe(400);
 
       const body = JSON.parse(response.body);
-      expect(body).toEqual({
+      expect(body).toMatchObject({
         success: false,
         error: {
           code: "VALIDATION_ERROR",
@@ -559,7 +559,7 @@ describe("POST /api/trips", () => {
       expect(response.statusCode).toBe(401);
 
       const body = JSON.parse(response.body);
-      expect(body).toEqual({
+      expect(body).toMatchObject({
         success: false,
         error: {
           code: "UNAUTHORIZED",
@@ -630,7 +630,7 @@ describe("POST /api/trips", () => {
       expect(response.statusCode).toBe(403);
 
       const body = JSON.parse(response.body);
-      expect(body).toEqual({
+      expect(body).toMatchObject({
         success: false,
         error: {
           code: "PROFILE_INCOMPLETE",
@@ -683,7 +683,7 @@ describe("POST /api/trips", () => {
       expect(response.statusCode).toBe(400);
 
       const body = JSON.parse(response.body);
-      expect(body).toEqual({
+      expect(body).toMatchObject({
         success: false,
         error: {
           code: "CO_ORGANIZER_NOT_FOUND",
@@ -747,7 +747,7 @@ describe("POST /api/trips", () => {
       expect(response.statusCode).toBe(409);
 
       const body = JSON.parse(response.body);
-      expect(body).toEqual({
+      expect(body).toMatchObject({
         success: false,
         error: {
           code: "MEMBER_LIMIT_EXCEEDED",
@@ -1149,7 +1149,7 @@ describe("GET /api/trips", () => {
       expect(response.statusCode).toBe(401);
 
       const body = JSON.parse(response.body);
-      expect(body).toEqual({
+      expect(body).toMatchObject({
         success: false,
         error: {
           code: "UNAUTHORIZED",

--- a/apps/api/tests/unit/audit.test.ts
+++ b/apps/api/tests/unit/audit.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from "vitest";
+import { auditLog } from "@/utils/audit.js";
+import type { FastifyRequest } from "fastify";
+
+function mockRequest(overrides?: { sub?: string; ip?: string }) {
+  return {
+    user: { sub: overrides?.sub ?? "user-123" },
+    ip: overrides?.ip ?? "127.0.0.1",
+    log: { info: vi.fn() },
+  } as unknown as FastifyRequest;
+}
+
+describe("auditLog", () => {
+  it("should call request.log.info with audit: true and action", () => {
+    const request = mockRequest();
+    auditLog(request, "auth.login_success");
+
+    expect(request.log.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        audit: true,
+        action: "auth.login_success",
+        userId: "user-123",
+        ip: "127.0.0.1",
+      }),
+      "audit: auth.login_success",
+    );
+  });
+
+  it("should include resourceType and resourceId when provided", () => {
+    const request = mockRequest();
+    auditLog(request, "trip.create", {
+      resourceType: "trip",
+      resourceId: "trip-456",
+    });
+
+    expect(request.log.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        audit: true,
+        action: "trip.create",
+        userId: "user-123",
+        resourceType: "trip",
+        resourceId: "trip-456",
+        ip: "127.0.0.1",
+      }),
+      "audit: trip.create",
+    );
+  });
+
+  it("should spread metadata into the log object", () => {
+    const request = mockRequest();
+    auditLog(request, "member.removed", {
+      resourceType: "trip",
+      resourceId: "trip-789",
+      metadata: { memberId: "member-abc" },
+    });
+
+    expect(request.log.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        audit: true,
+        action: "member.removed",
+        memberId: "member-abc",
+      }),
+      "audit: member.removed",
+    );
+  });
+
+  it("should handle missing user (unauthenticated requests)", () => {
+    const request = {
+      user: undefined,
+      ip: "10.0.0.1",
+      log: { info: vi.fn() },
+    } as unknown as FastifyRequest;
+
+    auditLog(request, "auth.login_failure");
+
+    expect(request.log.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        audit: true,
+        action: "auth.login_failure",
+        userId: undefined,
+        ip: "10.0.0.1",
+      }),
+      "audit: auth.login_failure",
+    );
+  });
+
+  it("should handle call with no detail parameter", () => {
+    const request = mockRequest();
+    auditLog(request, "auth.logout");
+
+    expect(request.log.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        audit: true,
+        action: "auth.logout",
+        resourceType: undefined,
+        resourceId: undefined,
+      }),
+      "audit: auth.logout",
+    );
+  });
+});

--- a/apps/web/tests/e2e/helpers/trips.ts
+++ b/apps/web/tests/e2e/helpers/trips.ts
@@ -13,6 +13,13 @@ export async function createTrip(
 ) {
   const tripDetail = new TripDetailPage(page);
   const trips = new TripsPage(page);
+
+  // Dismiss any Sonner toast that could intercept the FAB click
+  const toast = page.locator("[data-sonner-toast]").first();
+  if (await toast.isVisible().catch(() => false)) {
+    await toast.waitFor({ state: "hidden", timeout: 10000 });
+  }
+
   await trips.createTripButton.click();
   await expect(tripDetail.createDialogHeading).toBeVisible({ timeout: 10000 });
   await tripDetail.nameInput.fill(tripName);

--- a/docs/2026-02-01-tripful-mvp/PHASES.md
+++ b/docs/2026-02-01-tripful-mvp/PHASES.md
@@ -240,6 +240,7 @@
 ## 🚧 Phase 7: Polish & Testing
 
 - [ ] Add co-organizers post-creation UI (API exists at `POST /trips/:id/co-organizers`, needs dialog in members list)
+- [ ] Allow organizers to add member travel on behalf of other members (currently members can only add their own)
 - [ ] Entity count limits: max 50 events/trip, max 10 accommodations/trip, max 20 member travel/member (PRD Data Validation — only member limit of 25 is currently enforced)
 - [ ] Responsive design refinements
 - [ ] Performance optimization (query optimization, caching)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       fastify-type-provider-zod:
         specifier: ^4.0.2
         version: 4.0.2(fastify@5.7.2)(zod@3.25.76)
+      file-type:
+        specifier: ^21.3.0
+        version: 21.3.0
       libphonenumber-js:
         specifier: ^1.12.36
         version: 1.12.36
@@ -369,6 +372,9 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@borewit/text-codec@0.2.1':
+    resolution: {integrity: sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw==}
 
   '@csstools/color-helpers@5.1.0':
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
@@ -2413,6 +2419,13 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@tokenizer/inflate@0.4.1':
+    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -3504,6 +3517,10 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
+  file-type@21.3.0:
+    resolution: {integrity: sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA==}
+    engines: {node: '>=20'}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -3692,6 +3709,9 @@ packages:
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -4796,6 +4816,10 @@ packages:
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
+  strtok3@10.3.4:
+    resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
+    engines: {node: '>=18'}
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -4891,6 +4915,10 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  token-types@6.1.2:
+    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
+    engines: {node: '>=14.16'}
+
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
@@ -4981,6 +5009,10 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -5428,6 +5460,8 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@borewit/text-codec@0.2.1': {}
 
   '@csstools/color-helpers@5.1.0': {}
 
@@ -7092,6 +7126,15 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
+  '@tokenizer/inflate@0.4.1':
+    dependencies:
+      debug: 4.4.3
+      token-types: 6.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/token@0.3.0': {}
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -8087,8 +8130,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -8110,7 +8153,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -8121,22 +8164,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -8147,7 +8190,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -8400,6 +8443,15 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
+  file-type@21.3.0:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.4
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -8587,6 +8639,8 @@ snapshots:
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
+
+  ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 
@@ -9807,6 +9861,10 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  strtok3@10.3.4:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.4):
     dependencies:
       client-only: 0.0.1
@@ -9868,6 +9926,12 @@ snapshots:
   toad-cache@3.7.0: {}
 
   toidentifier@1.0.1: {}
+
+  token-types@6.1.2:
+    dependencies:
+      '@borewit/text-codec': 0.2.1
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
 
   tough-cookie@5.1.2:
     dependencies:
@@ -9973,6 +10037,8 @@ snapshots:
       - supports-color
 
   typescript@5.9.3: {}
+
+  uint8array-extras@1.5.0: {}
 
   unbox-primitive@1.1.0:
     dependencies:

--- a/shared/__tests__/sanitize.test.ts
+++ b/shared/__tests__/sanitize.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { stripControlChars } from "../utils/sanitize";
+
+describe("stripControlChars", () => {
+  it("should pass through normal strings unchanged", () => {
+    expect(stripControlChars("Hello World")).toBe("Hello World");
+    expect(stripControlChars("Trip to Paris 2026!")).toBe(
+      "Trip to Paris 2026!",
+    );
+    expect(stripControlChars("café résumé naïve")).toBe("café résumé naïve");
+  });
+
+  it("should preserve newlines, carriage returns, and tabs", () => {
+    expect(stripControlChars("line1\nline2")).toBe("line1\nline2");
+    expect(stripControlChars("line1\r\nline2")).toBe("line1\r\nline2");
+    expect(stripControlChars("col1\tcol2")).toBe("col1\tcol2");
+  });
+
+  it("should strip null bytes", () => {
+    expect(stripControlChars("hello\x00world")).toBe("helloworld");
+    expect(stripControlChars("\x00\x00\x00")).toBe("");
+  });
+
+  it("should strip C0 control characters (except tab, newline, carriage return)", () => {
+    // SOH, STX, ETX, BEL, BS, VT, FF, SO, SI, etc.
+    expect(stripControlChars("a\x01b\x02c\x03d")).toBe("abcd");
+    expect(stripControlChars("hello\x07world")).toBe("helloworld"); // BEL
+    expect(stripControlChars("hello\x08world")).toBe("helloworld"); // BS
+    expect(stripControlChars("hello\x0Bworld")).toBe("helloworld"); // VT
+    expect(stripControlChars("hello\x0Cworld")).toBe("helloworld"); // FF
+    expect(stripControlChars("hello\x1Bworld")).toBe("helloworld"); // ESC
+  });
+
+  it("should strip C1 control characters (U+007F-U+009F)", () => {
+    expect(stripControlChars("hello\x7Fworld")).toBe("helloworld"); // DEL
+    expect(stripControlChars("hello\x80world")).toBe("helloworld");
+    expect(stripControlChars("hello\x9Fworld")).toBe("helloworld");
+  });
+
+  it("should handle empty strings", () => {
+    expect(stripControlChars("")).toBe("");
+  });
+
+  it("should handle strings that are entirely control characters", () => {
+    expect(stripControlChars("\x00\x01\x02\x03")).toBe("");
+  });
+
+  it("should preserve unicode characters", () => {
+    expect(stripControlChars("日本語テスト")).toBe("日本語テスト");
+    expect(stripControlChars("🏖️ Beach Trip")).toBe("🏖️ Beach Trip");
+  });
+});

--- a/shared/schemas/accommodation.ts
+++ b/shared/schemas/accommodation.ts
@@ -1,6 +1,7 @@
 // Accommodation validation schemas for the Tripful platform
 
 import { z } from "zod";
+import { stripControlChars } from "../utils/sanitize";
 
 /**
  * Base accommodation data schema (without cross-field validation)
@@ -14,7 +15,8 @@ const baseAccommodationSchema = z.object({
     })
     .max(255, {
       message: "Accommodation name must not exceed 255 characters",
-    }),
+    })
+    .transform(stripControlChars),
   address: z.string().optional(),
   description: z
     .string()

--- a/shared/schemas/auth.ts
+++ b/shared/schemas/auth.ts
@@ -1,6 +1,7 @@
 // Authentication validation schemas for the Tripful platform
 
 import { z } from "zod";
+import { stripControlChars } from "../utils/sanitize";
 
 /**
  * Validates phone number for requesting verification code
@@ -55,7 +56,8 @@ export const completeProfileSchema = z.object({
     })
     .max(50, {
       message: "Display name must not exceed 50 characters",
-    }),
+    })
+    .transform(stripControlChars),
   timezone: z.string().nullable().optional(),
 });
 

--- a/shared/schemas/event.ts
+++ b/shared/schemas/event.ts
@@ -1,6 +1,7 @@
 // Event validation schemas for the Tripful platform
 
 import { z } from "zod";
+import { stripControlChars } from "../utils/sanitize";
 
 /**
  * Base event data schema (without cross-field validation)
@@ -14,7 +15,8 @@ const baseEventSchema = z.object({
     })
     .max(255, {
       message: "Event name must not exceed 255 characters",
-    }),
+    })
+    .transform(stripControlChars),
   description: z
     .string()
     .max(2000, {

--- a/shared/schemas/trip.ts
+++ b/shared/schemas/trip.ts
@@ -2,6 +2,7 @@
 
 import { z } from "zod";
 import { phoneNumberSchema } from "./phone";
+import { stripControlChars } from "../utils/sanitize";
 
 /**
  * Validates IANA timezone strings using Intl.supportedValuesOf
@@ -26,10 +27,14 @@ const baseTripSchema = z.object({
     })
     .max(100, {
       message: "Trip name must not exceed 100 characters",
-    }),
-  destination: z.string().min(1, {
-    message: "Destination is required",
-  }),
+    })
+    .transform(stripControlChars),
+  destination: z
+    .string()
+    .min(1, {
+      message: "Destination is required",
+    })
+    .transform(stripControlChars),
   startDate: z.string().date().optional(),
   endDate: z.string().date().optional(),
   timezone: timezoneSchema,
@@ -38,6 +43,7 @@ const baseTripSchema = z.object({
     .max(2000, {
       message: "Description must not exceed 2000 characters",
     })
+    .transform(stripControlChars)
     .optional(),
   coverImageUrl: z
     .string()

--- a/shared/schemas/user.ts
+++ b/shared/schemas/user.ts
@@ -1,6 +1,7 @@
 // User profile validation schemas for the Tripful platform
 
 import { z } from "zod";
+import { stripControlChars } from "../utils/sanitize";
 
 /** Allowed social media handle platforms */
 export const ALLOWED_HANDLE_PLATFORMS = ["venmo", "instagram"] as const;
@@ -38,6 +39,7 @@ export const updateProfileSchema = z.object({
     .max(50, {
       message: "Display name must not exceed 50 characters",
     })
+    .transform(stripControlChars)
     .optional(),
   timezone: z.string().nullable().optional(),
   handles: userHandlesSchema,

--- a/shared/utils/index.ts
+++ b/shared/utils/index.ts
@@ -2,6 +2,8 @@
 
 import { fromZonedTime, formatInTimeZone as formatInTz } from "date-fns-tz";
 
+export { stripControlChars } from "./sanitize";
+
 /**
  * Converts a date/time from a specific timezone to UTC
  * @param dateTime The date/time to convert (interpreted as being in the specified timezone)

--- a/shared/utils/sanitize.ts
+++ b/shared/utils/sanitize.ts
@@ -1,0 +1,12 @@
+/**
+ * Strips C0/C1 control characters from a string, preserving common whitespace
+ * (newline, carriage return, tab). Removes null bytes, escape sequences, and
+ * other invisible control characters that could cause display or security issues.
+ *
+ * C0 range: U+0000–U+001F (except \t \n \r)
+ * C1 range: U+007F–U+009F
+ */
+export function stripControlChars(str: string): string {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]/g, "");
+}


### PR DESCRIPTION
## Summary

Implements all 4 phases of the API security hardening plan — hardening measures from security audit, no critical vulnerabilities.

### Phase 1: Quick Wins
- **Secure cookies**: `secure` flag forced `true` in production regardless of `COOKIE_SECURE` env var
- **CSP header**: Enabled Content-Security-Policy (`default-src 'none'`, `frame-ancestors 'none'`)
- **HSTS header**: Added Strict-Transport-Security (1 year, includeSubDomains)
- **Input sanitization**: `stripControlChars` utility strips C0/C1 control characters from user-facing text fields via Zod `.transform()`
- **Request ID propagation**: All error responses and 404s include `requestId` for log correlation

### Phase 2: Account Lockout
- Account lockout after 5 failed verification attempts (15-min cooldown)
- New `failedAttempts` and `lockedUntil` columns on `verification_codes`
- 8 integration tests covering lockout lifecycle

### Phase 3: File Security
- **Magic byte validation**: File uploads validated by `file-type` (not just MIME header)
- **Storage abstraction**: `StorageService` interface with `LocalStorageService` implementation, swappable to S3 later

### Phase 4: Observability & DevOps
- **Structured audit logging**: Pino-based `auditLog()` helper emitting `audit: true` entries for 13 security-relevant actions across auth, trip, invitation, member, event, and accommodation controllers
- **Dependency scanning**: `pnpm audit --audit-level=high` in CI + Dependabot config for automated vulnerability PRs

## Test plan

- [x] 740 API tests passing (unit + integration)
- [x] TypeScript strict mode clean
- [x] ESLint clean
- [x] 5 audit helper unit tests
- [x] 8 account lockout integration tests
- [x] 6 magic byte validation unit tests
- [x] Security header integration tests (CSP, HSTS, requestId)

🤖 Generated with [Claude Code](https://claude.com/claude-code)