### PR TITLE
Add SEO technical foundation and landing page

### DIFF
--- a/apps/web/src/app/(app)/trips/[id]/page.tsx
+++ b/apps/web/src/app/(app)/trips/[id]/page.tsx
@@ -14,9 +14,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { id } = await params;
   try {
     const response = await serverApiRequest<GetTripResponse>(`/trips/${id}`);
-    return { title: response.trip.name };
+    return { title: response.trip.name, robots: { index: false, follow: false } };
   } catch {
-    return { title: "Trip" };
+    return { title: "Trip", robots: { index: false, follow: false } };
   }
 }
 

--- a/apps/web/src/app/(auth)/complete-profile/layout.tsx
+++ b/apps/web/src/app/(auth)/complete-profile/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "Complete Profile",
+  description: "Complete your Tripful profile to start planning trips.",
+  robots: { index: false, follow: false },
+};
+
+export default function CompleteProfileLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return children;
+}

--- a/apps/web/src/app/(auth)/login/layout.tsx
+++ b/apps/web/src/app/(auth)/login/layout.tsx
@@ -1,6 +1,14 @@
+import type { Metadata } from "next";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "Sign In",
+  description:
+    "Sign in to Tripful to start planning your next group trip. Coordinate travel plans with friends and family.",
+  alternates: { canonical: "/login" },
+};
 
 export default async function LoginLayout({
   children,

--- a/apps/web/src/app/(auth)/verify/layout.tsx
+++ b/apps/web/src/app/(auth)/verify/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "Verify",
+  description: "Verify your email to access Tripful.",
+  robots: { index: false, follow: false },
+};
+
+export default function VerifyLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/apps/web/src/app/apple-icon.tsx
+++ b/apps/web/src/app/apple-icon.tsx
@@ -1,0 +1,41 @@
+import { ImageResponse } from "next/og";
+
+export const size = { width: 180, height: 180 };
+export const contentType = "image/png";
+
+export default function AppleIcon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor: "#1a1814",
+          borderRadius: 36,
+        }}
+      >
+        <svg
+          width="120"
+          height="120"
+          viewBox="0 0 32 32"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <defs>
+            <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0%" stopColor="#1a5c9e" />
+              <stop offset="100%" stopColor="#d1643d" />
+            </linearGradient>
+          </defs>
+          <path
+            d="M30.2 1.8c-1.1-1.1-3-.9-4.3.4L19.5 8.6l-14-4.2c-.4-.1-.9 0-1.2.3L2.1 6.9c-.4.4-.4 1 0 1.3l10 6.5-4.8 4.8-3.5-.7c-.4-.1-.8 0-1 .3l-1.5 1.5c-.3.3-.3.9.1 1.2l4.2 2.6 2.6 4.2c.3.4.8.5 1.2.1l1.5-1.5c.3-.3.3-.7.3-1l-.7-3.5 4.8-4.8 6.5 10c.4.4 1 .4 1.3 0l2.2-2.2c.3-.3.4-.8.3-1.2l-4.2-14 6.4-6.4c1.3-1.3 1.5-3.2.4-4.3z"
+            fill="url(#g)"
+          />
+        </svg>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import type { ReactNode } from "react";
 import "./globals.css";
 import { Providers } from "./providers/providers";
@@ -7,8 +7,48 @@ import { cn } from "@/lib/utils";
 import { SkipLink } from "@/components/skip-link";
 
 export const metadata: Metadata = {
-  title: { default: "Tripful", template: "%s | Tripful" },
-  description: "Plan and share your adventures",
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_SITE_URL || "https://tripful.me"
+  ),
+  title: { default: "Tripful - Group Trip Planner", template: "%s | Tripful" },
+  description:
+    "Plan group trips together. Coordinate itineraries, accommodations, and events with your travel companions in one place.",
+  keywords: [
+    "group trip planner",
+    "trip planning app",
+    "collaborative travel planning",
+    "plan trip with friends",
+    "group vacation planner",
+  ],
+  authors: [{ name: "Tripful" }],
+  creator: "Tripful",
+  alternates: { canonical: "/" },
+  openGraph: {
+    type: "website",
+    siteName: "Tripful",
+    title: "Tripful - Group Trip Planner",
+    description:
+      "Plan group trips together. Coordinate itineraries, accommodations, and events with your travel companions in one place.",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Tripful - Group Trip Planner",
+    description:
+      "Plan group trips together. Coordinate itineraries, accommodations, and events with your travel companions in one place.",
+  },
+  robots: { index: true, follow: true },
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: "default",
+    title: "Tripful",
+  },
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 5,
+  themeColor: "#1a1814",
 };
 
 export default function RootLayout({

--- a/apps/web/src/app/manifest.ts
+++ b/apps/web/src/app/manifest.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "Tripful",
+    short_name: "Tripful",
+    description: "Plan group trips together",
+    start_url: "/",
+    display: "standalone",
+    background_color: "#1a1814",
+    theme_color: "#1a1814",
+    icons: [{ src: "/icon.svg", sizes: "any", type: "image/svg+xml" }],
+  };
+}

