### PR TITLE
Add devcontainer for multi-branch development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,8 +6,10 @@ RUN corepack enable && corepack prepare pnpm@10.30.1 --activate
 # Install turbo globally (npm avoids pnpm global dir permission issues)
 RUN npm install -g turbo
 
-# Install Playwright system dependencies + Chromium
-# Run as node user so browser cache is in the right place for test runs
+# Install Playwright system dependencies (requires root)
+RUN npx playwright install-deps chromium
+
+# Install Playwright browser as node user (cache lands in /home/node)
 USER node
-RUN npx playwright install --with-deps chromium
+RUN npx playwright install chromium
 USER root

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm
+
+# Enable corepack for pnpm (version from package.json)
+RUN corepack enable && corepack prepare pnpm@10.30.1 --activate
+
+# Install turbo globally (npm avoids pnpm global dir permission issues)
+RUN npm install -g turbo
+
+# Install Playwright system dependencies + Chromium
+# Run as node user so browser cache is in the right place for test runs
+USER node
+RUN npx playwright install --with-deps chromium
+USER root

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
   "postCreateCommand": "bash .devcontainer/setup.sh",
+  "shutdownAction": "stopCompose",
   "remoteEnv": {
     "NODE_ENV": "development"
   }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "Tripful",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspace",
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "postCreateCommand": "bash .devcontainer/setup.sh",
+  "remoteEnv": {
+    "NODE_ENV": "development"
+  }
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ..:/workspace:cached
+    ports:
+      - "3000" # random host port -> container 3000 (Next.js)
+      - "8000" # random host port -> container 8000 (Fastify)
+    command: sleep infinity
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: tripful
+      POSTGRES_PASSWORD: tripful_dev
+      POSTGRES_DB: tripful
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U tripful"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  postgres_data:

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -31,13 +31,13 @@ EOF
 fi
 
 # Install dependencies (approve native build scripts non-interactively)
-pnpm approve-builds esbuild sharp unrs-resolver 2>/dev/null || true
+pnpm approve-builds esbuild sharp unrs-resolver 2>&1 || true
 pnpm install
 
 # Build shared package (required before API/web can use it)
 pnpm --filter @tripful/shared build
 
 # Run database migrations
-cd /workspace/apps/api && pnpm db:migrate
+cd apps/api && pnpm db:migrate
 
 echo "[setup] Done! Ready to develop."

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[setup] Configuring Tripful devcontainer..."
+
+# Generate API .env only if it doesn't exist (preserves manual edits)
+if [ ! -f apps/api/.env ]; then
+  cat > apps/api/.env << 'EOF'
+NODE_ENV=development
+PORT=8000
+HOST=0.0.0.0
+DATABASE_URL=postgresql://tripful:tripful_dev@db:5432/tripful
+JWT_SECRET=devcontainer-secret-key-minimum-32-characters-long
+FRONTEND_URL=http://localhost:3000
+LOG_LEVEL=info
+UPLOAD_DIR=uploads
+MAX_FILE_SIZE=5242880
+ALLOWED_MIME_TYPES=image/jpeg,image/png,image/webp
+EOF
+  echo "[setup] Created apps/api/.env"
+fi
+
+# Generate web .env.local only if it doesn't exist
+if [ ! -f apps/web/.env.local ]; then
+  cat > apps/web/.env.local << 'EOF'
+NEXT_PUBLIC_API_URL=http://localhost:8000/api
+API_URL=http://localhost:8000/api
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
+EOF
+  echo "[setup] Created apps/web/.env.local"
+fi
+
+# Install dependencies (approve native build scripts non-interactively)
+pnpm approve-builds esbuild sharp unrs-resolver 2>/dev/null || true
+pnpm install
+
+# Build shared package (required before API/web can use it)
+pnpm --filter @tripful/shared build
+
+# Run database migrations
+cd /workspace/apps/api && pnpm db:migrate
+
+echo "[setup] Done! Ready to develop."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       api: ${{ steps.filter.outputs.api }}
       web: ${{ steps.filter.outputs.web }}
       shared: ${{ steps.filter.outputs.shared }}
+      devcontainer: ${{ steps.filter.outputs.devcontainer }}
     steps:
       - uses: actions/checkout@v6
 
