### PR TITLE
Add database seed script for local development

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,6 +17,7 @@
     "db:restart": "cd ../.. && docker-compose restart",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
+    "db:seed": "tsx src/db/seed.ts",
     "db:studio": "drizzle-kit studio",
     "clean": "rm -rf dist"
   },
@@ -50,6 +51,7 @@
     "@types/pg": "^8.11.10",
     "@vitest/coverage-v8": "^4.0.18",
     "drizzle-kit": "^0.28.1",
+    "drizzle-seed": "^0.3.1",
     "form-data": "^4.0.5",
     "pino-pretty": "^13.1.3",
     "tsx": "^4.19.2",

--- a/apps/api/src/db/seed.ts
+++ b/apps/api/src/db/seed.ts
@@ -1,0 +1,339 @@
+import { reset } from "drizzle-seed";
+import { db, pool } from "@/config/database.js";
+import * as schema from "@/db/schema/index.js";
+
+const PHONE_NUMBERS = [
+  "+15550000001",
+  "+15550000002",
+  "+15550000003",
+  "+15550000004",
+  "+15550000005",
+] as const;
+
+async function main() {
+  console.log("Resetting database...");
+  await reset(db, schema);
+
+  // --- Users ---
+  const userRows = await db
+    .insert(schema.users)
+    .values([
+      { phoneNumber: PHONE_NUMBERS[0], displayName: "Alice Johnson" },
+      { phoneNumber: PHONE_NUMBERS[1], displayName: "Bob Williams" },
+      { phoneNumber: PHONE_NUMBERS[2], displayName: "Carol Martinez" },
+      { phoneNumber: PHONE_NUMBERS[3], displayName: "David Kim" },
+      { phoneNumber: PHONE_NUMBERS[4], displayName: "Eve Chen" },
+    ])
+    .returning();
+
+  const alice = userRows[0]!;
+  const bob = userRows[1]!;
+  const carol = userRows[2]!;
+  const david = userRows[3]!;
+  const eve = userRows[4]!;
+
+  // --- Trips ---
+  const tripRows = await db
+    .insert(schema.trips)
+    .values([
+      {
+        name: "Tokyo Adventure",
+        destination: "Tokyo, Japan",
+        startDate: "2026-04-10",
+        endDate: "2026-04-17",
+        preferredTimezone: "Asia/Tokyo",
+        description: "A week exploring Tokyo — temples, food, and nightlife.",
+        createdBy: alice.id,
+      },
+      {
+        name: "Barcelona Beach Week",
+        destination: "Barcelona, Spain",
+        startDate: "2026-05-20",
+        endDate: "2026-05-27",
+        preferredTimezone: "Europe/Madrid",
+        description: "Sun, tapas, and Gaudi architecture.",
+        createdBy: bob.id,
+      },
+      {
+        name: "NYC Weekend",
+        destination: "New York City, USA",
+        startDate: "2026-03-14",
+        endDate: "2026-03-16",
+        preferredTimezone: "America/New_York",
+        description: "Quick weekend getaway to the city.",
+        createdBy: carol.id,
+      },
+    ])
+    .returning();
+
+  const tokyo = tripRows[0]!;
+  const barcelona = tripRows[1]!;
+  const nyc = tripRows[2]!;
+
+  // --- Members ---
+  const memberRows = await db
+    .insert(schema.members)
+    .values([
+      // Tokyo: Alice (organizer), Bob, Carol, David
+      {
+        tripId: tokyo.id,
+        userId: alice.id,
+        status: "going" as const,
+        isOrganizer: true,
+      },
+      {
+        tripId: tokyo.id,
+        userId: bob.id,
+        status: "going" as const,
+      },
+      {
+        tripId: tokyo.id,
+        userId: carol.id,
+        status: "maybe" as const,
+      },
+      {
+        tripId: tokyo.id,
+        userId: david.id,
+        status: "no_response" as const,
+      },
+      // Barcelona: Bob (organizer), Alice, Eve, Carol
+      {
+        tripId: barcelona.id,
+        userId: bob.id,
+        status: "going" as const,
+        isOrganizer: true,
+      },
+      {
+        tripId: barcelona.id,
+        userId: alice.id,
+        status: "going" as const,
+      },
+      {
+        tripId: barcelona.id,
+        userId: eve.id,
+        status: "going" as const,
+      },
+      {
+        tripId: barcelona.id,
+        userId: carol.id,
+        status: "not_going" as const,
+      },
+      // NYC: Carol (organizer), David, Eve
+      {
+        tripId: nyc.id,
+        userId: carol.id,
+        status: "going" as const,
+        isOrganizer: true,
+      },
+      {
+        tripId: nyc.id,
+        userId: david.id,
+        status: "maybe" as const,
+      },
+      {
+        tripId: nyc.id,
+        userId: eve.id,
+        status: "going" as const,
+      },
+    ])
+    .returning();
+
+  // --- Events ---
+  await db.insert(schema.events).values([
+    // Tokyo events
+    {
+      tripId: tokyo.id,
+      createdBy: alice.id,
+      name: "Senso-ji Temple Visit",
+      eventType: "activity" as const,
+      location: "Senso-ji, Asakusa, Tokyo",
+      startTime: new Date("2026-04-11T09:00:00+09:00"),
+      endTime: new Date("2026-04-11T12:00:00+09:00"),
+    },
+    {
+      tripId: tokyo.id,
+      createdBy: alice.id,
+      name: "Tsukiji Outer Market Lunch",
+      eventType: "meal" as const,
+      location: "Tsukiji Outer Market, Tokyo",
+      startTime: new Date("2026-04-11T12:30:00+09:00"),
+      endTime: new Date("2026-04-11T14:00:00+09:00"),
+    },
+    {
+      tripId: tokyo.id,
+      createdBy: bob.id,
+      name: "Shibuya Night Out",
+      eventType: "activity" as const,
+      location: "Shibuya, Tokyo",
+      startTime: new Date("2026-04-12T19:00:00+09:00"),
+      isOptional: true,
+    },
+    // Barcelona events
+    {
+      tripId: barcelona.id,
+      createdBy: bob.id,
+      name: "Sagrada Familia Tour",
+      eventType: "activity" as const,
+      location: "Sagrada Familia, Barcelona",
+      startTime: new Date("2026-05-21T10:00:00+02:00"),
+      endTime: new Date("2026-05-21T12:30:00+02:00"),
+    },
+    {
+      tripId: barcelona.id,
+      createdBy: eve.id,
+      name: "Paella Dinner",
+      eventType: "meal" as const,
+      location: "La Mar Salada, Barcelona",
+      startTime: new Date("2026-05-22T20:00:00+02:00"),
+      endTime: new Date("2026-05-22T22:00:00+02:00"),
+    },
+    // NYC events
+    {
+      tripId: nyc.id,
+      createdBy: carol.id,
+      name: "Broadway Show",
+      eventType: "activity" as const,
+      location: "Broadway, New York",
+      startTime: new Date("2026-03-14T19:30:00-04:00"),
+      endTime: new Date("2026-03-14T22:00:00-04:00"),
+    },
+    {
+      tripId: nyc.id,
+      createdBy: carol.id,
+      name: "Brunch at Balthazar",
+      eventType: "meal" as const,
+      location: "Balthazar, SoHo, New York",
+      startTime: new Date("2026-03-15T11:00:00-04:00"),
+      endTime: new Date("2026-03-15T13:00:00-04:00"),
+    },
+  ]);
+
+  // --- Accommodations ---
+  await db.insert(schema.accommodations).values([
+    {
+      tripId: tokyo.id,
+      createdBy: alice.id,
+      name: "Hotel Sunroute Plaza Shinjuku",
+      address: "2-3-1 Yoyogi, Shibuya-ku, Tokyo",
+      checkIn: new Date("2026-04-10T15:00:00+09:00"),
+      checkOut: new Date("2026-04-17T11:00:00+09:00"),
+    },
+    {
+      tripId: barcelona.id,
+      createdBy: bob.id,
+      name: "Airbnb near La Rambla",
+      address: "Carrer de Ferran 28, Barcelona",
+      checkIn: new Date("2026-05-20T14:00:00+02:00"),
+      checkOut: new Date("2026-05-27T10:00:00+02:00"),
+    },
+    {
+      tripId: nyc.id,
+      createdBy: carol.id,
+      name: "The NoMad Hotel",
+      address: "1170 Broadway, New York",
+      checkIn: new Date("2026-03-14T15:00:00-04:00"),
+      checkOut: new Date("2026-03-16T12:00:00-04:00"),
+    },
+  ]);
+
+  // --- Member Travel ---
+  const aliceTokyo = memberRows.find(
+    (m) => m.tripId === tokyo.id && m.userId === alice.id,
+  )!;
+  const bobTokyo = memberRows.find(
+    (m) => m.tripId === tokyo.id && m.userId === bob.id,
+  )!;
+
+  await db.insert(schema.memberTravel).values([
+    {
+      tripId: tokyo.id,
+      memberId: aliceTokyo.id,
+      travelType: "arrival" as const,
+      time: new Date("2026-04-10T10:30:00+09:00"),
+      location: "Narita International Airport",
+      details: "Flight JL005 from SFO",
+    },
+    {
+      tripId: tokyo.id,
+      memberId: aliceTokyo.id,
+      travelType: "departure" as const,
+      time: new Date("2026-04-17T14:00:00+09:00"),
+      location: "Narita International Airport",
+    },
+    {
+      tripId: tokyo.id,
+      memberId: bobTokyo.id,
+      travelType: "arrival" as const,
+      time: new Date("2026-04-10T16:00:00+09:00"),
+      location: "Haneda Airport",
+      details: "Flight NH106 from LAX",
+    },
+  ]);
+
+  // --- Messages ---
+  const msgRows = await db
+    .insert(schema.messages)
+    .values([
+      {
+        tripId: tokyo.id,
+        authorId: alice.id,
+        content: "So excited for Tokyo! Has everyone started packing?",
+      },
+    ])
+    .returning();
+
+  const tokyoMsg1 = msgRows[0]!;
+
+  await db.insert(schema.messages).values([
+    {
+      tripId: tokyo.id,
+      authorId: bob.id,
+      parentId: tokyoMsg1.id,
+      content: "Almost done! Can't wait for the ramen.",
+    },
+    {
+      tripId: tokyo.id,
+      authorId: carol.id,
+      content: "Still deciding if I can make it — will confirm by next week.",
+    },
+    {
+      tripId: barcelona.id,
+      authorId: bob.id,
+      content: "Found a great rooftop bar near our Airbnb!",
+    },
+    {
+      tripId: barcelona.id,
+      authorId: eve.id,
+      content: "I'll book the Sagrada Familia tickets. How many do we need?",
+    },
+    {
+      tripId: nyc.id,
+      authorId: carol.id,
+      content: "Hamilton tickets are booked! Saturday 7:30pm.",
+      isPinned: true,
+    },
+  ]);
+
+  // --- Print login info ---
+  console.log("\nSeed complete! Login with any phone number + code 000000:\n");
+  console.log("  Phone Number     Name");
+  console.log("  ──────────────── ──────────────");
+  const names = [
+    "Alice Johnson",
+    "Bob Williams",
+    "Carol Martinez",
+    "David Kim",
+    "Eve Chen",
+  ];
+  PHONE_NUMBERS.forEach((phone, i) => {
+    console.log(`  ${phone}  ${names[i]}`);
+  });
+  console.log("");
+}
+
+main()
+  .catch((err) => {
+    console.error("Seed failed:", err);
+    process.exit(1);
+  })
+  .finally(() => pool.end());