--- a/apps/web/src/app/opengraph-image.tsx
+++ b/apps/web/src/app/opengraph-image.tsx
@@ -1,0 +1,126 @@
+import { ImageResponse } from "next/og";
+
+export const alt = "Tripful - Group Trip Planner";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default async function OGImage() {
+  const [playfairFont, dmSansFont] = await Promise.all([
+    fetch(
+      "https://fonts.gstatic.com/s/playfairdisplay/v37/nuFvD-vYSZviVYUb_rj3ij__anPXJzDwcbmjWBN2PKdFvXDXbtM.ttf"
+    ).then((res) => res.arrayBuffer()),
+    fetch(
+      "https://fonts.gstatic.com/s/dmsans/v15/rP2Hp2ywxg089UriCZOIHTWEBlw.ttf"
+    ).then((res) => res.arrayBuffer()),
+  ]);
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor: "#1a1814",
+          position: "relative",
+        }}
+      >
+        {/* Gradient accent line at top */}
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            height: 6,
+            display: "flex",
+            background: "linear-gradient(to right, #1a5c9e, #d1643d)",
+          }}
+        />
+
+        {/* Wordmark */}
+        <div
+          style={{
+            fontSize: 80,
+            fontFamily: "Playfair Display",
+            fontWeight: 700,
+            color: "#fbf6ef",
+            letterSpacing: "-0.02em",
+            marginBottom: 16,
+            display: "flex",
+          }}
+        >
+          Tripful
+        </div>
+
+        {/* Tagline */}
+        <div
+          style={{
+            fontSize: 28,
+            fontFamily: "DM Sans",
+            color: "#8c8173",
+            display: "flex",
+          }}
+        >
+          Plan Group Trips Together
+        </div>
+
+        {/* Decorative diamond */}
+        <div
+          style={{
+            marginTop: 40,
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+          }}
+        >
+          <div
+            style={{
+              width: 48,
+              height: 1,
+              backgroundColor: "#3a2d22",
+              display: "flex",
+            }}
+          />
+          <div
+            style={{
+              width: 8,
+              height: 8,
+              transform: "rotate(45deg)",
+              border: "1px solid #d1643d",
+              display: "flex",
+            }}
+          />
+          <div
+            style={{
+              width: 48,
+              height: 1,
+              backgroundColor: "#3a2d22",
+              display: "flex",
+            }}
+          />
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+      fonts: [
+        {
+          name: "Playfair Display",
+          data: playfairFont,
+          style: "normal",
+          weight: 700,
+        },
+        {
+          name: "DM Sans",
+          data: dmSansFont,
+          style: "normal",
+          weight: 400,
+        },
+      ],
+    }
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,7 +1,52 @@
+import type { Metadata } from "next";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import Link from "next/link";
+import { Calendar, Building2, PartyPopper, Plane } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { JsonLd } from "@/components/json-ld";
+
+export const metadata: Metadata = {
+  title: "Tripful - Group Trip Planner | Plan Travel Together",
+  description:
+    "The group trip planner that makes collaborative travel planning easy. Coordinate itineraries, accommodations, events, and member logistics all in one place.",
+  alternates: { canonical: "/" },
+};
+
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://tripful.me";
+
+const features = [
+  {
+    icon: Calendar,
+    title: "Shared Itineraries",
+    description:
+      "Build a day-by-day schedule your whole group can see and contribute to.",
+  },
+  {
+    icon: Building2,
+    title: "Accommodations",
+    description:
+      "Research and decide on lodging together with all the details in one place.",
+  },
+  {
+    icon: PartyPopper,
+    title: "Event Planning",
+    description:
+      "Create events with RSVP tracking so everyone knows what's happening and when.",
+  },
+  {
+    icon: Plane,
+    title: "Travel Logistics",
+    description:
+      "Track member availability, flights, and travel details to keep the group in sync.",
+  },
+] as const;
+
+const steps = [
+  { number: "1", title: "Create a trip", description: "Set dates, add a destination, and give your trip a name." },
+  { number: "2", title: "Invite your group", description: "Share a link and everyone joins in seconds." },
+  { number: "3", title: "Plan together", description: "Add events, accommodations, and logistics as a group." },
+] as const;
 
 export default async function Home() {
   const cookieStore = await cookies();
@@ -12,31 +57,126 @@ export default async function Home() {
   }
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-background px-4">
-      {/* Decorative accent line */}
-      <div className="mb-6 h-1 w-16 rounded-full bg-accent" />
+    <>
+      <main className="flex min-h-screen flex-col bg-background">
+        {/* Hero Section */}
+        <section className="flex flex-col items-center justify-center px-4 pt-24 pb-20 text-center sm:pt-32 sm:pb-28">
+          <div className="mb-6 h-1 w-16 rounded-full bg-accent" />
+          <h1 className="mb-4 max-w-2xl text-5xl font-bold tracking-tight text-foreground sm:text-6xl lg:text-7xl font-[family-name:var(--font-playfair)]">
+            Plan Group Trips Together
+          </h1>
+          <p className="mb-10 max-w-lg text-center text-lg text-muted-foreground sm:text-xl">
+            The trip planning app that brings your travel group together.
+            Coordinate everything in one place.
+          </p>
+          <Button
+            variant="gradient"
+            size="lg"
+            className="rounded-xl px-10"
+            asChild
+          >
+            <Link href="/login">Get started</Link>
+          </Button>
+        </section>
 
-      {/* Wordmark */}
-      <h1 className="mb-4 text-6xl font-bold tracking-tight text-foreground sm:text-7xl font-[family-name:var(--font-playfair)]">
-        Tripful
-      </h1>
+        {/* Features Section */}
+        <section className="px-4 py-20 sm:py-28">
+          <div className="mx-auto max-w-5xl">
+            <h2 className="mb-12 text-center text-3xl font-bold tracking-tight text-foreground sm:text-4xl font-[family-name:var(--font-playfair)]">
+              Everything your group needs to plan the perfect trip
+            </h2>
+            <div className="grid gap-8 sm:grid-cols-2">
+              {features.map((feature) => (
+                <div
+                  key={feature.title}
+                  className="rounded-xl border border-border bg-card p-6"
+                >
+                  <feature.icon className="mb-3 h-6 w-6 text-accent" />
+                  <h3 className="mb-2 text-lg font-semibold text-foreground">
+                    {feature.title}
+                  </h3>
+                  <p className="text-sm text-muted-foreground leading-relaxed">
+                    {feature.description}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
 
-      {/* Tagline */}
-      <p className="mb-10 max-w-md text-center text-lg text-muted-foreground">
-        Plan and share your adventures
-      </p>
+        {/* How It Works Section */}
+        <section className="px-4 py-20 sm:py-28">
+          <div className="mx-auto max-w-3xl">
+            <h2 className="mb-12 text-center text-3xl font-bold tracking-tight text-foreground sm:text-4xl font-[family-name:var(--font-playfair)]">
+              How Tripful works
+            </h2>
+            <div className="grid gap-8 sm:grid-cols-3">
+              {steps.map((step) => (
+                <div key={step.number} className="text-center">
+                  <div className="mx-auto mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-accent text-sm font-bold text-accent-foreground">
+                    {step.number}
+                  </div>
+                  <h3 className="mb-2 text-lg font-semibold text-foreground">
+                    {step.title}
+                  </h3>
+                  <p className="text-sm text-muted-foreground leading-relaxed">
+                    {step.description}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
 
-      {/* CTA */}
-      <Button variant="gradient" size="lg" className="rounded-xl px-10" asChild>
-        <Link href="/login">Get started</Link>
-      </Button>
+        {/* Bottom CTA Section */}
+        <section className="flex flex-col items-center px-4 pt-12 pb-24 text-center sm:pb-32">
+          <div className="mb-8 flex items-center gap-3">
+            <div className="h-px w-12 bg-border" />
+            <div className="h-2 w-2 rotate-45 border border-primary/40" />
+            <div className="h-px w-12 bg-border" />
+          </div>
+          <h2 className="mb-6 text-2xl font-bold tracking-tight text-foreground sm:text-3xl font-[family-name:var(--font-playfair)]">
+            Ready to plan your next adventure?
+          </h2>
+          <Button
+            variant="gradient"
+            size="lg"
+            className="rounded-xl px-10"
+            asChild
+          >
+            <Link href="/login">Start planning</Link>
+          </Button>
+        </section>
+      </main>
 
-      {/* Decorative bottom element */}
-      <div className="mt-16 flex items-center gap-3">
-        <div className="h-px w-12 bg-border" />
-        <div className="h-2 w-2 rotate-45 border border-primary/40" />
-        <div className="h-px w-12 bg-border" />
-      </div>
-    </div>
+      {/* Structured Data */}
+      <JsonLd
+        data={{
+          "@context": "https://schema.org",
+          "@type": "WebSite",
+          name: "Tripful",
+          url: siteUrl,
+          description:
+            "Plan group trips together. Coordinate itineraries, accommodations, and events with your travel companions in one place.",
+        }}
+      />
+      <JsonLd
+        data={{
+          "@context": "https://schema.org",
+          "@type": "WebApplication",
+          name: "Tripful",
+          url: siteUrl,
+          applicationCategory: "TravelApplication",
+          operatingSystem: "Web",
+          description:
+            "The group trip planner that makes collaborative travel planning easy.",
+          offers: {
+            "@type": "Offer",
+            price: "0",
+            priceCurrency: "USD",
+          },
+        }}
+      />
+    </>
   );
 }

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,12 +1,12 @@
 import type { MetadataRoute } from "next";
 
 export default function robots(): MetadataRoute.Robots {
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://tripful.com";
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://tripful.me";
   return {
     rules: {
       userAgent: "*",
       allow: "/",
-      disallow: ["/trips"],
+      disallow: ["/trips", "/verify", "/complete-profile"],
     },
     sitemap: `${siteUrl}/sitemap.xml`,
   };

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,17 +1,17 @@
 import type { MetadataRoute } from "next";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://tripful.com";
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://tripful.me";
   return [
     {
       url: siteUrl,
-      lastModified: new Date(),
+      lastModified: new Date("2026-02-20"),
       changeFrequency: "monthly",
       priority: 1,
     },
     {
       url: `${siteUrl}/login`,
-      lastModified: new Date(),
+      lastModified: new Date("2026-02-20"),
       changeFrequency: "monthly",
       priority: 0.5,
     },

--- a/apps/web/src/app/twitter-image.tsx
+++ b/apps/web/src/app/twitter-image.tsx
@@ -1,0 +1,1 @@
+export { default, alt, size, contentType } from "./opengraph-image";

--- a/apps/web/src/components/json-ld.tsx
+++ b/apps/web/src/components/json-ld.tsx
@@ -1,0 +1,8 @@
+export function JsonLd({ data }: { data: Record<string, unknown> }) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

- Add comprehensive SEO metadata infrastructure (Open Graph, Twitter cards, canonical URLs, keywords, structured data)
- Generate dynamic OG image and Apple Touch Icon using Next.js `ImageResponse` API
- Add PWA manifest, per-page metadata, and noindex directives for auth/private routes
- Rewrite homepage from minimal wordmark into keyword-targeted landing page (hero, features, how-it-works, CTA sections)
- Fix robots.txt to disallow auth flow routes and sitemap.ts to use fixed dates
- Target "group trip planner" as primary keyword, "trip planning app" as secondary

## Changes

### Technical SEO Infrastructure
- **Root layout**: `metadataBase`, OG tags, Twitter cards, keywords, authors, viewport, canonical
- **Per-page metadata**: Login (title + description), verify/complete-profile (noindex), trip detail (noindex)
- **`opengraph-image.tsx`**: Dynamic 1200x630 OG image with Playfair Display + DM Sans fonts
- **`twitter-image.tsx`**: Re-exports OG image for Twitter cards
- **`apple-icon.tsx`**: Dynamic 180x180 Apple Touch Icon with brand gradient plane logo
- **`json-ld.tsx`**: Reusable `JsonLd` component for structured data
- **`manifest.ts`**: PWA web app manifest with brand colors
- **`robots.ts`**: Added `/verify`, `/complete-profile` to disallow list; updated domain to tripful.me
- **`sitemap.ts`**: Fixed `lastModified` from `new Date()` to fixed date; updated domain

### Landing Page Enhancement
- **Homepage**: Hero section (H1 with primary keyword), feature cards (4 features with Lucide icons), how-it-works steps, bottom CTA
- **Structured data**: WebSite + WebApplication JSON-LD schemas on homepage

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] Homepage renders new landing page content at `/`
- [ ] View source shows `<meta property="og:title">`, `<meta name="twitter:card">`, canonical, keywords
- [ ] `/opengraph-image` returns branded 1200x630 PNG
- [ ] `/sitemap.xml` shows fixed dates and tripful.me URLs
- [ ] `/robots.txt` includes `/verify` and `/complete-profile` in disallow
- [ ] `/manifest.webmanifest` returns valid JSON
- [ ] Auth redirect still works (logged-in users go to `/trips`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)