@@ -43,6 +44,9 @@ jobs:
               - '.github/**'
               - 'tsconfig.base.json'
               - 'eslint.config.js'
+            devcontainer:
+              - '.devcontainer/**'
+              - 'Makefile'
 
   # Step 2: Lint + Type Check
   quality:
@@ -92,6 +96,18 @@ jobs:
 
       - name: Dependency audit
         run: pnpm audit --audit-level=high
+
+  # Step 2b: Devcontainer config validation (no Node/pnpm needed)
+  devcontainer:
+    name: Devcontainer Tests
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.devcontainer == 'true'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate devcontainer config
+        run: bash scripts/__tests__/test-devcontainer.test.sh
 
   # Step 3: Unit Tests (API)
   unit-tests:

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ Thumbs.db
 # Misc
 *.pem
 .cache/
+.pnpm-store/
 temp/
 tmp/
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,118 @@
+.PHONY: dev-up dev-down dev-exec dev-list dev-clean dev-shell dev-logs dev-restart
+
+# Resolve branch -> worktree path
+BRANCH    ?= $(shell git branch --show-current)
+SLUG       = $(shell echo "$(BRANCH)" | tr '/' '-' | tr '_' '-' | tr '[:upper:]' '[:lower:]' | cut -c1-60)
+WORKTREE   = ../tripful--$(SLUG)
+DC         = devcontainer
+
+# Check that devcontainer CLI is installed
+check-deps:
+	@command -v $(DC) >/dev/null 2>&1 || { echo "Error: 'devcontainer' CLI not found. Install with: npm i -g @devcontainers/cli"; exit 1; }
+	@command -v docker >/dev/null 2>&1 || { echo "Error: 'docker' not found."; exit 1; }
+
+# Create worktree + start isolated devcontainer + show ports
+dev-up: check-deps
+	@start=$$(date +%s); \
+	if [ ! -d "$(WORKTREE)" ]; then \
+	  git worktree add "$(WORKTREE)" "$(BRANCH)" 2>/dev/null \
+	    || git worktree add "$(WORKTREE)" "origin/$(BRANCH)" \
+	    || { echo "Error: branch '$(BRANCH)' not found locally or in origin"; exit 1; }; \
+	fi; \
+	$(DC) up --workspace-folder "$(WORKTREE)"; \
+	echo ""; \
+	echo "=== $(BRANCH) is ready ==="; \
+	cid=$$(docker ps -q --filter "label=devcontainer.local_folder=$$(realpath $(WORKTREE))"); \
+	if [ -n "$$cid" ]; then \
+	  web=$$(docker port "$$cid" 3000 2>/dev/null | head -1); \
+	  api=$$(docker port "$$cid" 8000 2>/dev/null | head -1); \
+	  echo "  Web:  $${web:-not exposed}"; \
+	  echo "  API:  $${api:-not exposed}"; \
+	fi; \
+	end=$$(date +%s); \
+	echo "  Time: $$(( end - start ))s"
+
+# Run a command inside the branch's container
+# Usage: make dev-exec BRANCH=feature/auth CMD="pnpm test"
+#        make dev-exec BRANCH=feature/auth CMD="pnpm lint && pnpm typecheck"
+dev-exec: check-deps
+	@$(DC) exec --workspace-folder "$(WORKTREE)" $(CMD)
+
+# Stop container (keeps worktree on disk)
+dev-down: check-deps
+	@cid=$$(docker ps -q --filter "label=devcontainer.local_folder=$$(realpath $(WORKTREE))"); \
+	if [ -n "$$cid" ]; then \
+	  docker stop "$$cid"; \
+	  echo "Stopped container for $(BRANCH)"; \
+	else \
+	  echo "No running container for $(BRANCH)"; \
+	fi
+	@if [ -d "$(WORKTREE)" ]; then \
+	  git worktree remove "$(WORKTREE)" 2>/dev/null \
+	    || echo "Worktree has changes — kept at $(WORKTREE). Use git worktree remove --force to delete."; \
+	fi
+
+# Restart container without removing worktree
+dev-restart: check-deps
+	@cid=$$(docker ps -q --filter "label=devcontainer.local_folder=$$(realpath $(WORKTREE))"); \
+	[ -n "$$cid" ] && docker stop "$$cid" || true
+	@$(DC) up --workspace-folder "$(WORKTREE)"
+
+# Open interactive shell in the container
+dev-shell: check-deps
+	@$(DC) exec --workspace-folder "$(WORKTREE)" bash
+
+# Tail container logs
+dev-logs: check-deps
+	@cid=$$(docker ps -q --filter "label=devcontainer.local_folder=$$(realpath $(WORKTREE))"); \
+	if [ -n "$$cid" ]; then \
+	  docker logs -f "$$cid"; \
+	else \
+	  echo "No running container for $(BRANCH)"; \
+	fi
+
+# Show all branch environments, status, and ports
+dev-list:
+	@printf "%-25s %-10s %-20s %s\n" "BRANCH" "STATUS" "PORTS" "PATH"; \
+	found=0; \
+	for wt in ../tripful--*; do \
+	  [ -d "$$wt" ] || continue; \
+	  found=1; \
+	  name=$$(basename "$$wt" | sed 's/^tripful--//'); \
+	  cid=$$(docker ps -q --filter "label=devcontainer.local_folder=$$(realpath $$wt)"); \
+	  if [ -n "$$cid" ]; then \
+	    web=$$(docker port "$$cid" 3000 2>/dev/null | head -1 | sed 's/.*://'); \
+	    api=$$(docker port "$$cid" 8000 2>/dev/null | head -1 | sed 's/.*://'); \
+	    printf "%-25s %-10s %-20s %s\n" "$$name" "running" "web:$${web:-?} api:$${api:-?}" "$$wt"; \
+	  else \
+	    printf "%-25s %-10s %-20s %s\n" "$$name" "stopped" "-" "$$wt"; \
+	  fi; \
+	done; \
+	[ "$$found" -eq 0 ] && echo "(no environments found)"
+
+# Remove all stopped envs
+dev-clean:
+	@to_remove=""; \
+	for wt in ../tripful--*; do \
+	  [ -d "$$wt" ] || continue; \
+	  cid=$$(docker ps -q --filter "label=devcontainer.local_folder=$$(realpath $$wt)"); \
+	  if [ -z "$$cid" ]; then \
+	    to_remove="$$to_remove $$wt"; \
+	  fi; \
+	done; \
+	if [ -z "$$to_remove" ]; then \
+	  echo "No stopped environments to clean."; \
+	else \
+	  echo "Will remove:$$to_remove"; \
+	  printf "Continue? [y/N] "; \
+	  read -r ans; \
+	  if [ "$$ans" = "y" ] || [ "$$ans" = "Y" ]; then \
+	    for wt in $$to_remove; do \
+	      echo "Removing $$wt"; \
+	      git worktree remove "$$wt" --force 2>/dev/null || rm -rf "$$wt"; \
+	    done; \
+	    echo "Done. Run 'docker volume prune' to reclaim disk space."; \
+	  else \
+	    echo "Aborted."; \
+	  fi; \
+	fi

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ dev-up: check-deps
 dev-exec: check-deps
 	@$(DC) exec --workspace-folder "$(WORKTREE)" $(CMD)
 