--- a/apps/api/src/db/seed.ts
+++ b/apps/api/src/db/seed.ts
@@ -1,6 +1,37 @@
-import { reset } from "drizzle-seed";
+import { reset, cities } from "drizzle-seed";
 import { db, pool } from "@/config/database.js";
 import * as schema from "@/db/schema/index.js";
+
+// --- Helpers ---
+
+function daysFromNow(days: number, hour = 12): Date {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + days);
+  d.setUTCHours(hour, 0, 0, 0);
+  return d;
+}
+
+function pick<T>(arr: readonly T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)]!;
+}
+
+function randInt(min: number, max: number): number {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function shuffle<T>(arr: T[]): T[] {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j]!, arr[i]!];
+  }
+  return arr;
+}
+
+function toDateStr(d: Date) {
+  return d.toISOString().slice(0, 10);
+}
+
+// --- Data pools ---
 
 const PHONE_NUMBERS = [
   "+15550000001",
@@ -10,11 +41,32 @@ const PHONE_NUMBERS = [
   "+15550000005",
 ] as const;
 
+const EVENT_NAMES = {
+  activity: [
+    "Temple Visit", "Museum Tour", "Walking Tour", "Night Out", "Morning Hike",
+    "Beach Day", "Cable Car Ride", "Stadium Tour", "Street Art Walk", "Boat Tour",
+    "Sunset Viewpoint", "Neighborhood Walk", "Comedy Show", "Cooking Class",
+    "Bike Ride", "Park Picnic", "Live Music", "Market Stroll",
+  ],
+  meal: [
+    "Brunch", "Lunch Spot", "Dinner Reservation", "Street Food Tour",
+    "Rooftop Drinks", "Tapas Night", "Pizza Night", "Cocktail Hour",
+    "Market Breakfast", "Seafood Feast", "Wine Tasting", "Dessert Run",
+  ],
+  travel: [
+    "Airport Transfer", "Train to City Center", "Ferry Crossing",
+    "Bus to Hotel", "Shuttle to Airport", "Car Rental Pickup",
+    "Taxi to Station", "Drive to Next City",
+  ],
+};
+
+// --- Main ---
+
 async function main() {
   console.log("Resetting database...");
   await reset(db, schema);
 
-  // --- Users ---
+  // Users
   const userRows = await db
     .insert(schema.users)
     .values([
@@ -26,21 +78,20 @@ async function main() {
     ])
     .returning();
 
-  const alice = userRows[0]!;
-  const bob = userRows[1]!;
-  const carol = userRows[2]!;
-  const david = userRows[3]!;
-  const eve = userRows[4]!;
+  const [alice, bob, carol, david, eve] = userRows as [
+    (typeof userRows)[0], (typeof userRows)[0], (typeof userRows)[0],
+    (typeof userRows)[0], (typeof userRows)[0],
+  ];
 
-  // --- Trips ---
+  // Trips — one upcoming, one future, one in-progress
   const tripRows = await db
     .insert(schema.trips)
     .values([
       {
         name: "Tokyo Adventure",
         destination: "Tokyo, Japan",
-        startDate: "2026-04-10",
-        endDate: "2026-04-17",
+        startDate: toDateStr(daysFromNow(3)),
+        endDate: toDateStr(daysFromNow(10)),
         preferredTimezone: "Asia/Tokyo",
         description: "A week exploring Tokyo — temples, food, and nightlife.",
         createdBy: alice.id,
@@ -48,8 +99,8 @@ async function main() {
       {
         name: "Barcelona Beach Week",
         destination: "Barcelona, Spain",
-        startDate: "2026-05-20",
-        endDate: "2026-05-27",
+        startDate: toDateStr(daysFromNow(18)),
+        endDate: toDateStr(daysFromNow(25)),
         preferredTimezone: "Europe/Madrid",
         description: "Sun, tapas, and Gaudi architecture.",
         createdBy: bob.id,
@@ -57,8 +108,8 @@ async function main() {
       {
         name: "NYC Weekend",
         destination: "New York City, USA",
-        startDate: "2026-03-14",
-        endDate: "2026-03-16",
+        startDate: toDateStr(daysFromNow(-2)),
+        endDate: toDateStr(daysFromNow(1)),
         preferredTimezone: "America/New_York",
         description: "Quick weekend getaway to the city.",
         createdBy: carol.id,
@@ -66,268 +117,175 @@ async function main() {
     ])
     .returning();
 
-  const tokyo = tripRows[0]!;
-  const barcelona = tripRows[1]!;
-  const nyc = tripRows[2]!;
+  const [tokyo, barcelona, nyc] = tripRows as [
+    (typeof tripRows)[0], (typeof tripRows)[0], (typeof tripRows)[0],
+  ];
 
-  // --- Members ---
+  // Members
   const memberRows = await db
     .insert(schema.members)
     .values([
-      // Tokyo: Alice (organizer), Bob, Carol, David
-      {
-        tripId: tokyo.id,
-        userId: alice.id,
-        status: "going" as const,
-        isOrganizer: true,
-      },
-      {
-        tripId: tokyo.id,
-        userId: bob.id,
-        status: "going" as const,
-      },
-      {
-        tripId: tokyo.id,
-        userId: carol.id,
-        status: "maybe" as const,
-      },
-      {
-        tripId: tokyo.id,
-        userId: david.id,
-        status: "no_response" as const,
-      },
-      // Barcelona: Bob (organizer), Alice, Eve, Carol
-      {
-        tripId: barcelona.id,
-        userId: bob.id,
-        status: "going" as const,
-        isOrganizer: true,
-      },
-      {
-        tripId: barcelona.id,
-        userId: alice.id,
-        status: "going" as const,
-      },
-      {
-        tripId: barcelona.id,
-        userId: eve.id,
-        status: "going" as const,
-      },
-      {
-        tripId: barcelona.id,
-        userId: carol.id,
-        status: "not_going" as const,
-      },
-      // NYC: Carol (organizer), David, Eve
-      {
-        tripId: nyc.id,
-        userId: carol.id,
-        status: "going" as const,
-        isOrganizer: true,
-      },
-      {
-        tripId: nyc.id,
-        userId: david.id,
-        status: "maybe" as const,
-      },
-      {
-        tripId: nyc.id,
-        userId: eve.id,
-        status: "going" as const,
-      },
+      { tripId: tokyo.id, userId: alice.id, status: "going" as const, isOrganizer: true },
+      { tripId: tokyo.id, userId: bob.id, status: "going" as const },
+      { tripId: tokyo.id, userId: carol.id, status: "maybe" as const },
+      { tripId: tokyo.id, userId: david.id, status: "no_response" as const },
+      { tripId: barcelona.id, userId: bob.id, status: "going" as const, isOrganizer: true },
+      { tripId: barcelona.id, userId: alice.id, status: "going" as const },
+      { tripId: barcelona.id, userId: eve.id, status: "going" as const },
+      { tripId: barcelona.id, userId: carol.id, status: "not_going" as const },
+      { tripId: nyc.id, userId: carol.id, status: "going" as const, isOrganizer: true },
+      { tripId: nyc.id, userId: david.id, status: "maybe" as const },
+      { tripId: nyc.id, userId: eve.id, status: "going" as const },
     ])
     .returning();
 
-  // --- Events ---
-  await db.insert(schema.events).values([
-    // Tokyo events
-    {
-      tripId: tokyo.id,
-      createdBy: alice.id,
-      name: "Senso-ji Temple Visit",
-      eventType: "activity" as const,
-      location: "Senso-ji, Asakusa, Tokyo",
-      startTime: new Date("2026-04-11T09:00:00+09:00"),
-      endTime: new Date("2026-04-11T12:00:00+09:00"),
-    },
-    {
-      tripId: tokyo.id,
-      createdBy: alice.id,
-      name: "Tsukiji Outer Market Lunch",
-      eventType: "meal" as const,
-      location: "Tsukiji Outer Market, Tokyo",
-      startTime: new Date("2026-04-11T12:30:00+09:00"),
-      endTime: new Date("2026-04-11T14:00:00+09:00"),
-    },
-    {
-      tripId: tokyo.id,
-      createdBy: bob.id,
-      name: "Shibuya Night Out",
-      eventType: "activity" as const,
-      location: "Shibuya, Tokyo",
-      startTime: new Date("2026-04-12T19:00:00+09:00"),
-      isOptional: true,
-    },
-    // Barcelona events
-    {
-      tripId: barcelona.id,
-      createdBy: bob.id,
-      name: "Sagrada Familia Tour",
-      eventType: "activity" as const,
-      location: "Sagrada Familia, Barcelona",
-      startTime: new Date("2026-05-21T10:00:00+02:00"),
-      endTime: new Date("2026-05-21T12:30:00+02:00"),
-    },
-    {
-      tripId: barcelona.id,
-      createdBy: eve.id,
-      name: "Paella Dinner",
-      eventType: "meal" as const,
-      location: "La Mar Salada, Barcelona",
-      startTime: new Date("2026-05-22T20:00:00+02:00"),
-      endTime: new Date("2026-05-22T22:00:00+02:00"),
-    },
-    // NYC events
-    {
-      tripId: nyc.id,
-      createdBy: carol.id,
-      name: "Broadway Show",
-      eventType: "activity" as const,
-      location: "Broadway, New York",
-      startTime: new Date("2026-03-14T19:30:00-04:00"),
-      endTime: new Date("2026-03-14T22:00:00-04:00"),
-    },
-    {
-      tripId: nyc.id,
-      createdBy: carol.id,
-      name: "Brunch at Balthazar",
-      eventType: "meal" as const,
-      location: "Balthazar, SoHo, New York",
-      startTime: new Date("2026-03-15T11:00:00-04:00"),
-      endTime: new Date("2026-03-15T13:00:00-04:00"),
-    },
-  ]);
+  // Events — randomly generated per trip
+  const trips = [
+    { trip: tokyo, startDay: 3, days: 7, creators: [alice, bob, carol] },
+    { trip: barcelona, startDay: 18, days: 7, creators: [bob, alice, eve] },
+    { trip: nyc, startDay: -2, days: 3, creators: [carol, david, eve] },
+  ];
 
-  // --- Accommodations ---
+  for (const { trip, startDay, days, creators } of trips) {
+    const eventValues: (typeof schema.events.$inferInsert)[] = [];
+    const activityNames = shuffle([...EVENT_NAMES.activity]);
+    const mealNames = shuffle([...EVENT_NAMES.meal]);
+    const travelNames = shuffle([...EVENT_NAMES.travel]);
+    let ai = 0;
+    let mi = 0;
+    let ti = 0;
+
+    for (let day = 0; day < days; day++) {
+      const isFirstDay = day === 0;
+      const isLastDay = day === days - 1;
+
+      // Add a travel event on first/last day
+      if (isFirstDay || isLastDay) {
+        const name = travelNames[ti++ % travelNames.length]!;
+        const hour = isFirstDay ? randInt(7, 9) : randInt(16, 19);
+        eventValues.push({
+          tripId: trip.id,
+          createdBy: pick(creators).id,
+          name,
+          eventType: "travel",
+          location: pick(cities),
+          startTime: daysFromNow(startDay + day, hour),
+          endTime: daysFromNow(startDay + day, hour + randInt(1, 3)),
+        });
+      }
+
+      const count = randInt(3, 5);
+      const hours = shuffle([8, 10, 12, 14, 16, 19]).slice(0, count).sort((a, b) => a - b);
+
+      for (const hour of hours) {
+        const type = hour >= 19 || hour <= 8 || hour === 12 ? "meal" as const : pick(["activity", "meal"] as const);
+        const name = type === "meal"
+          ? mealNames[mi++ % mealNames.length]!
+          : activityNames[ai++ % activityNames.length]!;
+        const duration = type === "meal" ? randInt(1, 2) : randInt(2, 4);
+
+        eventValues.push({
+          tripId: trip.id,
+          createdBy: pick(creators).id,
+          name,
+          eventType: type,
+          location: pick(cities),
+          startTime: daysFromNow(startDay + day, hour),
+          endTime: daysFromNow(startDay + day, hour + duration),
+          isOptional: Math.random() < 0.15,
+        });
+      }
+    }
+
+    await db.insert(schema.events).values(eventValues);
+  }
+
+  // Member travel — arrival + departure for going/maybe members
+  const travelValues: (typeof schema.memberTravel.$inferInsert)[] = [];
+
+  for (const { trip, startDay, days } of trips) {
+    const goingMembers = memberRows.filter(
+      (m) => m.tripId === trip.id && (m.status === "going" || m.status === "maybe"),
+    );
+
+    for (const m of goingMembers) {
+      const location = `${pick(cities)} Airport`;
+
+      travelValues.push({
+        tripId: trip.id,
+        memberId: m.id,
+        travelType: "arrival",
+        time: daysFromNow(startDay, randInt(7, 16)),
+        location,
+        details: pick(["Flight from SFO", "Flight from LAX", "Flight from JFK",
+          "Flight from ORD", "Flight from LHR", "Train from nearby city"]),
+      });
+
+      if (Math.random() < 0.8) {
+        travelValues.push({
+          tripId: trip.id,
+          memberId: m.id,
+          travelType: "departure",
+          time: daysFromNow(startDay + days, randInt(8, 18)),
+          location,
+        });
+      }
+    }
+  }
+
+  await db.insert(schema.memberTravel).values(travelValues);
+
+  // Accommodations
   await db.insert(schema.accommodations).values([
     {
-      tripId: tokyo.id,
-      createdBy: alice.id,
+      tripId: tokyo.id, createdBy: alice.id,
       name: "Hotel Sunroute Plaza Shinjuku",
       address: "2-3-1 Yoyogi, Shibuya-ku, Tokyo",
-      checkIn: new Date("2026-04-10T15:00:00+09:00"),
-      checkOut: new Date("2026-04-17T11:00:00+09:00"),
+      checkIn: daysFromNow(3, 15), checkOut: daysFromNow(10, 11),
     },
     {
-      tripId: barcelona.id,
-      createdBy: bob.id,
+      tripId: barcelona.id, createdBy: bob.id,
       name: "Airbnb near La Rambla",
       address: "Carrer de Ferran 28, Barcelona",
-      checkIn: new Date("2026-05-20T14:00:00+02:00"),
-      checkOut: new Date("2026-05-27T10:00:00+02:00"),
+      checkIn: daysFromNow(18, 14), checkOut: daysFromNow(25, 10),
     },
     {
-      tripId: nyc.id,
-      createdBy: carol.id,
+      tripId: nyc.id, createdBy: carol.id,
       name: "The NoMad Hotel",
       address: "1170 Broadway, New York",
-      checkIn: new Date("2026-03-14T15:00:00-04:00"),
-      checkOut: new Date("2026-03-16T12:00:00-04:00"),
+      checkIn: daysFromNow(-2, 15), checkOut: daysFromNow(1, 12),
     },
   ]);
 
-  // --- Member Travel ---
-  const aliceTokyo = memberRows.find(
-    (m) => m.tripId === tokyo.id && m.userId === alice.id,
-  )!;
-  const bobTokyo = memberRows.find(
-    (m) => m.tripId === tokyo.id && m.userId === bob.id,
-  )!;
-
-  await db.insert(schema.memberTravel).values([
-    {
-      tripId: tokyo.id,
-      memberId: aliceTokyo.id,
-      travelType: "arrival" as const,
-      time: new Date("2026-04-10T10:30:00+09:00"),
-      location: "Narita International Airport",
-      details: "Flight JL005 from SFO",
-    },
-    {
-      tripId: tokyo.id,
-      memberId: aliceTokyo.id,
-      travelType: "departure" as const,
-      time: new Date("2026-04-17T14:00:00+09:00"),
-      location: "Narita International Airport",
-    },
-    {
-      tripId: tokyo.id,
-      memberId: bobTokyo.id,
-      travelType: "arrival" as const,
-      time: new Date("2026-04-10T16:00:00+09:00"),
-      location: "Haneda Airport",
-      details: "Flight NH106 from LAX",
-    },
-  ]);
-
-  // --- Messages ---
-  const msgRows = await db
+  // Messages
+  const [tokyoMsg1] = await db
     .insert(schema.messages)
-    .values([
-      {
-        tripId: tokyo.id,
-        authorId: alice.id,
-        content: "So excited for Tokyo! Has everyone started packing?",
-      },
-    ])
+    .values({
+      tripId: tokyo.id,
+      authorId: alice.id,
+      content: "So excited for Tokyo! Has everyone started packing?",
+    })
     .returning();
 
-  const tokyoMsg1 = msgRows[0]!;
-
   await db.insert(schema.messages).values([
-    {
-      tripId: tokyo.id,
-      authorId: bob.id,
-      parentId: tokyoMsg1.id,
-      content: "Almost done! Can't wait for the ramen.",
-    },
-    {
-      tripId: tokyo.id,
-      authorId: carol.id,
-      content: "Still deciding if I can make it — will confirm by next week.",
-    },
-    {
-      tripId: barcelona.id,
-      authorId: bob.id,
-      content: "Found a great rooftop bar near our Airbnb!",
-    },
-    {
-      tripId: barcelona.id,
-      authorId: eve.id,
-      content: "I'll book the Sagrada Familia tickets. How many do we need?",
-    },
-    {
-      tripId: nyc.id,
-      authorId: carol.id,
-      content: "Hamilton tickets are booked! Saturday 7:30pm.",
-      isPinned: true,
-    },
+    { tripId: tokyo.id, authorId: bob.id, parentId: tokyoMsg1!.id,
+      content: "Almost done! Can't wait for the ramen." },
+    { tripId: tokyo.id, authorId: carol.id,
+      content: "Still deciding if I can make it — will confirm by next week." },
+    { tripId: barcelona.id, authorId: bob.id,
+      content: "Found a great rooftop bar near our Airbnb!" },
+    { tripId: barcelona.id, authorId: eve.id,
+      content: "I'll book the Sagrada Familia tickets. How many do we need?" },
+    { tripId: nyc.id, authorId: carol.id, isPinned: true,
+      content: "Hamilton tickets are booked! Saturday 7:30pm." },
   ]);
 
-  // --- Print login info ---
+  // Print login info
   console.log("\nSeed complete! Login with any phone number + code 000000:\n");
   console.log("  Phone Number     Name");
   console.log("  ──────────────── ──────────────");
-  const names = [
-    "Alice Johnson",
-    "Bob Williams",
-    "Carol Martinez",
-    "David Kim",
-    "Eve Chen",
-  ];
-  PHONE_NUMBERS.forEach((phone, i) => {
-    console.log(`  ${phone}  ${names[i]}`);
-  });
+  const names = ["Alice Johnson", "Bob Williams", "Carol Martinez", "David Kim", "Eve Chen"];
+  PHONE_NUMBERS.forEach((phone, i) => console.log(`  ${phone}  ${names[i]}`));
   console.log("");
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       drizzle-kit:
         specifier: ^0.28.1
         version: 0.28.1
+      drizzle-seed:
+        specifier: ^0.3.1
+        version: 0.3.1(drizzle-orm@0.36.4(@types/pg@8.16.0)(@types/react@19.2.10)(pg@8.18.0)(react@19.2.4))
       form-data:
         specifier: ^4.0.5
         version: 4.0.5
@@ -2763,6 +2766,14 @@ packages:
       sqlite3:
         optional: true
 
+  drizzle-seed@0.3.1:
+    resolution: {integrity: sha512-F/0lgvfOAsqlYoHM/QAGut4xXIOXoE5VoAdv2FIl7DpGYVXlAzKuJO+IphkKUFK3Dz+rFlOsQLnMNrvoQ0cx7g==}
+    peerDependencies:
+      drizzle-orm: '>=0.36.4'
+    peerDependenciesMeta:
+      drizzle-orm:
+        optional: true
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -4001,6 +4012,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -7190,6 +7204,12 @@ snapshots:
       pg: 8.18.0
       react: 19.2.4
 
+  drizzle-seed@0.3.1(drizzle-orm@0.36.4(@types/pg@8.16.0)(@types/react@19.2.10)(pg@8.18.0)(react@19.2.4)):
+    dependencies:
+      pure-rand: 6.1.0
+    optionalDependencies:
+      drizzle-orm: 0.36.4(@types/pg@8.16.0)(@types/react@19.2.10)(pg@8.18.0)(react@19.2.4)
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -8618,6 +8638,8 @@ snapshots:
       once: 1.4.0
 
   punycode@2.3.1: {}
+
+  pure-rand@6.1.0: {}
 
   queue-microtask@1.2.3: {}
 


### PR DESCRIPTION
## Summary

- Adds `pnpm db:seed` command to populate the dev database with realistic sample data
- Seeds 5 users, 3 trips (Tokyo, Barcelona, NYC), 11 members, accommodations, messages
- Randomly generates **3-5 events per day per trip** (activities, meals, travel) using drizzle-seed's 42k city dataset for locations
- Generates arrival/departure travel records for all going/maybe members
- Dates are **relative to today** — trips stay current across dev sessions (one in-progress, one upcoming, one future)
- Idempotent: `reset()` truncates all tables before re-seeding
- Prints seeded phone numbers to stdout for easy login with verification code `000000`

## Test plan

- [x] `pnpm db:seed` completes successfully
- [x] Running twice is idempotent (no errors on re-run)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] Log in via seeded phone number with code `000000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)