### PR TITLE
Add trip-aware date pickers

### DIFF
--- a/apps/web/src/components/itinerary/create-accommodation-dialog.tsx
+++ b/apps/web/src/components/itinerary/create-accommodation-dialog.tsx
@@ -100,10 +100,13 @@ export function CreateAccommodationDialog({
     return isNaN(d.getTime()) ? undefined : d;
   }, [checkInValue]);
 
-  // Auto-fill checkOut when checkIn is set and checkOut is empty (+1 day)
+  // Auto-fill checkOut when checkIn is set and checkOut is empty or before checkIn (+1 day)
   useEffect(() => {
-    if (checkInValue && !form.getValues("checkOut")) {
-      form.setValue("checkOut", addDays(new Date(checkInValue), 1).toISOString());
+    if (checkInValue) {
+      const currentOut = form.getValues("checkOut");
+      if (!currentOut || new Date(currentOut) <= new Date(checkInValue)) {
+        form.setValue("checkOut", addDays(new Date(checkInValue), 1).toISOString());
+      }
     }
   }, [checkInValue, form]);
 

--- a/apps/web/src/components/itinerary/create-accommodation-dialog.tsx
+++ b/apps/web/src/components/itinerary/create-accommodation-dialog.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Loader2, Plus, X } from "lucide-react";
 import { toast } from "sonner";