-# Stop container (keeps worktree on disk)
+# Stop container + remove worktree
 dev-down: check-deps
 	@cid=$$(docker ps -q --filter "label=devcontainer.local_folder=$$(realpath $(WORKTREE))"); \
 	if [ -n "$$cid" ]; then \
@@ -46,8 +46,8 @@ dev-down: check-deps
 	  echo "Stopped container for $(BRANCH)"; \
 	else \
 	  echo "No running container for $(BRANCH)"; \
-	fi
-	@if [ -d "$(WORKTREE)" ]; then \
+	fi; \
+	if [ -d "$(WORKTREE)" ]; then \
 	  git worktree remove "$(WORKTREE)" 2>/dev/null \
 	    || echo "Worktree has changes — kept at $(WORKTREE). Use git worktree remove --force to delete."; \
 	fi

--- a/scripts/__tests__/test-devcontainer.test.sh
+++ b/scripts/__tests__/test-devcontainer.test.sh
@@ -1,0 +1,417 @@
+#!/bin/bash
+# Tests for devcontainer multi-branch setup
+# Validates configs, slug generation, and setup.sh idempotency
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+log_test() {
+    echo -e "${YELLOW}TEST:${NC} $1"
+}
+
+log_pass() {
+    echo -e "  ${GREEN}PASS${NC}"
+    ((TESTS_PASSED++)) || true
+}
+
+log_fail() {
+    echo -e "  ${RED}FAIL${NC} $1"
+    ((TESTS_FAILED++)) || true
+}
+
+# Get project root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# ============================================================
+# devcontainer.json validation
+# ============================================================
+
+echo ""
+echo "=== devcontainer.json ==="
+
+log_test "devcontainer.json exists"
+if [ -f "$PROJECT_ROOT/.devcontainer/devcontainer.json" ]; then
+    log_pass
+else
+    log_fail "file not found"
+fi
+
+log_test "devcontainer.json is valid JSON"
+if python3 -c "import json; json.load(open('$PROJECT_ROOT/.devcontainer/devcontainer.json'))" 2>/dev/null; then
+    log_pass
+else
+    log_fail "invalid JSON"
+fi
+
+log_test "devcontainer.json has required fields"
+MISSING=""
+for field in dockerComposeFile service workspaceFolder postCreateCommand; do
+    if ! python3 -c "
+import json, sys
+d = json.load(open('$PROJECT_ROOT/.devcontainer/devcontainer.json'))
+if '$field' not in d: sys.exit(1)
+" 2>/dev/null; then
+        MISSING="$MISSING $field"
+    fi
+done
+if [ -z "$MISSING" ]; then
+    log_pass
+else
+    log_fail "missing:$MISSING"
+fi
+
+log_test "devcontainer.json service is 'app'"
+if python3 -c "
+import json, sys
+d = json.load(open('$PROJECT_ROOT/.devcontainer/devcontainer.json'))
+sys.exit(0 if d.get('service') == 'app' else 1)
+" 2>/dev/null; then
+    log_pass
+else
+    log_fail "service should be 'app'"
+fi
+
+log_test "devcontainer.json has shutdownAction"
+if python3 -c "
+import json, sys
+d = json.load(open('$PROJECT_ROOT/.devcontainer/devcontainer.json'))
+sys.exit(0 if 'shutdownAction' in d else 1)
+" 2>/dev/null; then
+    log_pass
+else
+    log_fail "shutdownAction missing — containers may be orphaned"
+fi
+
+# ============================================================
+# docker-compose.yml validation
+# ============================================================
+
+echo ""
+echo "=== docker-compose.yml ==="
+
+log_test "docker-compose.yml exists"
+if [ -f "$PROJECT_ROOT/.devcontainer/docker-compose.yml" ]; then
+    log_pass
+else
+    log_fail "file not found"
+fi
+
+log_test "docker-compose.yml is valid (docker compose config)"
+if command -v docker >/dev/null 2>&1; then
+    if docker compose -f "$PROJECT_ROOT/.devcontainer/docker-compose.yml" config >/dev/null 2>&1; then
+        log_pass
+    else
+        log_fail "docker compose config failed"
+    fi
+else
+    echo -e "  ${YELLOW}SKIP${NC} docker not available"
+fi
+
+log_test "docker-compose.yml defines 'app' and 'db' services"
+if grep -q "^  app:" "$PROJECT_ROOT/.devcontainer/docker-compose.yml" \
+   && grep -q "^  db:" "$PROJECT_ROOT/.devcontainer/docker-compose.yml"; then
+    log_pass
+else
+    log_fail "expected 'app' and 'db' services"
+fi
+
+log_test "app service uses random port assignment (no host:container mapping)"
+# Ports should be just "3000" and "8000", not "3000:3000"
+if grep -E '^\s+- "[0-9]+:[0-9]+"' "$PROJECT_ROOT/.devcontainer/docker-compose.yml" >/dev/null 2>&1; then
+    log_fail "found host:container port mapping — breaks multi-branch isolation"
+else
+    log_pass
+fi
+
+log_test "db service has healthcheck"
+if grep -q "healthcheck:" "$PROJECT_ROOT/.devcontainer/docker-compose.yml"; then
+    log_pass
+else
+    log_fail "PostgreSQL healthcheck missing"
+fi
+
+log_test "app depends on db with service_healthy condition"
+if grep -q "service_healthy" "$PROJECT_ROOT/.devcontainer/docker-compose.yml"; then
+    log_pass
+else
+    log_fail "app should wait for db healthcheck"
+fi
+
+# ============================================================
+# Dockerfile validation
+# ============================================================
+
+echo ""
+echo "=== Dockerfile ==="
+
+log_test "Dockerfile exists"
+if [ -f "$PROJECT_ROOT/.devcontainer/Dockerfile" ]; then
+    log_pass
+else
+    log_fail "file not found"
+fi
+
+log_test "Dockerfile installs pnpm via corepack"
+if grep -q "corepack.*pnpm" "$PROJECT_ROOT/.devcontainer/Dockerfile"; then
+    log_pass
+else
+    log_fail "expected corepack prepare pnpm"
+fi
+
+log_test "Dockerfile installs Playwright as node user"
+if grep -B5 "playwright install chromium" "$PROJECT_ROOT/.devcontainer/Dockerfile" | grep -q "USER node"; then
+    log_pass
+else
+    log_fail "Playwright browser should install as node user for cache alignment"
+fi
+
+log_test "Dockerfile installs Playwright system deps as root"
+if grep -q "playwright install-deps" "$PROJECT_ROOT/.devcontainer/Dockerfile"; then
+    log_pass
+else
+    log_fail "system deps should be installed separately as root"
+fi
+
+# ============================================================
+# setup.sh validation
+# ============================================================
+
+echo ""
+echo "=== setup.sh ==="
+
+log_test "setup.sh exists and is executable"
+if [ -x "$PROJECT_ROOT/.devcontainer/setup.sh" ]; then
+    log_pass
+else
+    log_fail "not found or not executable"
+fi
+
+log_test "setup.sh uses strict mode (set -euo pipefail)"
+if head -3 "$PROJECT_ROOT/.devcontainer/setup.sh" | grep -q "set -euo pipefail"; then
+    log_pass
+else
+    log_fail "expected strict bash mode"
+fi
+
+log_test "setup.sh generates env files idempotently (only if not exists)"
+API_GUARDS=$(grep -c '! -f apps/api/.env' "$PROJECT_ROOT/.devcontainer/setup.sh")
+WEB_GUARDS=$(grep -c '! -f apps/web/.env.local' "$PROJECT_ROOT/.devcontainer/setup.sh")
+if [ "$API_GUARDS" -ge 1 ] && [ "$WEB_GUARDS" -ge 1 ]; then
+    log_pass
+else
+    log_fail "env file creation should be guarded with [ ! -f ] checks"
+fi
+
+log_test "setup.sh DATABASE_URL points to compose 'db' service"
+if grep -q "DATABASE_URL=.*@db:" "$PROJECT_ROOT/.devcontainer/setup.sh"; then
+    log_pass
+else
+    log_fail "DATABASE_URL should use 'db' (compose service name), not 'localhost'"
+fi
+
+log_test "setup.sh runs pnpm install"
+if grep -q "pnpm install" "$PROJECT_ROOT/.devcontainer/setup.sh"; then
+    log_pass
+else
+    log_fail "expected pnpm install"
+fi
+
+log_test "setup.sh builds shared package before migrations"
+INSTALL_LINE=$(grep -n "pnpm install" "$PROJECT_ROOT/.devcontainer/setup.sh" | head -1 | cut -d: -f1)
+SHARED_LINE=$(grep -n "@tripful/shared build" "$PROJECT_ROOT/.devcontainer/setup.sh" | head -1 | cut -d: -f1)
+MIGRATE_LINE=$(grep -n "db:migrate" "$PROJECT_ROOT/.devcontainer/setup.sh" | head -1 | cut -d: -f1)
+if [ -n "$INSTALL_LINE" ] && [ -n "$SHARED_LINE" ] && [ -n "$MIGRATE_LINE" ] \
+   && [ "$INSTALL_LINE" -lt "$SHARED_LINE" ] && [ "$SHARED_LINE" -lt "$MIGRATE_LINE" ]; then
+    log_pass
+else
+    log_fail "order should be: pnpm install -> shared build -> db:migrate"
+fi
+
+log_test "setup.sh does not hardcode /workspace path"
+# The postCreateCommand runs from workspaceFolder, so relative paths should work
+if grep -q "cd /workspace" "$PROJECT_ROOT/.devcontainer/setup.sh"; then
+    log_fail "use relative paths instead of hardcoded /workspace"
+else
+    log_pass
+fi
+
+# ============================================================
+# setup.sh idempotency (functional test)
+# ============================================================
+
+echo ""
+echo "=== setup.sh idempotency ==="
+
+TMPDIR_TEST=$(mktemp -d)
+trap "rm -rf $TMPDIR_TEST" EXIT
+
+log_test "env files are created when missing"
+mkdir -p "$TMPDIR_TEST/apps/api" "$TMPDIR_TEST/apps/web"
+# Extract just the env-file-generation part of setup.sh and run it
+(
+    cd "$TMPDIR_TEST"
+    # Simulate the env generation logic
+    if [ ! -f apps/api/.env ]; then
+        echo "DATABASE_URL=test" > apps/api/.env
+    fi
+    if [ ! -f apps/web/.env.local ]; then
+        echo "API_URL=test" > apps/web/.env.local
+    fi
+)
+if [ -f "$TMPDIR_TEST/apps/api/.env" ] && [ -f "$TMPDIR_TEST/apps/web/.env.local" ]; then
+    log_pass
+else
+    log_fail "env files not created"
+fi
+
+log_test "env files are preserved when they already exist"
+echo "CUSTOM=value" > "$TMPDIR_TEST/apps/api/.env"
+echo "CUSTOM=value" > "$TMPDIR_TEST/apps/web/.env.local"
+(
+    cd "$TMPDIR_TEST"
+    if [ ! -f apps/api/.env ]; then
+        echo "OVERWRITTEN" > apps/api/.env
+    fi
+    if [ ! -f apps/web/.env.local ]; then
+        echo "OVERWRITTEN" > apps/web/.env.local
+    fi
+)
+if grep -q "CUSTOM=value" "$TMPDIR_TEST/apps/api/.env" \
+   && grep -q "CUSTOM=value" "$TMPDIR_TEST/apps/web/.env.local"; then
+    log_pass
+else
+    log_fail "existing env files were overwritten"
+fi
+
+# ============================================================
+# Makefile slug generation
+# ============================================================
+
+echo ""
+echo "=== Makefile slug generation ==="
+
+test_slug() {
+    local input="$1"
+    local expected="$2"
+    local description="$3"
+
+    local actual
+    actual=$(echo "$input" | tr '/' '-' | tr '_' '-' | tr '[:upper:]' '[:lower:]' | cut -c1-60)
+
+    log_test "$description: '$input' -> '$expected'"
+    if [ "$actual" = "$expected" ]; then
+        log_pass
+    else
+        log_fail "got '$actual'"
+    fi
+}
+
+test_slug "feature/auth" "feature-auth" "slashes become dashes"
+test_slug "feature_auth" "feature-auth" "underscores become dashes"
+test_slug "Feature/Auth" "feature-auth" "uppercase to lowercase"
+test_slug "main" "main" "simple branch name unchanged"
+test_slug "fix/JIRA-123_update_login" "fix-jira-123-update-login" "mixed separators normalized"
+test_slug "a-very-long-branch-name-that-exceeds-the-sixty-character-limit-for-slugs" \
+          "a-very-long-branch-name-that-exceeds-the-sixty-character-lim" \
+          "truncated to 60 chars"
+
+# ============================================================
+# Makefile targets
+# ============================================================
+
+echo ""
+echo "=== Makefile targets ==="
+
+log_test "Makefile exists"
+if [ -f "$PROJECT_ROOT/Makefile" ]; then
+    log_pass
+else
+    log_fail "file not found"
+fi
+
+for target in dev-up dev-down dev-exec dev-list dev-clean dev-shell dev-logs dev-restart; do
+    log_test "Makefile has '$target' target"
+    if grep -q "^$target:" "$PROJECT_ROOT/Makefile"; then
+        log_pass
+    else
+        log_fail "target not found"
+    fi
+done
+
+log_test "Makefile targets are declared in .PHONY"
+PHONY_LINE=$(grep "^\.PHONY:" "$PROJECT_ROOT/Makefile")
+MISSING_PHONY=""
+for target in dev-up dev-down dev-exec dev-list dev-clean dev-shell dev-logs dev-restart; do
+    if ! echo "$PHONY_LINE" | grep -q "$target"; then
+        MISSING_PHONY="$MISSING_PHONY $target"
+    fi
+done
+if [ -z "$MISSING_PHONY" ]; then
+    log_pass
+else
+    log_fail "missing from .PHONY:$MISSING_PHONY"
+fi
+
+log_test "dev-down uses single shell block (worktree cleanup always runs)"
+# A single shell block means only one line starting with tab+@ in the recipe
+RECIPE_STARTS=$(sed -n '/^dev-down:/,/^[^	 ]/p' "$PROJECT_ROOT/Makefile" | grep -cP '^\t@')
+if [ "$RECIPE_STARTS" -eq 1 ]; then
+    log_pass
+else
+    log_fail "expected 1 recipe block, found $RECIPE_STARTS — worktree cleanup may be skipped on docker stop failure"
+fi
+
+log_test "check-deps verifies devcontainer CLI"
+if grep -q 'command -v.*devcontainer\|command -v.*\$(DC)' "$PROJECT_ROOT/Makefile"; then
+    log_pass
+else
+    log_fail "check-deps should verify devcontainer CLI is installed"
+fi
+
+log_test "check-deps verifies docker"
+if grep -q 'command -v.*docker' "$PROJECT_ROOT/Makefile"; then
+    log_pass
+else
+    log_fail "check-deps should verify docker is installed"
+fi
+
+# ============================================================
+# .gitignore
+# ============================================================
+
+echo ""
+echo "=== .gitignore ==="
+
+log_test ".pnpm-store/ is gitignored"
+if grep -q "\.pnpm-store/" "$PROJECT_ROOT/.gitignore"; then
+    log_pass
+else
+    log_fail "pnpm creates .pnpm-store/ in workspace via bind mount — should be gitignored"
+fi
+
+log_test ".devcontainer/.env is covered by gitignore"
+# The .env pattern should match .devcontainer/.env
+if grep -q "^\.env$" "$PROJECT_ROOT/.gitignore"; then
+    log_pass
+else
+    log_fail ".devcontainer/.env should be gitignored"
+fi
+
+# ============================================================
+# Summary
+# ============================================================
+
+echo ""
+echo "================================"
+TOTAL=$((TESTS_PASSED + TESTS_FAILED))
+echo -e "Results: ${GREEN}$TESTS_PASSED passed${NC}, ${RED}$TESTS_FAILED failed${NC}, $TOTAL total"
+echo "================================"
+
+exit $TESTS_FAILED


### PR DESCRIPTION
## Summary

- Adds Docker Compose-based devcontainer (Dockerfile, docker-compose.yml, devcontainer.json, setup.sh) so each git worktree gets an isolated container with Node.js 22, pnpm, PostgreSQL 16, and Playwright Chromium
- Adds Makefile with `dev-up`, `dev-down`, `dev-exec`, `dev-list`, `dev-shell`, `dev-logs`, `dev-restart`, and `dev-clean` targets for managing branch environments from the host
- Ports are randomly assigned per container — multiple branches run simultaneously with no conflicts

## Test plan

- [x] `devcontainer up` builds image and starts containers
- [x] setup.sh creates env files, installs deps, builds shared package, runs migrations
- [x] `pnpm lint` passes inside container
- [x] `pnpm typecheck` passes inside container
- [x] `pnpm test` runs inside container (pre-existing flaky tests only)
- [x] Playwright Chromium pre-installed and version-matched
- [x] Random host ports assigned and accessible
- [ ] `make dev-up BRANCH=main` from host repo (requires Makefile merged to main first)
- [ ] Multi-branch simultaneous operation via `make dev-list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)