### PR TITLE
Simplify devcontainer + add playwright-cli for manual testing

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,13 +3,14 @@ FROM mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm
 # Enable corepack for pnpm (version from package.json)
 RUN corepack enable && corepack prepare pnpm@10.30.1 --activate
 
-# Install turbo globally (npm avoids pnpm global dir permission issues)
-RUN npm install -g turbo
+# Install turbo and playwright-cli globally (npm avoids pnpm global dir permission issues)
+RUN npm install -g turbo @playwright/cli@latest
 
-# Install Playwright system dependencies (requires root)
-RUN npx playwright install-deps chromium
+# Install Playwright system dependencies and Chrome (requires root)
+RUN npx playwright install-deps chromium \
+    && npx playwright install chrome
 
-# Install Playwright browser as node user (cache lands in /home/node)
+# Install Playwright browsers as node user (cache lands in /home/node)
 USER node
 RUN npx playwright install chromium
 USER root

--- a/.devcontainer/playwright-cli.config.json
+++ b/.devcontainer/playwright-cli.config.json
@@ -1,0 +1,8 @@
+{
+  "browser": {
+    "browserName": "chromium",
+    "launchOptions": {
+      "chromiumSandbox": false
+    }
+  }
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# pnpm requires CI=true in non-TTY environments (devcontainer up)
+export CI=true
+
 echo "[setup] Configuring Tripful devcontainer..."
 
 # Generate API .env only if it doesn't exist (preserves manual edits)

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ node_modules/
 coverage/
 .nyc_output/
 *.lcov
+.playwright-cli/
 
 # Next.js
 .next/

--- a/Makefile
+++ b/Makefile
@@ -1,118 +1,25 @@
-.PHONY: dev-up dev-down dev-exec dev-list dev-clean dev-shell dev-logs dev-restart
+.PHONY: test-up test-down test-exec test-run test-status
 
-# Resolve branch -> worktree path
-BRANCH    ?= $(shell git branch --show-current)
-SLUG       = $(shell echo "$(BRANCH)" | tr '/' '-' | tr '_' '-' | tr '[:upper:]' '[:lower:]' | cut -c1-60)
-WORKTREE   = ../tripful--$(SLUG)
-DC         = devcontainer
+SLUG := $(shell basename $(CURDIR) | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g')
+PROJECT := $(SLUG)_devcontainer
+DC := devcontainer
 
-# Check that devcontainer CLI is installed
 check-deps:
-	@command -v $(DC) >/dev/null 2>&1 || { echo "Error: 'devcontainer' CLI not found. Install with: npm i -g @devcontainers/cli"; exit 1; }
-	@command -v docker >/dev/null 2>&1 || { echo "Error: 'docker' not found."; exit 1; }
+	@command -v $(DC) >/dev/null 2>&1 || { echo "Error: devcontainer CLI required (npm i -g @devcontainers/cli)"; exit 1; }
+	@command -v docker >/dev/null 2>&1 || { echo "Error: docker required"; exit 1; }
 
-# Create worktree + start isolated devcontainer + show ports
-dev-up: check-deps
-	@start=$$(date +%s); \
-	if [ ! -d "$(WORKTREE)" ]; then \
-	  git worktree add "$(WORKTREE)" "$(BRANCH)" 2>/dev/null \
-	    || git worktree add "$(WORKTREE)" "origin/$(BRANCH)" \
-	    || { echo "Error: branch '$(BRANCH)' not found locally or in origin"; exit 1; }; \
-	fi; \
-	$(DC) up --workspace-folder "$(WORKTREE)"; \
-	echo ""; \
-	echo "=== $(BRANCH) is ready ==="; \
-	cid=$$(docker ps -q --filter "label=devcontainer.local_folder=$$(realpath $(WORKTREE))"); \
-	if [ -n "$$cid" ]; then \
-	  web=$$(docker port "$$cid" 3000 2>/dev/null | head -1); \
-	  api=$$(docker port "$$cid" 8000 2>/dev/null | head -1); \
-	  echo "  Web:  $${web:-not exposed}"; \
-	  echo "  API:  $${api:-not exposed}"; \
-	fi; \
-	end=$$(date +%s); \
-	echo "  Time: $$(( end - start ))s"
+test-up: check-deps
+	$(DC) up --workspace-folder .
 
-# Run a command inside the branch's container
-# Usage: make dev-exec BRANCH=feature/auth CMD="pnpm test"
-#        make dev-exec BRANCH=feature/auth CMD="pnpm lint && pnpm typecheck"
-dev-exec: check-deps
-	@$(DC) exec --workspace-folder "$(WORKTREE)" $(CMD)
+test-down:
+	docker compose -p $(PROJECT) down -v
 
-# Stop container + remove worktree
-dev-down: check-deps
-	@cid=$$(docker ps -q --filter "label=devcontainer.local_folder=$$(realpath $(WORKTREE))"); \
-	if [ -n "$$cid" ]; then \
-	  docker stop "$$cid"; \
-	  echo "Stopped container for $(BRANCH)"; \
-	else \
-	  echo "No running container for $(BRANCH)"; \
-	fi; \
-	if [ -d "$(WORKTREE)" ]; then \
-	  git worktree remove "$(WORKTREE)" 2>/dev/null \
-	    || echo "Worktree has changes — kept at $(WORKTREE). Use git worktree remove --force to delete."; \
-	fi
+test-exec:
+	@docker compose -p $(PROJECT) exec -u node -w /workspace app $(CMD)
 
-# Restart container without removing worktree
-dev-restart: check-deps
-	@cid=$$(docker ps -q --filter "label=devcontainer.local_folder=$$(realpath $(WORKTREE))"); \
-	[ -n "$$cid" ] && docker stop "$$cid" || true
-	@$(DC) up --workspace-folder "$(WORKTREE)"
+test-run:
+	$(MAKE) test-exec CMD="pnpm test"
+	$(MAKE) test-exec CMD="pnpm test:e2e"
 
-# Open interactive shell in the container
-dev-shell: check-deps
-	@$(DC) exec --workspace-folder "$(WORKTREE)" bash
-
-# Tail container logs
-dev-logs: check-deps
-	@cid=$$(docker ps -q --filter "label=devcontainer.local_folder=$$(realpath $(WORKTREE))"); \
-	if [ -n "$$cid" ]; then \
-	  docker logs -f "$$cid"; \
-	else \
-	  echo "No running container for $(BRANCH)"; \
-	fi
-
-# Show all branch environments, status, and ports
-dev-list:
-	@printf "%-25s %-10s %-20s %s\n" "BRANCH" "STATUS" "PORTS" "PATH"; \
-	found=0; \
-	for wt in ../tripful--*; do \
-	  [ -d "$$wt" ] || continue; \
-	  found=1; \
-	  name=$$(basename "$$wt" | sed 's/^tripful--//'); \
-	  cid=$$(docker ps -q --filter "label=devcontainer.local_folder=$$(realpath $$wt)"); \
-	  if [ -n "$$cid" ]; then \
-	    web=$$(docker port "$$cid" 3000 2>/dev/null | head -1 | sed 's/.*://'); \
-	    api=$$(docker port "$$cid" 8000 2>/dev/null | head -1 | sed 's/.*://'); \
-	    printf "%-25s %-10s %-20s %s\n" "$$name" "running" "web:$${web:-?} api:$${api:-?}" "$$wt"; \
-	  else \
-	    printf "%-25s %-10s %-20s %s\n" "$$name" "stopped" "-" "$$wt"; \
-	  fi; \
-	done; \
-	[ "$$found" -eq 0 ] && echo "(no environments found)"
-
-# Remove all stopped envs
-dev-clean:
-	@to_remove=""; \
-	for wt in ../tripful--*; do \
-	  [ -d "$$wt" ] || continue; \
-	  cid=$$(docker ps -q --filter "label=devcontainer.local_folder=$$(realpath $$wt)"); \
-	  if [ -z "$$cid" ]; then \
-	    to_remove="$$to_remove $$wt"; \
-	  fi; \
-	done; \
-	if [ -z "$$to_remove" ]; then \
-	  echo "No stopped environments to clean."; \
-	else \
-	  echo "Will remove:$$to_remove"; \
-	  printf "Continue? [y/N] "; \
-	  read -r ans; \
-	  if [ "$$ans" = "y" ] || [ "$$ans" = "Y" ]; then \
-	    for wt in $$to_remove; do \
-	      echo "Removing $$wt"; \
-	      git worktree remove "$$wt" --force 2>/dev/null || rm -rf "$$wt"; \
-	    done; \
-	    echo "Done. Run 'docker volume prune' to reclaim disk space."; \
-	  else \
-	    echo "Aborted."; \
-	  fi; \
-	fi
+test-status:
+	@docker compose -p $(PROJECT) ps 2>/dev/null || echo "No container running for $(SLUG)"


### PR DESCRIPTION
## Summary

- **Makefile**: Replace 8 worktree-coupled targets with 5 directory-agnostic ones (`test-up`, `test-down`, `test-exec`, `test-run`, `test-status`). SLUG derived from directory name instead of git branch.
- **Playwright CLI**: Add `playwright-cli` inside the container for interactive browser testing. LLM agents can navigate the UI, take snapshots/screenshots, and handle auth by clicking through the login flow — no CORS issues or hardcoded tokens.
- **CLAUDE.md**: Container-first testing policy, manual testing docs, separated host vs container commands.
- **Test script**: Simplified from 45 → 35 tests (removed slug generation and worktree-specific checks).

## Test plan

- [x] `bash scripts/__tests__/test-devcontainer.test.sh` — 35/35 pass
- [x] `make test-up` starts container
- [x] `make test-exec CMD="pnpm lint"` — passes
- [x] `make test-exec CMD="pnpm typecheck"` — passes
- [x] `make test-exec CMD="pnpm test:e2e"` — 21/21 pass
- [x] `playwright-cli open`, `snapshot`, `screenshot` — verified end-to-end inside container

🤖 Generated with [Claude Code](https://claude.com/claude-code)