+import { parse, addDays } from "date-fns";
 import {
   createAccommodationSchema,
   type CreateAccommodationInput,
@@ -51,8 +52,8 @@ export function CreateAccommodationDialog({
   tripId,
   timezone,
   onSuccess,
-  tripStartDate: _tripStartDate,
-  tripEndDate: _tripEndDate,
+  tripStartDate,
+  tripEndDate,
 }: CreateAccommodationDialogProps) {
   const { mutate: createAccommodation, isPending } = useCreateAccommodation();
   const [newLink, setNewLink] = useState("");
@@ -78,6 +79,33 @@ export function CreateAccommodationDialog({
       setLinkError(null);
     }
   }, [open, form]);
+
+  // Trip-aware defaults
+  const tripStartMonth = useMemo(() => {
+    if (!tripStartDate) return undefined;
+    const parsed = parse(tripStartDate, "yyyy-MM-dd", new Date());
+    return isNaN(parsed.getTime()) ? undefined : parsed;
+  }, [tripStartDate]);
+
+  const tripRange = useMemo(() => {
+    if (!tripStartDate && !tripEndDate) return undefined;
+    return { start: tripStartDate, end: tripEndDate };
+  }, [tripStartDate, tripEndDate]);
+
+  // Compute defaultMonth from watched checkIn for checkOut picker
+  const checkInValue = form.watch("checkIn");
+  const checkInMonth = useMemo(() => {
+    if (!checkInValue) return undefined;
+    const d = new Date(checkInValue);
+    return isNaN(d.getTime()) ? undefined : d;
+  }, [checkInValue]);
+
+  // Auto-fill checkOut when checkIn is set and checkOut is empty (+1 day)
+  useEffect(() => {
+    if (checkInValue && !form.getValues("checkOut")) {
+      form.setValue("checkOut", addDays(new Date(checkInValue), 1).toISOString());
+    }
+  }, [checkInValue, form]);
 
   const handleSubmit = (data: CreateAccommodationInput) => {
     createAccommodation(
@@ -229,6 +257,8 @@ export function CreateAccommodationDialog({
                           placeholder="Check-in"
                           aria-label="Check-in"
                           disabled={isPending}
+                          defaultMonth={tripStartMonth}
+                          tripRange={tripRange}
                         />
                       </FormControl>
                       <FormMessage />
@@ -253,6 +283,8 @@ export function CreateAccommodationDialog({
                           placeholder="Check-out"
                           aria-label="Check-out"
                           disabled={isPending}
+                          defaultMonth={checkInMonth || tripStartMonth}
+                          tripRange={tripRange}
                         />
                       </FormControl>
                       <FormMessage />

--- a/apps/web/src/components/itinerary/create-accommodation-dialog.tsx
+++ b/apps/web/src/components/itinerary/create-accommodation-dialog.tsx
@@ -41,8 +41,8 @@ interface CreateAccommodationDialogProps {
   tripId: string;
   timezone: string;
   onSuccess?: () => void;
-  tripStartDate?: string | null;
-  tripEndDate?: string | null;
+  tripStartDate?: string | null | undefined;
+  tripEndDate?: string | null | undefined;
 }
 
 export function CreateAccommodationDialog({
@@ -51,8 +51,8 @@ export function CreateAccommodationDialog({
   tripId,
   timezone,
   onSuccess,
-  tripStartDate,
-  tripEndDate,
+  tripStartDate: _tripStartDate,
+  tripEndDate: _tripEndDate,
 }: CreateAccommodationDialogProps) {
   const { mutate: createAccommodation, isPending } = useCreateAccommodation();
   const [newLink, setNewLink] = useState("");

--- a/apps/web/src/components/itinerary/create-accommodation-dialog.tsx
+++ b/apps/web/src/components/itinerary/create-accommodation-dialog.tsx
@@ -41,6 +41,8 @@ interface CreateAccommodationDialogProps {
   tripId: string;
   timezone: string;
   onSuccess?: () => void;
+  tripStartDate?: string | null;
+  tripEndDate?: string | null;
 }
 
 export function CreateAccommodationDialog({
@@ -49,6 +51,8 @@ export function CreateAccommodationDialog({
   tripId,
   timezone,
   onSuccess,
+  tripStartDate,
+  tripEndDate,
 }: CreateAccommodationDialogProps) {
   const { mutate: createAccommodation, isPending } = useCreateAccommodation();
   const [newLink, setNewLink] = useState("");

--- a/apps/web/src/components/itinerary/create-event-dialog.tsx
+++ b/apps/web/src/components/itinerary/create-event-dialog.tsx
@@ -48,6 +48,8 @@ interface CreateEventDialogProps {
   tripId: string;
   timezone: string;
   onSuccess?: () => void;
+  tripStartDate?: string | null;
+  tripEndDate?: string | null;
 }
 
 export function CreateEventDialog({
@@ -56,6 +58,8 @@ export function CreateEventDialog({
   tripId,
   timezone,
   onSuccess,
+  tripStartDate,
+  tripEndDate,
 }: CreateEventDialogProps) {
   const { mutate: createEvent, isPending } = useCreateEvent();
   const [newLink, setNewLink] = useState("");

--- a/apps/web/src/components/itinerary/create-event-dialog.tsx
+++ b/apps/web/src/components/itinerary/create-event-dialog.tsx
@@ -113,10 +113,13 @@ export function CreateEventDialog({
     return isNaN(d.getTime()) ? undefined : d;
   }, [startTimeValue]);
 
-  // Auto-fill endTime when startTime is set and endTime is empty (+1 hour)
+  // Auto-fill endTime when startTime is set and endTime is empty or before startTime (+1 hour)
   useEffect(() => {
-    if (startTimeValue && !form.getValues("endTime")) {
-      form.setValue("endTime", addHours(new Date(startTimeValue), 1).toISOString());
+    if (startTimeValue) {
+      const currentEnd = form.getValues("endTime");
+      if (!currentEnd || new Date(currentEnd) <= new Date(startTimeValue)) {
+        form.setValue("endTime", addHours(new Date(startTimeValue), 1).toISOString());
+      }
     }
   }, [startTimeValue, form]);
 

--- a/apps/web/src/components/itinerary/create-member-travel-dialog.tsx
+++ b/apps/web/src/components/itinerary/create-member-travel-dialog.tsx
@@ -57,6 +57,8 @@ interface CreateMemberTravelDialogProps {
   timezone: string;
   isOrganizer?: boolean;
   onSuccess?: () => void;
+  tripStartDate?: string | null;
+  tripEndDate?: string | null;
 }
 
 export function CreateMemberTravelDialog({
@@ -66,6 +68,8 @@ export function CreateMemberTravelDialog({
   timezone,
   isOrganizer,
   onSuccess,
+  tripStartDate,
+  tripEndDate,
 }: CreateMemberTravelDialogProps) {
   const { mutate: createMemberTravel, isPending } = useCreateMemberTravel();
   const { user } = useAuth();

--- a/apps/web/src/components/itinerary/create-member-travel-dialog.tsx
+++ b/apps/web/src/components/itinerary/create-member-travel-dialog.tsx
@@ -57,8 +57,8 @@ interface CreateMemberTravelDialogProps {
   timezone: string;
   isOrganizer?: boolean;
   onSuccess?: () => void;
-  tripStartDate?: string | null;
-  tripEndDate?: string | null;
+  tripStartDate?: string | null | undefined;
+  tripEndDate?: string | null | undefined;
 }
 
 export function CreateMemberTravelDialog({
@@ -68,8 +68,8 @@ export function CreateMemberTravelDialog({
   timezone,
   isOrganizer,
   onSuccess,
-  tripStartDate,
-  tripEndDate,
+  tripStartDate: _tripStartDate,
+  tripEndDate: _tripEndDate,
 }: CreateMemberTravelDialogProps) {
   const { mutate: createMemberTravel, isPending } = useCreateMemberTravel();
   const { user } = useAuth();

--- a/apps/web/src/components/itinerary/create-member-travel-dialog.tsx
+++ b/apps/web/src/components/itinerary/create-member-travel-dialog.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
+import { parse } from "date-fns";
 import {
   createMemberTravelSchema,
   type CreateMemberTravelInput,
@@ -68,8 +69,8 @@ export function CreateMemberTravelDialog({
   timezone,
   isOrganizer,
   onSuccess,
-  tripStartDate: _tripStartDate,
-  tripEndDate: _tripEndDate,
+  tripStartDate,
+  tripEndDate,
 }: CreateMemberTravelDialogProps) {
   const { mutate: createMemberTravel, isPending } = useCreateMemberTravel();
   const { user } = useAuth();
@@ -101,6 +102,24 @@ export function CreateMemberTravelDialog({
       setSelectedMemberId("self");
     }
   }, [open, form, timezone]);
+
+  // Trip-aware defaults
+  const tripStartMonth = useMemo(() => {
+    if (!tripStartDate) return undefined;
+    const parsed = parse(tripStartDate, "yyyy-MM-dd", new Date());
+    return isNaN(parsed.getTime()) ? undefined : parsed;
+  }, [tripStartDate]);
+
+  const tripEndMonth = useMemo(() => {
+    if (!tripEndDate) return undefined;
+    const parsed = parse(tripEndDate, "yyyy-MM-dd", new Date());
+    return isNaN(parsed.getTime()) ? undefined : parsed;
+  }, [tripEndDate]);
+
+  const tripRange = useMemo(() => {
+    if (!tripStartDate && !tripEndDate) return undefined;
+    return { start: tripStartDate, end: tripEndDate };
+  }, [tripStartDate, tripEndDate]);
 
   const handleSubmit = (formData: CreateMemberTravelInput) => {
     const data = { ...formData };
@@ -308,6 +327,8 @@ export function CreateMemberTravelDialog({
                         placeholder="Select date & time"
                         aria-label="Travel time"
                         disabled={isPending}
+                        defaultMonth={travelType === "departure" ? tripEndMonth : tripStartMonth}
+                        tripRange={tripRange}
                       />
                     </FormControl>
                     <FormMessage />

--- a/apps/web/src/components/itinerary/day-by-day-view.tsx
+++ b/apps/web/src/components/itinerary/day-by-day-view.tsx
@@ -428,6 +428,8 @@ export function DayByDayView({
           }}
           event={editingEvent}
           timezone={timezone}
+          tripStartDate={tripStartDate}
+          tripEndDate={tripEndDate}
         />
       )}
       {editingAccommodation && (
@@ -438,6 +440,8 @@ export function DayByDayView({
           }}
           accommodation={editingAccommodation}
           timezone={timezone}
+          tripStartDate={tripStartDate}
+          tripEndDate={tripEndDate}
         />
       )}
       {editingMemberTravel && (
@@ -448,6 +452,8 @@ export function DayByDayView({
           }}
           memberTravel={editingMemberTravel}
           timezone={timezone}
+          tripStartDate={tripStartDate}
+          tripEndDate={tripEndDate}
         />
       )}
     </div>

--- a/apps/web/src/components/itinerary/edit-accommodation-dialog.tsx
+++ b/apps/web/src/components/itinerary/edit-accommodation-dialog.tsx
@@ -128,11 +128,14 @@ export function EditAccommodationDialog({
     return isNaN(d.getTime()) ? undefined : d;
   }, [checkInValue]);
 
-  // Auto-fill checkOut when checkIn is set and checkOut is empty (+1 day)
+  // Auto-fill checkOut when checkIn is set and checkOut is empty or before checkIn (+1 day)
   useEffect(() => {
     if (isInitializing.current) return;
-    if (checkInValue && !form.getValues("checkOut")) {
-      form.setValue("checkOut", addDays(new Date(checkInValue), 1).toISOString());
+    if (checkInValue) {
+      const currentOut = form.getValues("checkOut");
+      if (!currentOut || new Date(currentOut) <= new Date(checkInValue)) {
+        form.setValue("checkOut", addDays(new Date(checkInValue), 1).toISOString());
+      }
     }
   }, [checkInValue, form]);
 

--- a/apps/web/src/components/itinerary/edit-accommodation-dialog.tsx
+++ b/apps/web/src/components/itinerary/edit-accommodation-dialog.tsx
@@ -55,6 +55,8 @@ interface EditAccommodationDialogProps {
   accommodation: Accommodation;
   timezone: string;
   onSuccess?: () => void;
+  tripStartDate?: string | null;
+  tripEndDate?: string | null;
 }
 
 export function EditAccommodationDialog({
@@ -63,6 +65,8 @@ export function EditAccommodationDialog({
   accommodation,
   timezone,
   onSuccess,
+  tripStartDate,
+  tripEndDate,
 }: EditAccommodationDialogProps) {
   const { mutate: updateAccommodation, isPending } = useUpdateAccommodation();
   const { mutate: deleteAccommodation, isPending: isDeleting } =

--- a/apps/web/src/components/itinerary/edit-accommodation-dialog.tsx
+++ b/apps/web/src/components/itinerary/edit-accommodation-dialog.tsx
@@ -55,8 +55,8 @@ interface EditAccommodationDialogProps {
   accommodation: Accommodation;
   timezone: string;
   onSuccess?: () => void;
-  tripStartDate?: string | null;
-  tripEndDate?: string | null;
+  tripStartDate?: string | null | undefined;
+  tripEndDate?: string | null | undefined;
 }
 
 export function EditAccommodationDialog({
@@ -65,8 +65,8 @@ export function EditAccommodationDialog({
   accommodation,
   timezone,
   onSuccess,
-  tripStartDate,
-  tripEndDate,
+  tripStartDate: _tripStartDate,
+  tripEndDate: _tripEndDate,
 }: EditAccommodationDialogProps) {
   const { mutate: updateAccommodation, isPending } = useUpdateAccommodation();
   const { mutate: deleteAccommodation, isPending: isDeleting } =

--- a/apps/web/src/components/itinerary/edit-event-dialog.tsx
+++ b/apps/web/src/components/itinerary/edit-event-dialog.tsx
@@ -155,11 +155,14 @@ export function EditEventDialog({
     return isNaN(d.getTime()) ? undefined : d;
   }, [startTimeValue]);
 
-  // Auto-fill endTime when startTime is set and endTime is empty (+1 hour)
+  // Auto-fill endTime when startTime is set and endTime is empty or before startTime (+1 hour)
   useEffect(() => {
     if (isInitializing.current) return;
-    if (startTimeValue && !form.getValues("endTime")) {
-      form.setValue("endTime", addHours(new Date(startTimeValue), 1).toISOString());
+    if (startTimeValue) {
+      const currentEnd = form.getValues("endTime");
+      if (!currentEnd || new Date(currentEnd) <= new Date(startTimeValue)) {
+        form.setValue("endTime", addHours(new Date(startTimeValue), 1).toISOString());
+      }
     }
   }, [startTimeValue, form]);
 

--- a/apps/web/src/components/itinerary/edit-event-dialog.tsx
+++ b/apps/web/src/components/itinerary/edit-event-dialog.tsx
@@ -65,6 +65,8 @@ interface EditEventDialogProps {
   event: Event;
   timezone: string;
   onSuccess?: () => void;
+  tripStartDate?: string | null;
+  tripEndDate?: string | null;
 }
 
 export function EditEventDialog({
@@ -73,6 +75,8 @@ export function EditEventDialog({
   event,
   timezone,
   onSuccess,
+  tripStartDate,
+  tripEndDate,
 }: EditEventDialogProps) {
   const { mutate: updateEvent, isPending } = useUpdateEvent();
   const { mutate: deleteEvent, isPending: isDeleting } = useDeleteEvent();

--- a/apps/web/src/components/itinerary/edit-member-travel-dialog.tsx
+++ b/apps/web/src/components/itinerary/edit-member-travel-dialog.tsx
@@ -63,6 +63,8 @@ interface EditMemberTravelDialogProps {
   memberTravel: MemberTravel;
   timezone: string;
   onSuccess?: () => void;
+  tripStartDate?: string | null;
+  tripEndDate?: string | null;
 }
 
 export function EditMemberTravelDialog({
@@ -71,6 +73,8 @@ export function EditMemberTravelDialog({
   memberTravel,
   timezone,
   onSuccess,
+  tripStartDate,
+  tripEndDate,
 }: EditMemberTravelDialogProps) {
   const { mutate: updateMemberTravel, isPending } = useUpdateMemberTravel();
   const { mutate: deleteMemberTravel, isPending: isDeleting } =

--- a/apps/web/src/components/itinerary/edit-member-travel-dialog.tsx
+++ b/apps/web/src/components/itinerary/edit-member-travel-dialog.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Loader2, Trash2 } from "lucide-react";
 import { toast } from "sonner";
+import { parse } from "date-fns";
 import {
   updateMemberTravelSchema,
   type UpdateMemberTravelInput,
@@ -73,8 +74,8 @@ export function EditMemberTravelDialog({
   memberTravel,
   timezone,
   onSuccess,
-  tripStartDate: _tripStartDate,
-  tripEndDate: _tripEndDate,
+  tripStartDate,
+  tripEndDate,
 }: EditMemberTravelDialogProps) {
   const { mutate: updateMemberTravel, isPending } = useUpdateMemberTravel();
   const { mutate: deleteMemberTravel, isPending: isDeleting } =
@@ -108,6 +109,24 @@ export function EditMemberTravelDialog({
       setSelectedTimezone(timezone);
     }
   }, [open, memberTravel, form, timezone]);
+
+  // Trip-aware defaults
+  const tripStartMonth = useMemo(() => {
+    if (!tripStartDate) return undefined;
+    const parsed = parse(tripStartDate, "yyyy-MM-dd", new Date());
+    return isNaN(parsed.getTime()) ? undefined : parsed;
+  }, [tripStartDate]);
+
+  const tripEndMonth = useMemo(() => {
+    if (!tripEndDate) return undefined;
+    const parsed = parse(tripEndDate, "yyyy-MM-dd", new Date());
+    return isNaN(parsed.getTime()) ? undefined : parsed;
+  }, [tripEndDate]);
+
+  const tripRange = useMemo(() => {
+    if (!tripStartDate && !tripEndDate) return undefined;
+    return { start: tripStartDate, end: tripEndDate };
+  }, [tripStartDate, tripEndDate]);
 
   const handleSubmit = (data: UpdateMemberTravelInput) => {
     updateMemberTravel(
@@ -247,6 +266,8 @@ export function EditMemberTravelDialog({
                         placeholder="Select date & time"
                         aria-label="Travel time"
                         disabled={isPending || isDeleting}
+                        defaultMonth={travelType === "departure" ? tripEndMonth : tripStartMonth}
+                        tripRange={tripRange}
                       />
                     </FormControl>
                     <FormMessage />

--- a/apps/web/src/components/itinerary/edit-member-travel-dialog.tsx
+++ b/apps/web/src/components/itinerary/edit-member-travel-dialog.tsx
@@ -63,8 +63,8 @@ interface EditMemberTravelDialogProps {
   memberTravel: MemberTravel;
   timezone: string;
   onSuccess?: () => void;
-  tripStartDate?: string | null;
-  tripEndDate?: string | null;
+  tripStartDate?: string | null | undefined;
+  tripEndDate?: string | null | undefined;
 }
 
 export function EditMemberTravelDialog({
@@ -73,8 +73,8 @@ export function EditMemberTravelDialog({
   memberTravel,
   timezone,
   onSuccess,
-  tripStartDate,
-  tripEndDate,
+  tripStartDate: _tripStartDate,
+  tripEndDate: _tripEndDate,
 }: EditMemberTravelDialogProps) {
   const { mutate: updateMemberTravel, isPending } = useUpdateMemberTravel();
   const { mutate: deleteMemberTravel, isPending: isDeleting } =

--- a/apps/web/src/components/itinerary/group-by-type-view.tsx
+++ b/apps/web/src/components/itinerary/group-by-type-view.tsx
@@ -32,6 +32,8 @@ interface GroupByTypeViewProps {
   userId: string;
   userNameMap: Map<string, string>;
   isLocked?: boolean;
+  tripStartDate?: string | null;
+  tripEndDate?: string | null;
 }
 
 export function GroupByTypeView({
@@ -43,6 +45,8 @@ export function GroupByTypeView({
   userId,
   userNameMap,
   isLocked,
+  tripStartDate,
+  tripEndDate,
 }: GroupByTypeViewProps) {
   // Group events by type
   const groupedEvents = useMemo(() => {
@@ -289,6 +293,8 @@ export function GroupByTypeView({
           }}
           event={editingEvent}
           timezone={timezone}
+          tripStartDate={tripStartDate}
+          tripEndDate={tripEndDate}
         />
       )}
       {editingAccommodation && (
@@ -299,6 +305,8 @@ export function GroupByTypeView({
           }}
           accommodation={editingAccommodation}
           timezone={timezone}
+          tripStartDate={tripStartDate}
+          tripEndDate={tripEndDate}
         />
       )}
       {editingMemberTravel && (
@@ -309,6 +317,8 @@ export function GroupByTypeView({
           }}
           memberTravel={editingMemberTravel}
           timezone={timezone}
+          tripStartDate={tripStartDate}
+          tripEndDate={tripEndDate}
         />
       )}
     </div>

--- a/apps/web/src/components/itinerary/group-by-type-view.tsx
+++ b/apps/web/src/components/itinerary/group-by-type-view.tsx
@@ -32,8 +32,8 @@ interface GroupByTypeViewProps {
   userId: string;
   userNameMap: Map<string, string>;
   isLocked?: boolean;
-  tripStartDate?: string | null;
-  tripEndDate?: string | null;
+  tripStartDate?: string | null | undefined;
+  tripEndDate?: string | null | undefined;
 }
 
 export function GroupByTypeView({

--- a/apps/web/src/components/itinerary/itinerary-header.tsx
+++ b/apps/web/src/components/itinerary/itinerary-header.tsx
@@ -50,6 +50,8 @@ interface ItineraryHeaderProps {
   isMember: boolean;
   allowMembersToAddEvents: boolean;
   isLocked?: boolean;
+  tripStartDate?: string | null;
+  tripEndDate?: string | null;
 }
 
 export function ItineraryHeader({
@@ -64,6 +66,8 @@ export function ItineraryHeader({
   isMember,
   allowMembersToAddEvents,
   isLocked,
+  tripStartDate,
+  tripEndDate,
 }: ItineraryHeaderProps) {
   const [isCreateEventOpen, setIsCreateEventOpen] = useState(false);
   const [isCreateAccommodationOpen, setIsCreateAccommodationOpen] =
@@ -212,12 +216,16 @@ export function ItineraryHeader({
         onOpenChange={setIsCreateEventOpen}
         tripId={tripId}
         timezone={selectedTimezone}
+        tripStartDate={tripStartDate}
+        tripEndDate={tripEndDate}
       />
       <CreateAccommodationDialog
         open={isCreateAccommodationOpen}
         onOpenChange={setIsCreateAccommodationOpen}
         tripId={tripId}
         timezone={selectedTimezone}
+        tripStartDate={tripStartDate}
+        tripEndDate={tripEndDate}
       />
       <CreateMemberTravelDialog
         open={isCreateMemberTravelOpen}
@@ -225,6 +233,8 @@ export function ItineraryHeader({
         tripId={tripId}
         timezone={selectedTimezone}
         isOrganizer={isOrganizer}
+        tripStartDate={tripStartDate}
+        tripEndDate={tripEndDate}
       />
     </>
   );

--- a/apps/web/src/components/itinerary/itinerary-header.tsx
+++ b/apps/web/src/components/itinerary/itinerary-header.tsx
@@ -50,8 +50,8 @@ interface ItineraryHeaderProps {
   isMember: boolean;
   allowMembersToAddEvents: boolean;
   isLocked?: boolean;
-  tripStartDate?: string | null;
-  tripEndDate?: string | null;
+  tripStartDate?: string | null | undefined;
+  tripEndDate?: string | null | undefined;
 }
 
 export function ItineraryHeader({

--- a/apps/web/src/components/itinerary/itinerary-view.tsx
+++ b/apps/web/src/components/itinerary/itinerary-view.tsx
@@ -238,12 +238,16 @@ export function ItineraryView({ tripId, onAddTravel }: ItineraryViewProps) {
           onOpenChange={setIsCreateEventOpen}
           tripId={tripId}
           timezone={timezone}
+          tripStartDate={trip?.startDate || null}
+          tripEndDate={trip?.endDate || null}
         />
         <CreateAccommodationDialog
           open={isCreateAccommodationOpen}
           onOpenChange={setIsCreateAccommodationOpen}
           tripId={tripId}
           timezone={timezone}
+          tripStartDate={trip?.startDate || null}
+          tripEndDate={trip?.endDate || null}
         />
         <DeletedItemsDialog
           open={isDeletedItemsOpen}
@@ -270,6 +274,8 @@ export function ItineraryView({ tripId, onAddTravel }: ItineraryViewProps) {
         isMember={!!isMember}
         allowMembersToAddEvents={trip?.allowMembersToAddEvents || false}
         isLocked={isLocked}
+        tripStartDate={trip?.startDate || null}
+        tripEndDate={trip?.endDate || null}
       />
 
       {/* Content */}
@@ -313,6 +319,8 @@ export function ItineraryView({ tripId, onAddTravel }: ItineraryViewProps) {
             userId={user?.id || ""}
             userNameMap={userNameMap}
             isLocked={isLocked}
+            tripStartDate={trip?.startDate || null}
+            tripEndDate={trip?.endDate || null}
           />
         )}
         {isOrganizer && hasDeletedItems && (

--- a/apps/web/src/components/trip/create-trip-dialog.tsx
+++ b/apps/web/src/components/trip/create-trip-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
@@ -73,6 +73,14 @@ export function CreateTripDialog({
       coOrganizerPhones: [],
     },
   });
+
+  // Auto-fill endDate when startDate is set and endDate is empty
+  const startDateValue = form.watch("startDate");
+  useEffect(() => {
+    if (startDateValue && !form.getValues("endDate")) {
+      form.setValue("endDate", startDateValue);
+    }
+  }, [startDateValue, form]);
 
   const handleContinue = async () => {
     // Validate Step 1 fields before proceeding

--- a/apps/web/src/components/trip/member-onboarding-wizard.tsx
+++ b/apps/web/src/components/trip/member-onboarding-wizard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import {
   Sheet,
   SheetContent,
@@ -25,6 +25,7 @@ import { useAuth } from "@/app/providers/auth-provider";
 import { useCreateEvent } from "@/hooks/use-events";
 import { localPartsToUTC, formatInTimezone } from "@/lib/utils/timezone";
 import { toast } from "sonner";
+import { parse } from "date-fns";
 import type { TripDetailWithMeta } from "@/hooks/trip-queries";
 import { Loader2, X, Check, Plane, MapPin, Calendar } from "lucide-react";
 
@@ -295,6 +296,24 @@ export function MemberOnboardingWizard({
     createEvent.isPending ||
     updateMySettings.isPending;
 
+  // Trip-aware defaults
+  const tripRange = useMemo(() => {
+    if (!trip.startDate && !trip.endDate) return undefined;
+    return { start: trip.startDate, end: trip.endDate };
+  }, [trip.startDate, trip.endDate]);
+
+  const tripStartMonth = useMemo(() => {
+    if (!trip.startDate) return undefined;
+    const parsed = parse(trip.startDate, "yyyy-MM-dd", new Date());
+    return isNaN(parsed.getTime()) ? undefined : parsed;
+  }, [trip.startDate]);
+
+  const tripEndMonth = useMemo(() => {
+    if (!trip.endDate) return undefined;
+    const parsed = parse(trip.endDate, "yyyy-MM-dd", new Date());
+    return isNaN(parsed.getTime()) ? undefined : parsed;
+  }, [trip.endDate]);
+
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent>
@@ -405,6 +424,8 @@ export function MemberOnboardingWizard({
                   timezone={timezone}
                   placeholder="Pick arrival date & time"
                   aria-label="Arrival date and time"
+                  defaultMonth={tripStartMonth}
+                  tripRange={tripRange}
                 />
               </div>
               <div className="space-y-2">
@@ -435,6 +456,8 @@ export function MemberOnboardingWizard({
                   timezone={timezone}
                   placeholder="Pick departure date & time"
                   aria-label="Departure date and time"
+                  defaultMonth={tripEndMonth}
+                  tripRange={tripRange}
                 />
               </div>
               <div className="space-y-2">
@@ -477,6 +500,8 @@ export function MemberOnboardingWizard({
                   timezone={timezone}
                   placeholder="Pick event date & time"
                   aria-label="Event date and time"
+                  defaultMonth={tripStartMonth}
+                  tripRange={tripRange}
                 />
               </div>
               <Button

--- a/apps/web/src/components/ui/calendar.tsx
+++ b/apps/web/src/components/ui/calendar.tsx
@@ -11,6 +11,7 @@ import {
   DayPicker,
   getDefaultClassNames,
   type DayButton,
+  type Matcher,
 } from "react-day-picker";
 
 import { cn } from "@/lib/utils";
@@ -28,7 +29,7 @@ function Calendar({
   ...props
 }: React.ComponentProps<typeof DayPicker> & {
   buttonVariant?: React.ComponentProps<typeof Button>["variant"];
-  tripRange?: { start?: string | null; end?: string | null };
+  tripRange?: { start?: string | null | undefined; end?: string | null | undefined };
 }) {
   const defaultClassNames = getDefaultClassNames();
 
@@ -47,7 +48,7 @@ function Calendar({
     )
       return {};
 
-    const mods: Record<string, unknown> = {};
+    const mods: Record<string, Matcher | Matcher[] | undefined> = {};
     if (startDate && !isNaN(startDate.getTime()) && endDate && !isNaN(endDate.getTime())) {
       mods.tripRange = { from: startDate, to: endDate };
     }
@@ -167,7 +168,7 @@ function Calendar({
         hidden: cn("invisible", defaultClassNames.hidden),
         ...classNames,
       }}
-      modifiers={{ ...tripModifiers, ...props.modifiers }}
+      modifiers={{ ...tripModifiers, ...props.modifiers } as Record<string, Matcher | Matcher[]>}
       modifiersClassNames={{ ...tripModifiersClassNames, ...props.modifiersClassNames }}
       components={{
         Root: ({ className, rootRef, ...props }) => {

--- a/apps/web/src/components/ui/calendar.tsx
+++ b/apps/web/src/components/ui/calendar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { parse } from "date-fns";
 import {
   ChevronDownIcon,
   ChevronLeftIcon,
@@ -23,11 +24,46 @@ function Calendar({
   buttonVariant = "ghost",
   formatters,
   components,
+  tripRange,
   ...props
 }: React.ComponentProps<typeof DayPicker> & {
   buttonVariant?: React.ComponentProps<typeof Button>["variant"];
+  tripRange?: { start?: string | null; end?: string | null };
 }) {
   const defaultClassNames = getDefaultClassNames();
+
+  // Compute trip range modifiers for highlighting
+  const tripModifiers = React.useMemo(() => {
+    if (!tripRange) return {};
+    const startDate = tripRange.start
+      ? parse(tripRange.start, "yyyy-MM-dd", new Date())
+      : undefined;
+    const endDate = tripRange.end
+      ? parse(tripRange.end, "yyyy-MM-dd", new Date())
+      : undefined;
+    if (
+      (!startDate || isNaN(startDate.getTime())) &&
+      (!endDate || isNaN(endDate.getTime()))
+    )
+      return {};
+
+    const mods: Record<string, unknown> = {};
+    if (startDate && !isNaN(startDate.getTime()) && endDate && !isNaN(endDate.getTime())) {
+      mods.tripRange = { from: startDate, to: endDate };
+    }
+    if (startDate && !isNaN(startDate.getTime())) mods.tripRangeStart = startDate;
+    if (endDate && !isNaN(endDate.getTime())) mods.tripRangeEnd = endDate;
+    return mods;
+  }, [tripRange]);
+
+  const tripModifiersClassNames = React.useMemo(() => {
+    if (!tripRange) return {};
+    return {
+      tripRange: "bg-primary/8",
+      tripRangeStart: "bg-primary/15 rounded-l-md",
+      tripRangeEnd: "bg-primary/15 rounded-r-md",
+    };
+  }, [tripRange]);
 
   return (
     <DayPicker
@@ -131,6 +167,8 @@ function Calendar({
         hidden: cn("invisible", defaultClassNames.hidden),
         ...classNames,
       }}
+      modifiers={{ ...tripModifiers, ...props.modifiers }}
+      modifiersClassNames={{ ...tripModifiersClassNames, ...props.modifiersClassNames }}
       components={{
         Root: ({ className, rootRef, ...props }) => {
           return (

--- a/apps/web/src/components/ui/date-picker.tsx
+++ b/apps/web/src/components/ui/date-picker.tsx
@@ -19,8 +19,8 @@ interface DatePickerProps {
   placeholder?: string;
   disabled?: boolean;
   "aria-label"?: string;
-  defaultMonth?: Date;
-  tripRange?: { start?: string | null; end?: string | null };
+  defaultMonth?: Date | undefined;
+  tripRange?: { start?: string | null | undefined; end?: string | null | undefined } | undefined;
 }
 
 export function DatePicker({
@@ -66,11 +66,12 @@ export function DatePicker({
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-auto p-0" align="start">
+        {/* @ts-expect-error — react-day-picker union types incompatible with exactOptionalPropertyTypes */}
         <Calendar
           mode="single"
           selected={selected}
           onSelect={handleSelect}
-          defaultMonth={selected || defaultMonth}
+          defaultMonth={(selected ?? defaultMonth) as Date}
           tripRange={tripRange}
         />
       </PopoverContent>

--- a/apps/web/src/components/ui/date-picker.tsx
+++ b/apps/web/src/components/ui/date-picker.tsx
@@ -19,6 +19,8 @@ interface DatePickerProps {
   placeholder?: string;
   disabled?: boolean;
   "aria-label"?: string;
+  defaultMonth?: Date;
+  tripRange?: { start?: string | null; end?: string | null };
 }
 
 export function DatePicker({
@@ -27,6 +29,8 @@ export function DatePicker({
   placeholder = "Pick a date",
   disabled,
   "aria-label": ariaLabel,
+  defaultMonth,
+  tripRange,
 }: DatePickerProps) {
   const [open, setOpen] = React.useState(false);
 
@@ -66,7 +70,8 @@ export function DatePicker({
           mode="single"
           selected={selected}
           onSelect={handleSelect}
-          {...(selected ? { defaultMonth: selected } : {})}
+          defaultMonth={selected || defaultMonth}
+          tripRange={tripRange}
         />
       </PopoverContent>
     </Popover>

--- a/apps/web/src/components/ui/datetime-picker.tsx
+++ b/apps/web/src/components/ui/datetime-picker.tsx
@@ -21,8 +21,8 @@ interface DateTimePickerProps {
   placeholder?: string;
   disabled?: boolean;
   "aria-label"?: string;
-  defaultMonth?: Date;
-  tripRange?: { start?: string | null; end?: string | null };
+  defaultMonth?: Date | undefined;
+  tripRange?: { start?: string | null | undefined; end?: string | null | undefined } | undefined;
 }
 
 export function DateTimePicker({
@@ -96,11 +96,12 @@ export function DateTimePicker({
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-auto p-0" align="start">
+        {/* @ts-expect-error — react-day-picker union types incompatible with exactOptionalPropertyTypes */}
         <Calendar
           mode="single"
           selected={selectedDate}
           onSelect={handleDateSelect}
-          defaultMonth={selectedDate || defaultMonth}
+          defaultMonth={(selectedDate ?? defaultMonth) as Date}
           tripRange={tripRange}
         />
         <div className="border-t border-border p-3">

--- a/apps/web/src/components/ui/datetime-picker.tsx
+++ b/apps/web/src/components/ui/datetime-picker.tsx
@@ -21,6 +21,8 @@ interface DateTimePickerProps {
   placeholder?: string;
   disabled?: boolean;
   "aria-label"?: string;
+  defaultMonth?: Date;
+  tripRange?: { start?: string | null; end?: string | null };
 }
 
 export function DateTimePicker({
@@ -30,6 +32,8 @@ export function DateTimePicker({
   placeholder = "Pick a date & time",
   disabled,
   "aria-label": ariaLabel,
+  defaultMonth,
+  tripRange,
 }: DateTimePickerProps) {
   const [open, setOpen] = React.useState(false);
 
@@ -96,7 +100,8 @@ export function DateTimePicker({
           mode="single"
           selected={selectedDate}
           onSelect={handleDateSelect}
-          {...(selectedDate ? { defaultMonth: selectedDate } : {})}
+          defaultMonth={selectedDate || defaultMonth}
+          tripRange={tripRange}
         />
         <div className="border-t border-border p-3">
           <input


### PR DESCRIPTION
## Summary
- **Calendar component** gets `tripRange` modifiers that highlight trip date bands with a subtle primary tint (`bg-primary/8`) and accented start/end days
- **DatePicker & DateTimePicker** accept `defaultMonth` and `tripRange` props so calendars open to the trip month instead of current month
- **Prop threading** flows trip start/end dates from `ItineraryView` through `ItineraryHeader`, `DayByDayView`, and `GroupByTypeView` into all create/edit dialogs
- **Trip create/edit dialogs** auto-fill end date when start date is set (same value)
- **Event dialogs** auto-fill end time (+1 hour from start), all pickers show trip range highlighting
- **Accommodation dialogs** auto-fill check-out (+1 day from check-in), all pickers show trip range highlighting
- **Member travel dialogs** calendar opens to trip start (arrival) or trip end (departure) month with trip range highlighting
- **Onboarding wizard** all 3 DateTimePickers (arrival, departure, event) get trip range highlighting and smart default months

All 11 date picker instances across 16 files are now trip-aware.

## Test plan
- [ ] Open create event dialog — calendar opens to trip start month, trip dates highlighted
- [ ] Set event start time — end time auto-fills to +1 hour
- [ ] Open create accommodation dialog — calendar opens to trip start month
- [ ] Set check-in — check-out auto-fills to +1 day
- [ ] Open create member travel (arrival) — calendar opens to trip start month
- [ ] Switch to departure — calendar opens to trip end month
- [ ] Open edit dialogs — auto-fill does NOT trigger (existing values preserved)
- [ ] Open member onboarding wizard — all 3 steps show trip range highlighting
- [ ] Create a trip with no dates set — all dialogs gracefully fall back (no crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)