### PR TITLE
Redesign member travel cards to match accommodation card style

### DIFF
--- a/apps/web/src/components/itinerary/accommodation-card.tsx
+++ b/apps/web/src/components/itinerary/accommodation-card.tsx
@@ -83,7 +83,9 @@ export const AccommodationCard = memo(function AccommodationCard({
             >
               <MapPin className="w-3 h-3 shrink-0" />
               <span className="underline underline-offset-2">
-                {accommodation.address}
+                {accommodation.address.length > 20
+                  ? accommodation.address.slice(0, 20) + "…"
+                  : accommodation.address}
               </span>
             </a>
           )}
@@ -96,6 +98,22 @@ export const AccommodationCard = memo(function AccommodationCard({
           className="mt-2 pt-2 border-t border-border/40 space-y-2 ml-6"
           onClick={(e) => e.stopPropagation()}
         >
+          {/* Address */}
+          {accommodation.address && (
+            <a
+              href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(accommodation.address)}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-xs text-muted-foreground active:text-primary hover:text-primary py-0.5"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <MapPin className="w-3.5 h-3.5 shrink-0" />
+              <span className="underline underline-offset-2">
+                {accommodation.address}
+              </span>
+            </a>
+          )}
+
           {/* Check-in / Check-out */}
           <div className="grid grid-cols-2 gap-2 text-sm">
             <div>

--- a/apps/web/src/components/itinerary/accommodation-card.tsx
+++ b/apps/web/src/components/itinerary/accommodation-card.tsx
@@ -11,7 +11,7 @@ import {
 } from "lucide-react";
 import type { Accommodation } from "@tripful/shared/types";
 import { Button } from "@/components/ui/button";
-import { calculateNights, formatInTimezone } from "@/lib/utils/timezone";
+import { formatInTimezone } from "@/lib/utils/timezone";
 
 interface AccommodationCardProps {
   accommodation: Accommodation;
@@ -34,8 +34,6 @@ export const AccommodationCard = memo(function AccommodationCard({
 }: AccommodationCardProps) {
   const [isExpanded, setIsExpanded] = useState(false);
 
-  const nights = calculateNights(accommodation.checkIn, accommodation.checkOut);
-  const nightsLabel = nights === 1 ? "1 night" : `${nights} nights`;
   const datePrefix = showDate
     ? formatInTimezone(accommodation.checkIn, timezone, "date")
     : null;
@@ -66,17 +64,28 @@ export const AccommodationCard = memo(function AccommodationCard({
 
         <Building2 className="w-3.5 h-3.5 shrink-0 text-[var(--color-accommodation)]" />
 
-        <div className="flex items-center gap-2 min-w-0 flex-1">
+        <div className="flex items-center gap-2 min-w-0 flex-1 flex-wrap">
           <span className="font-semibold text-foreground text-sm truncate">
             {accommodation.name}
-          </span>
-          <span className="text-xs text-muted-foreground shrink-0">
-            {nightsLabel}
           </span>
           {datePrefix && (
             <span className="text-xs text-muted-foreground shrink-0">
               {datePrefix}
             </span>
+          )}
+          {accommodation.address && (
+            <a
+              href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(accommodation.address)}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-primary active:text-primary shrink-0"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <MapPin className="w-3 h-3 shrink-0" />
+              <span className="underline underline-offset-2">
+                {accommodation.address}
+              </span>
+            </a>
           )}
         </div>
       </div>
@@ -102,22 +111,6 @@ export const AccommodationCard = memo(function AccommodationCard({
               </p>
             </div>
           </div>
-
-          {/* Address */}
-          {accommodation.address && (
-            <a
-              href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(accommodation.address)}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 text-xs text-muted-foreground active:text-primary hover:text-primary py-0.5"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <MapPin className="w-3.5 h-3.5 shrink-0" />
-              <span className="underline underline-offset-2">
-                {accommodation.address}
-              </span>
-            </a>
-          )}
 
           {/* Description */}
           {accommodation.description && (

--- a/apps/web/src/components/itinerary/group-by-type-view.tsx
+++ b/apps/web/src/components/itinerary/group-by-type-view.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useMemo, useState } from "react";
-import { Home, Car, Utensils, Calendar, Plane } from "lucide-react";
+import { Building2, Car, Utensils, Calendar, PlaneLanding, PlaneTakeoff } from "lucide-react";
 import type { Event, Accommodation, MemberTravel } from "@tripful/shared/types";
 import { EventCard } from "./event-card";
 import { AccommodationCard } from "./accommodation-card";
@@ -96,7 +96,7 @@ export function GroupByTypeView({
     () => [
       {
         title: "Accommodations",
-        icon: Home,
+        icon: Building2,
         iconClassName: "",
         color: "text-[var(--color-accommodation)]",
         bgColor: "bg-[var(--color-accommodation-light)]",
@@ -105,8 +105,8 @@ export function GroupByTypeView({
       },
       {
         title: "Arrivals",
-        icon: Plane,
-        iconClassName: "rotate-90",
+        icon: PlaneLanding,
+        iconClassName: "",
         color: "text-[var(--color-member-travel)]",
         bgColor: "bg-[var(--color-member-travel-light)]",
         items: groupedEvents.arrivals,
@@ -141,8 +141,8 @@ export function GroupByTypeView({
       },
       {
         title: "Departures",
-        icon: Plane,
-        iconClassName: "-rotate-90",
+        icon: PlaneTakeoff,
+        iconClassName: "",
         color: "text-[var(--color-member-travel)]",
         bgColor: "bg-[var(--color-member-travel-light)]",
         items: groupedEvents.departures,

--- a/apps/web/src/components/itinerary/member-travel-card.tsx
+++ b/apps/web/src/components/itinerary/member-travel-card.tsx
@@ -94,7 +94,9 @@ export const MemberTravelCard = memo(function MemberTravelCard({
             >
               <MapPin className="w-3 h-3 shrink-0" />
               <span className="underline underline-offset-2">
-                {memberTravel.location}
+                {memberTravel.location.length > 20
+                  ? memberTravel.location.slice(0, 20) + "…"
+                  : memberTravel.location}
               </span>
             </a>
           )}
@@ -107,6 +109,22 @@ export const MemberTravelCard = memo(function MemberTravelCard({
           className="mt-2 pt-2 border-t border-border/40 space-y-2 ml-6"
           onClick={(e) => e.stopPropagation()}
         >
+          {/* Location */}
+          {memberTravel.location && (
+            <a
+              href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(memberTravel.location)}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-xs text-muted-foreground active:text-primary hover:text-primary py-0.5"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <MapPin className="w-3.5 h-3.5 shrink-0" />
+              <span className="underline underline-offset-2">
+                {memberTravel.location}
+              </span>
+            </a>
+          )}
+
           {/* Date & Time */}
           <div className="text-sm">
             <span className="text-xs text-muted-foreground">

--- a/apps/web/src/components/itinerary/member-travel-card.tsx
+++ b/apps/web/src/components/itinerary/member-travel-card.tsx
@@ -1,8 +1,17 @@
 "use client";
 
-import { memo } from "react";
-import { Clock, MapPin, PlaneLanding, PlaneTakeoff } from "lucide-react";
+import { memo, useState } from "react";
+import {
+  ChevronDown,
+  ChevronRight,
+  Clock,
+  MapPin,
+  Pencil,
+  PlaneLanding,
+  PlaneTakeoff,
+} from "lucide-react";
 import type { MemberTravel } from "@tripful/shared/types";
+import { Button } from "@/components/ui/button";
 import { formatInTimezone } from "@/lib/utils/timezone";
 
 interface MemberTravelCardProps {
@@ -24,63 +33,115 @@ export const MemberTravelCard = memo(function MemberTravelCard({
   onEdit,
   showDate,
 }: MemberTravelCardProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
   const isArrival = memberTravel.travelType === "arrival";
   const PlaneIcon = isArrival ? PlaneLanding : PlaneTakeoff;
+  const travelLabel = isArrival ? "Arrival" : "Departure";
 
   const time = formatInTimezone(memberTravel.time, timezone, "time");
+  const dateTime = formatInTimezone(memberTravel.time, timezone, "datetime");
   const date = showDate
     ? formatInTimezone(memberTravel.time, timezone, "date")
     : null;
 
-  const isClickable = canEdit && onEdit;
-
   return (
     <div
-      role={isClickable ? "button" : undefined}
-      tabIndex={isClickable ? 0 : undefined}
-      className={`rounded-lg py-1.5 px-2 transition-all ${isClickable ? "hover:bg-muted/50 cursor-pointer" : ""}`}
-      onClick={isClickable ? () => onEdit?.(memberTravel) : undefined}
-      onKeyDown={
-        isClickable
-          ? (e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                onEdit?.(memberTravel);
-              }
-            }
-          : undefined
-      }
+      role="button"
+      tabIndex={0}
+      aria-expanded={isExpanded}
+      className="rounded-xl border border-border/60 border-l-2 border-l-[var(--color-member-travel)] py-2 px-3 transition-all hover:shadow-sm cursor-pointer"
+      onClick={() => setIsExpanded((prev) => !prev)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          setIsExpanded((prev) => !prev);
+        }
+      }}
     >
-      <div className="flex items-center gap-2 text-sm text-muted-foreground flex-wrap">
-        <PlaneIcon className="w-4 h-4 shrink-0" />
-        <span className="font-medium text-foreground">{memberName}</span>
-        <span className="text-muted-foreground/40">·</span>
-        {date && (
-          <>
-            <span>{date}</span>
-            <span className="text-muted-foreground/40">·</span>
-          </>
-        )}
-        <Clock className="w-3 h-3 shrink-0" />
-        <span>{time}</span>
-        {memberTravel.location && (
-          <>
-            <span className="text-muted-foreground/40">·</span>
+      {/* Compact view */}
+      <div className="flex items-center gap-2">
+        <div className="shrink-0 text-[var(--color-member-travel)]">
+          {isExpanded ? (
+            <ChevronDown className="w-3.5 h-3.5" />
+          ) : (
+            <ChevronRight className="w-3.5 h-3.5" />
+          )}
+        </div>
+
+        <PlaneIcon className="w-3.5 h-3.5 shrink-0 text-[var(--color-member-travel)]" />
+
+        <div className="flex items-center gap-2 min-w-0 flex-1 flex-wrap">
+          <span className="font-semibold text-foreground text-sm truncate">
+            {memberName}
+          </span>
+          {date && (
+            <span className="text-xs text-muted-foreground shrink-0">
+              {date}
+            </span>
+          )}
+          <span className="text-xs text-muted-foreground shrink-0 flex items-center gap-1">
+            <Clock className="w-3 h-3" />
+            {time}
+          </span>
+          {memberTravel.location && (
             <a
               href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(memberTravel.location)}`}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 hover:text-primary active:text-primary min-w-0"
+              className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-primary active:text-primary shrink-0"
               onClick={(e) => e.stopPropagation()}
             >
               <MapPin className="w-3 h-3 shrink-0" />
-              <span className="underline underline-offset-2 truncate">
+              <span className="underline underline-offset-2">
                 {memberTravel.location}
               </span>
             </a>
-          </>
-        )}
+          )}
+        </div>
       </div>
+
+      {/* Expanded view */}
+      {isExpanded && (
+        <div
+          className="mt-2 pt-2 border-t border-border/40 space-y-2 ml-6"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* Date & Time */}
+          <div className="text-sm">
+            <span className="text-xs text-muted-foreground">
+              {travelLabel} time
+            </span>
+            <p className="font-medium text-foreground text-xs">{dateTime}</p>
+          </div>
+
+          {/* Details (flight number, terminal, etc.) */}
+          {memberTravel.details && (
+            <p className="text-xs text-muted-foreground whitespace-pre-wrap">
+              {memberTravel.details}
+            </p>
+          )}
+
+          {/* Edit button */}
+          {canEdit && onEdit && (
+            <div className="pt-1">
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onEdit(memberTravel);
+                }}
+                className="h-9 sm:h-7 text-xs gap-1"
+                title="Edit flight"
+              >
+                <Pencil className="w-3 h-3" />
+                Edit
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 });

--- a/apps/web/tests/e2e/itinerary-journey.spec.ts
+++ b/apps/web/tests/e2e/itinerary-journey.spec.ts
@@ -160,7 +160,7 @@ test.describe("Itinerary Journey", () => {
           .getByRole("button", { name: "Create accommodation" })
           .click();
 
-        // Expand the accommodation card to reveal the address link
+        // Address link is visible in the compact card header (no expand needed)
         const accommodationCard = page
           .locator('[role="button"][aria-expanded]')
           .filter({
@@ -170,14 +170,9 @@ test.describe("Itinerary Journey", () => {
           })
           .first();
         await expect(accommodationCard).toBeVisible({ timeout: 10000 });
-        const isAccommodationExpanded =
-          await accommodationCard.getAttribute("aria-expanded");
-        if (isAccommodationExpanded !== "true") {
-          await accommodationCard.click();
-        }
 
-        // Address should be a Google Maps link
-        const addressLink = page.getByRole("link", {
+        // Address should be a Google Maps link (scoped to first card instance)
+        const addressLink = accommodationCard.getByRole("link", {
           name: "123 Main St, San Diego",
         });
         await expect(addressLink).toBeVisible();
@@ -185,9 +180,6 @@ test.describe("Itinerary Journey", () => {
           "href",
           /google\.com\/maps\/search/,
         );
-
-        // Collapse the accommodation card so it doesn't interfere with later steps
-        await accommodationCard.click();
       });
 
       await snap(page, "09-itinerary-with-events");

--- a/apps/web/tests/e2e/itinerary-journey.spec.ts
+++ b/apps/web/tests/e2e/itinerary-journey.spec.ts
@@ -172,8 +172,9 @@ test.describe("Itinerary Journey", () => {
         await expect(accommodationCard).toBeVisible({ timeout: 10000 });
 
         // Address should be a Google Maps link (scoped to first card instance)
+        // Compact view truncates addresses > 20 chars: "123 Main St, San Die…"
         const addressLink = accommodationCard.getByRole("link", {
-          name: "123 Main St, San Diego",
+          name: /123 Main St/,
         });
         await expect(addressLink).toBeVisible();
         await expect(addressLink).toHaveAttribute(

--- a/apps/web/tests/e2e/trip-journey.spec.ts
+++ b/apps/web/tests/e2e/trip-journey.spec.ts
@@ -809,9 +809,9 @@ test.describe("Trip Journey", () => {
         page.getByText("Delegated Member").first(),
       ).toBeVisible({ timeout: 10000 });
 
-      // Location should also be visible
+      // Location should also be visible (compact view truncates > 20 chars)
       const locationLink = page.getByRole("link", {
-        name: "Seattle-Tacoma Airport",
+        name: /Seattle-Tacoma/,
       });
       await expect(locationLink).toBeVisible();
 


### PR DESCRIPTION
## Summary
- Redesign member travel cards with expandable compact/detail view matching the accommodation card pattern (chevron, colored left border, dropdown details)
- Truncate location to 20 chars in card header, show full location in expanded dropdown
- Fix E2E test for accommodation address link in compact header
- Update group-by-type view to use distinct Arrival/Departure plane icons

## Test plan
- [ ] Verify member travel cards render with compact view (name, time, truncated location)
- [ ] Verify clicking a card expands to show full details (location, datetime, notes, edit button)
- [ ] Verify accommodation card address link works in compact header
- [ ] Run E2E tests: `pnpm test:e2e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)