### PR TITLE
Add trip themes with 6 curated presets and full-page theming

### DIFF
--- a/apps/api/src/db/migrations/0019_watery_wrecking_crew.sql
+++ b/apps/api/src/db/migrations/0019_watery_wrecking_crew.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "trips" ADD COLUMN "theme_id" varchar(50);--> statement-breakpoint
+ALTER TABLE "trips" ADD COLUMN "theme_font" varchar(30);

--- a/apps/api/src/db/migrations/meta/0019_snapshot.json
+++ b/apps/api/src/db/migrations/meta/0019_snapshot.json
@@ -1,0 +1,2302 @@
+{
+  "id": "1d359cf9-d339-49c0-ac14-7cbeedba0bca",
+  "prevId": "28d775b0-81d7-42c0-a043-eb8ce37a2acc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accommodations": {
+      "name": "accommodations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "check_in": {
+          "name": "check_in",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_out": {
+          "name": "check_out",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "links": {
+          "name": "links",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accommodations_trip_id_idx": {
+          "name": "accommodations_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_created_by_idx": {
+          "name": "accommodations_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_check_in_idx": {
+          "name": "accommodations_check_in_idx",
+          "columns": [
+            {
+              "expression": "check_in",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_deleted_at_idx": {
+          "name": "accommodations_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_trip_id_deleted_at_idx": {
+          "name": "accommodations_trip_id_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_trip_id_not_deleted_idx": {
+          "name": "accommodations_trip_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accommodations\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accommodations_trip_id_trips_id_fk": {
+          "name": "accommodations_trip_id_trips_id_fk",
+          "tableFrom": "accommodations",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accommodations_created_by_users_id_fk": {
+          "name": "accommodations_created_by_users_id_fk",
+          "tableFrom": "accommodations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "accommodations_deleted_by_users_id_fk": {
+          "name": "accommodations_deleted_by_users_id_fk",
+          "tableFrom": "accommodations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_attempts": {
+      "name": "auth_attempts",
+      "schema": "",
+      "columns": {
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_failed_at": {
+          "name": "last_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blacklisted_tokens": {
+      "name": "blacklisted_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "jti": {
+          "name": "jti",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blacklisted_tokens_expires_at_idx": {
+          "name": "blacklisted_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blacklisted_tokens_user_id_users_id_fk": {
+          "name": "blacklisted_tokens_user_id_users_id_fk",
+          "tableFrom": "blacklisted_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "blacklisted_tokens_jti_unique": {
+          "name": "blacklisted_tokens_jti_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "jti"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meetup_location": {
+          "name": "meetup_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meetup_time": {
+          "name": "meetup_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_day": {
+          "name": "all_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_optional": {
+          "name": "is_optional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "links": {
+          "name": "links",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_trip_id_idx": {
+          "name": "events_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_created_by_idx": {
+          "name": "events_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_start_time_idx": {
+          "name": "events_start_time_idx",
+          "columns": [
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_deleted_at_idx": {
+          "name": "events_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_trip_id_deleted_at_idx": {
+          "name": "events_trip_id_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_trip_id_not_deleted_idx": {
+          "name": "events_trip_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_trip_id_trips_id_fk": {
+          "name": "events_trip_id_trips_id_fk",
+          "tableFrom": "events",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_created_by_users_id_fk": {
+          "name": "events_created_by_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_deleted_by_users_id_fk": {
+          "name": "events_deleted_by_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_phone": {
+          "name": "invitee_phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitations_trip_id_idx": {
+          "name": "invitations_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_invitee_phone_idx": {
+          "name": "invitations_invitee_phone_idx",
+          "columns": [
+            {
+              "expression": "invitee_phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_trip_id_trips_id_fk": {
+          "name": "invitations_trip_id_trips_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_id_users_id_fk": {
+          "name": "invitations_inviter_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitations_trip_phone_unique": {
+          "name": "invitations_trip_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trip_id",
+            "invitee_phone"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member_travel": {
+      "name": "member_travel",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "travel_type": {
+          "name": "travel_type",
+          "type": "member_travel_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_travel_trip_id_idx": {
+          "name": "member_travel_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_member_id_idx": {
+          "name": "member_travel_member_id_idx",
+          "columns": [
+            {
+              "expression": "member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_time_idx": {
+          "name": "member_travel_time_idx",
+          "columns": [
+            {
+              "expression": "time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_deleted_at_idx": {
+          "name": "member_travel_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_member_id_deleted_at_idx": {
+          "name": "member_travel_member_id_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_trip_id_deleted_at_idx": {
+          "name": "member_travel_trip_id_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_trip_id_not_deleted_idx": {
+          "name": "member_travel_trip_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"member_travel\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_travel_trip_id_trips_id_fk": {
+          "name": "member_travel_trip_id_trips_id_fk",
+          "tableFrom": "member_travel",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_travel_member_id_members_id_fk": {
+          "name": "member_travel_member_id_members_id_fk",
+          "tableFrom": "member_travel",
+          "tableTo": "members",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_travel_deleted_by_users_id_fk": {
+          "name": "member_travel_deleted_by_users_id_fk",
+          "tableFrom": "member_travel",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "rsvp_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'no_response'"
+        },
+        "is_organizer": {
+          "name": "is_organizer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "share_phone": {
+          "name": "share_phone",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "members_trip_id_idx": {
+          "name": "members_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "members_user_id_idx": {
+          "name": "members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "members_trip_id_is_organizer_idx": {
+          "name": "members_trip_id_is_organizer_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_organizer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "members_trip_id_trips_id_fk": {
+          "name": "members_trip_id_trips_id_fk",
+          "tableFrom": "members",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "members_user_id_users_id_fk": {
+          "name": "members_user_id_users_id_fk",
+          "tableFrom": "members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "members_trip_user_unique": {
+          "name": "members_trip_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trip_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_reactions": {
+      "name": "message_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_reactions_message_id_idx": {
+          "name": "message_reactions_message_id_idx",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_reactions_user_id_idx": {
+          "name": "message_reactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_reactions_message_id_messages_id_fk": {
+          "name": "message_reactions_message_id_messages_id_fk",
+          "tableFrom": "message_reactions",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_reactions_user_id_users_id_fk": {
+          "name": "message_reactions_user_id_users_id_fk",
+          "tableFrom": "message_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "message_reactions_message_user_emoji_unique": {
+          "name": "message_reactions_message_user_emoji_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id",
+            "user_id",
+            "emoji"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_trip_id_created_at_idx": {
+          "name": "messages_trip_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_parent_id_idx": {
+          "name": "messages_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_author_id_idx": {
+          "name": "messages_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_trip_toplevel_idx": {
+          "name": "messages_trip_toplevel_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"messages\".\"parent_id\" IS NULL AND \"messages\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_trip_id_not_deleted_idx": {
+          "name": "messages_trip_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"messages\".\"deleted_at\" IS NULL AND \"messages\".\"parent_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_trip_id_trips_id_fk": {
+          "name": "messages_trip_id_trips_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_author_id_users_id_fk": {
+          "name": "messages_author_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_parent_id_messages_id_fk": {
+          "name": "messages_parent_id_messages_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_deleted_by_users_id_fk": {
+          "name": "messages_deleted_by_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.muted_members": {
+      "name": "muted_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted_by": {
+          "name": "muted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "muted_members_trip_id_trips_id_fk": {
+          "name": "muted_members_trip_id_trips_id_fk",
+          "tableFrom": "muted_members",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "muted_members_user_id_users_id_fk": {
+          "name": "muted_members_user_id_users_id_fk",
+          "tableFrom": "muted_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "muted_members_muted_by_users_id_fk": {
+          "name": "muted_members_muted_by_users_id_fk",
+          "tableFrom": "muted_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "muted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "muted_members_trip_user_unique": {
+          "name": "muted_members_trip_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trip_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daily_itinerary": {
+          "name": "daily_itinerary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "trip_messages": {
+          "name": "trip_messages",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_user_id_users_id_fk": {
+          "name": "notification_preferences_user_id_users_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_preferences_trip_id_trips_id_fk": {
+          "name": "notification_preferences_trip_id_trips_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_preferences_user_trip_unique": {
+          "name": "notification_preferences_user_trip_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "trip_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_created_at_idx": {
+          "name": "notifications_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_id_created_at_desc_idx": {
+          "name": "notifications_user_id_created_at_desc_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notifications\".\"read_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_trip_user_created_at_idx": {
+          "name": "notifications_trip_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_trip_id_trips_id_fk": {
+          "name": "notifications_trip_id_trips_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_entries": {
+      "name": "rate_limit_entries",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rate_limit_entries_expires_at_idx": {
+          "name": "rate_limit_entries_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sent_reminders": {
+      "name": "sent_reminders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sent_reminders_type_ref_idx": {
+          "name": "sent_reminders_type_ref_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sent_reminders_user_id_users_id_fk": {
+          "name": "sent_reminders_user_id_users_id_fk",
+          "tableFrom": "sent_reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sent_reminders_type_ref_user_unique": {
+          "name": "sent_reminders_type_ref_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "type",
+            "reference_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trips": {
+      "name": "trips",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_timezone": {
+          "name": "preferred_timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_id": {
+          "name": "theme_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_font": {
+          "name": "theme_font",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allow_members_to_add_events": {
+          "name": "allow_members_to_add_events",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_all_members": {
+          "name": "show_all_members",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancelled": {
+          "name": "cancelled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trips_created_by_idx": {
+          "name": "trips_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trips_created_by_users_id_fk": {
+          "name": "trips_created_by_users_id_fk",
+          "tableFrom": "trips",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_photo_url": {
+          "name": "profile_photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handles": {
+          "name": "handles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_phone_number_idx": {
+          "name": "users_phone_number_idx",
+          "columns": [
+            {
+              "expression": "phone_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_phone_number_unique": {
+          "name": "users_phone_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.event_type": {
+      "name": "event_type",
+      "schema": "public",
+      "values": [
+        "travel",
+        "meal",
+        "activity"
+      ]
+    },
+    "public.invitation_status": {
+      "name": "invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "declined",
+        "failed"
+      ]
+    },
+    "public.member_travel_type": {
+      "name": "member_travel_type",
+      "schema": "public",
+      "values": [
+        "arrival",
+        "departure"
+      ]
+    },
+    "public.rsvp_status": {
+      "name": "rsvp_status",
+      "schema": "public",
+      "values": [
+        "going",
+        "not_going",
+        "maybe",
+        "no_response"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1772321663513,
       "tag": "0018_abnormal_squadron_sinister",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1772424229347,
+      "tag": "0019_watery_wrecking_crew",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -82,6 +82,8 @@ export const trips = pgTable(
     preferredTimezone: varchar("preferred_timezone", { length: 100 }).notNull(),
     description: text("description"),
     coverImageUrl: text("cover_image_url"),
+    themeId: varchar("theme_id", { length: 50 }),
+    themeFont: varchar("theme_font", { length: 30 }),
     createdBy: uuid("created_by")
       .notNull()
       .references(() => users.id),

--- a/apps/api/src/services/trip.service.ts
+++ b/apps/api/src/services/trip.service.ts
@@ -51,6 +51,8 @@ export type TripSummary = {
   startDate: string | null;
   endDate: string | null;
   coverImageUrl: string | null;
+  themeId: string | null;
+  themeFont: string | null;
   isOrganizer: boolean;
   rsvpStatus: "going" | "not_going" | "maybe" | "no_response";
   organizerInfo: Array<{
@@ -107,6 +109,8 @@ type TripPreview = Pick<
   | "preferredTimezone"
   | "description"
   | "coverImageUrl"
+  | "themeId"
+  | "themeFont"
 >;
 
 /**
@@ -286,6 +290,8 @@ export class TripService implements ITripService {
           description: data.description || null,
           coverImageUrl:
             data.coverImageUrl === null ? null : data.coverImageUrl || null,
+          themeId: data.themeId ?? null,
+          themeFont: data.themeFont ?? null,
           createdBy: userId,
           allowMembersToAddEvents: data.allowMembersToAddEvents,
         })
@@ -408,6 +414,8 @@ export class TripService implements ITripService {
         preferredTimezone: trip.preferredTimezone,
         description: trip.description,
         coverImageUrl: trip.coverImageUrl,
+        themeId: trip.themeId,
+        themeFont: trip.themeFont,
         ...meta,
       };
     }
@@ -507,6 +515,8 @@ export class TripService implements ITripService {
         startDate: trips.startDate,
         endDate: trips.endDate,
         coverImageUrl: trips.coverImageUrl,
+        themeId: trips.themeId,
+        themeFont: trips.themeFont,
       })
       .from(trips)
       .where(and(...baseConditions))
@@ -628,6 +638,8 @@ export class TripService implements ITripService {
         startDate: trip.startDate,
         endDate: trip.endDate,
         coverImageUrl: trip.coverImageUrl,
+        themeId: trip.themeId,
+        themeFont: trip.themeFont,
         isOrganizer,
         rsvpStatus,
         organizerInfo,

--- a/apps/web/src/app/(app)/trips/[id]/trip-detail-content.tsx
+++ b/apps/web/src/app/(app)/trips/[id]/trip-detail-content.tsx
@@ -212,8 +212,11 @@ export function TripDetailContent({ tripId }: { tripId: string }) {
   }
 
   return (
-    <TripThemeProvider themeId={trip.themeId} themeFont={trip.themeFont}>
-      <div className="min-h-screen bg-background motion-safe:animate-[revealUp_400ms_ease-out_both]">
+    <TripThemeProvider themeId={trip.themeId} themeFont={trip.themeFont} scope="page">
+      <div
+        className="min-h-screen bg-background motion-safe:animate-[revealUp_400ms_ease-out_both]"
+        style={preset ? { background: buildBackground(preset.background) } : undefined}
+      >
       {/* Hero section with cover image + overlay */}
       <div className="relative h-64 sm:h-80 overflow-hidden">
         {/* Background: cover photo or default pattern */}

--- a/apps/web/src/app/(app)/trips/[id]/trip-detail-content.tsx
+++ b/apps/web/src/app/(app)/trips/[id]/trip-detail-content.tsx
@@ -58,7 +58,6 @@ import { ErrorBoundary } from "@/components/error-boundary";
 import { MembersList } from "@/components/trip/members-list";
 import { TripPreview } from "@/components/trip/trip-preview";
 import { TripThemeProvider } from "@/components/trip/trip-theme-provider";
-import { buildBackground } from "@/lib/theme-styles";
 import { THEME_PRESETS } from "@tripful/shared/config";
 import { THEME_FONTS } from "@tripful/shared/config";
 import { useScrollReveal } from "@/hooks/use-scroll-reveal";
@@ -215,7 +214,7 @@ export function TripDetailContent({ tripId }: { tripId: string }) {
     <TripThemeProvider themeId={trip.themeId} themeFont={trip.themeFont} scope="page">
       <div
         className="min-h-screen bg-background motion-safe:animate-[revealUp_400ms_ease-out_both]"
-        style={preset ? { background: buildBackground(preset.background) } : undefined}
+        style={preset ? { background: "var(--theme-background)" } : undefined}
       >
       {/* Hero section with cover image + overlay */}
       <div className="relative h-64 sm:h-80 overflow-hidden">
@@ -232,7 +231,7 @@ export function TripDetailContent({ tripId }: { tripId: string }) {
         ) : preset ? (
           <div
             className="absolute inset-0"
-            style={{ background: buildBackground(preset.background) }}
+            style={{ background: "var(--theme-background)" }}
           />
         ) : (
           <div className="absolute inset-0 bg-gradient-to-br from-primary/30 via-accent/20 to-secondary/30">

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,7 +2,14 @@ import type { Metadata, Viewport } from "next";
 import type { ReactNode } from "react";
 import "./globals.css";
 import { Providers } from "./providers/providers";
-import { playfairDisplay, plusJakartaSans, spaceGrotesk } from "@/lib/fonts";
+import {
+  caveat,
+  nunito,
+  oswald,
+  playfairDisplay,
+  plusJakartaSans,
+  spaceGrotesk,
+} from "@/lib/fonts";
 import { cn } from "@/lib/utils";
 import { SkipLink } from "@/components/skip-link";
 
@@ -61,7 +68,14 @@ export default function RootLayout({
     <html
       lang="en"
       suppressHydrationWarning
-      className={cn(playfairDisplay.variable, plusJakartaSans.variable, spaceGrotesk.variable)}
+      className={cn(
+        playfairDisplay.variable,
+        plusJakartaSans.variable,
+        spaceGrotesk.variable,
+        nunito.variable,
+        caveat.variable,
+        oswald.variable,
+      )}
     >
       <body className="antialiased">
         <noscript>

--- a/apps/web/src/components/itinerary/day-by-day-view.tsx
+++ b/apps/web/src/components/itinerary/day-by-day-view.tsx
@@ -364,7 +364,7 @@ export function DayByDayView({
           >
             {/* Date gutter — outer cell stretches to row height so sticky works */}
             <div className="relative">
-              <div className="sticky top-[7.75rem] z-10 flex flex-col items-center pt-3 bg-background">
+              <div className="sticky top-[7.75rem] z-10 flex flex-col items-center pt-3">
                 <span
                   className={cn(
                     "text-xs font-medium uppercase",

--- a/apps/web/src/components/itinerary/group-by-type-view.tsx
+++ b/apps/web/src/components/itinerary/group-by-type-view.tsx
@@ -167,7 +167,7 @@ export function GroupByTypeView({
           >
             {/* Icon gutter — outer cell stretches to row height so sticky works */}
             <div className="relative">
-              <div className="sticky top-[7.75rem] z-10 flex flex-col items-center pt-3 bg-background">
+              <div className="sticky top-[7.75rem] z-10 flex flex-col items-center pt-3">
                 <div
                   className={`flex h-10 w-10 items-center justify-center rounded-full ${bgFor(section)} ${section.color}`}
                   title={section.title}

--- a/apps/web/src/components/trip/create-trip-dialog.tsx
+++ b/apps/web/src/components/trip/create-trip-dialog.tsx
@@ -40,6 +40,8 @@ import {
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { ImageUpload } from "@/components/trip/image-upload";
+import { ThemePicker } from "@/components/trip/theme-picker";
+import { FontPicker } from "@/components/trip/font-picker";
 import { DatePicker } from "@/components/ui/date-picker";
 import { Plus, X, Loader2 } from "lucide-react";
 import { TIMEZONES } from "@/lib/constants";
@@ -69,6 +71,8 @@ export function CreateTripDialog({
       timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
       description: "",
       coverImageUrl: null,
+      themeId: null,
+      themeFont: null,
       allowMembersToAddEvents: true,
       coOrganizerPhones: [],
     },
@@ -427,6 +431,50 @@ export function CreateTripDialog({
                           Optional: Upload a cover image for your trip
                         </FormDescription>
                         <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  {/* Theme */}
+                  <FormField
+                    control={form.control}
+                    name="themeId"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className="text-base font-semibold text-foreground">
+                          Theme
+                        </FormLabel>
+                        <FormControl>
+                          <ThemePicker
+                            value={field.value ?? null}
+                            onChange={field.onChange}
+                          />
+                        </FormControl>
+                        <FormDescription className="text-sm text-muted-foreground">
+                          Optional: Choose a visual theme for your trip
+                        </FormDescription>
+                      </FormItem>
+                    )}
+                  />
+
+                  {/* Font */}
+                  <FormField
+                    control={form.control}
+                    name="themeFont"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel className="text-base font-semibold text-foreground">
+                          Title font
+                        </FormLabel>
+                        <FormControl>
+                          <FontPicker
+                            value={field.value ?? null}
+                            onChange={field.onChange}
+                          />
+                        </FormControl>
+                        <FormDescription className="text-sm text-muted-foreground">
+                          Optional: Choose a font for trip titles
+                        </FormDescription>
                       </FormItem>
                     )}
                   />

--- a/apps/web/src/components/trip/create-trip-dialog.tsx
+++ b/apps/web/src/components/trip/create-trip-dialog.tsx
@@ -42,6 +42,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { ImageUpload } from "@/components/trip/image-upload";
 import { ThemePicker } from "@/components/trip/theme-picker";
 import { FontPicker } from "@/components/trip/font-picker";
+import { useThemePreview } from "@/hooks/use-theme-preview";
 import { DatePicker } from "@/components/ui/date-picker";
 import { Plus, X, Loader2 } from "lucide-react";
 import { TIMEZONES } from "@/lib/constants";
@@ -76,6 +77,17 @@ export function CreateTripDialog({
       allowMembersToAddEvents: true,
       coOrganizerPhones: [],
     },
+  });
+
+  const watchedThemeId = form.watch("themeId");
+  const watchedThemeFont = form.watch("themeFont");
+
+  useThemePreview({
+    themeId: watchedThemeId ?? null,
+    themeFont: watchedThemeFont ?? null,
+    initialThemeId: null,
+    initialThemeFont: null,
+    enabled: open,
   });
 
   const handleContinue = async () => {

--- a/apps/web/src/components/trip/edit-trip-dialog.tsx
+++ b/apps/web/src/components/trip/edit-trip-dialog.tsx
@@ -53,6 +53,8 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { ImageUpload } from "@/components/trip/image-upload";
+import { ThemePicker } from "@/components/trip/theme-picker";
+import { FontPicker } from "@/components/trip/font-picker";
 import { DatePicker } from "@/components/ui/date-picker";
 import { Trash2, Loader2 } from "lucide-react";
 import { TIMEZONES } from "@/lib/constants";
@@ -83,6 +85,8 @@ export function EditTripDialog({
       timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
       description: "",
       coverImageUrl: null,
+      themeId: null,
+      themeFont: null,
       allowMembersToAddEvents: true,
       showAllMembers: false,
     },
@@ -102,6 +106,8 @@ export function EditTripDialog({
         timezone: trip.preferredTimezone,
         description: trip.description || "",
         coverImageUrl: trip.coverImageUrl,
+        themeId: trip.themeId ?? null,
+        themeFont: (trip.themeFont ?? null) as UpdateTripInput["themeFont"],
         allowMembersToAddEvents: trip.allowMembersToAddEvents,
         showAllMembers: trip.showAllMembers,
       });
@@ -375,6 +381,50 @@ export function EditTripDialog({
                       Optional: Upload a cover image for your trip
                     </FormDescription>
                     <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* Theme */}
+              <FormField
+                control={form.control}
+                name="themeId"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel className="text-base font-semibold text-foreground">
+                      Theme
+                    </FormLabel>
+                    <FormControl>
+                      <ThemePicker
+                        value={field.value ?? null}
+                        onChange={field.onChange}
+                      />
+                    </FormControl>
+                    <FormDescription className="text-sm text-muted-foreground">
+                      Optional: Choose a visual theme for your trip
+                    </FormDescription>
+                  </FormItem>
+                )}
+              />
+
+              {/* Font */}
+              <FormField
+                control={form.control}
+                name="themeFont"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel className="text-base font-semibold text-foreground">
+                      Title font
+                    </FormLabel>
+                    <FormControl>
+                      <FontPicker
+                        value={field.value ?? null}
+                        onChange={field.onChange}
+                      />
+                    </FormControl>
+                    <FormDescription className="text-sm text-muted-foreground">
+                      Optional: Choose a font for trip titles
+                    </FormDescription>
                   </FormItem>
                 )}
               />

--- a/apps/web/src/components/trip/edit-trip-dialog.tsx
+++ b/apps/web/src/components/trip/edit-trip-dialog.tsx
@@ -55,6 +55,7 @@ import {
 import { ImageUpload } from "@/components/trip/image-upload";
 import { ThemePicker } from "@/components/trip/theme-picker";
 import { FontPicker } from "@/components/trip/font-picker";
+import { useThemePreview } from "@/hooks/use-theme-preview";
 import { DatePicker } from "@/components/ui/date-picker";
 import { Trash2, Loader2 } from "lucide-react";
 import { TIMEZONES } from "@/lib/constants";
@@ -90,6 +91,17 @@ export function EditTripDialog({
       allowMembersToAddEvents: true,
       showAllMembers: false,
     },
+  });
+
+  const watchedThemeId = form.watch("themeId");
+  const watchedThemeFont = form.watch("themeFont");
+
+  const { commit: commitThemePreview } = useThemePreview({
+    themeId: watchedThemeId ?? null,
+    themeFont: watchedThemeFont ?? null,
+    initialThemeId: trip.themeId ?? null,
+    initialThemeFont: (trip.themeFont ?? null) as string | null,
+    enabled: open,
   });
 
   const isInitializing = useRef(false);
@@ -128,6 +140,7 @@ export function EditTripDialog({
   }, [startDateValue, form]);
 
   const handleSubmit = (data: UpdateTripInput) => {
+    commitThemePreview();
     updateTrip(
       { tripId: trip.id, data },
       {

--- a/apps/web/src/components/trip/font-picker.tsx
+++ b/apps/web/src/components/trip/font-picker.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { THEME_FONT_VALUES } from "@tripful/shared/types";
+import { THEME_FONTS, FONT_DISPLAY_NAMES } from "@tripful/shared/config";
+import { cn } from "@/lib/utils";
+import { Check } from "lucide-react";
+
+interface FontPickerProps {
+  value: string | null;
+  onChange: (font: string | null) => void;
+}
+
+export function FontPicker({ value, onChange }: FontPickerProps) {
+  return (
+    <div className="space-y-2">
+      {THEME_FONT_VALUES.map((font) => {
+        const isSelected = value === font;
+        const isDefault = font === "plus-jakarta";
+
+        return (
+          <button
+            key={font}
+            type="button"
+            onClick={() => onChange(isSelected ? null : font)}
+            className={cn(
+              "w-full rounded-lg border p-3 cursor-pointer text-left transition-all",
+              isSelected
+                ? "border-primary bg-primary/5"
+                : "border-border hover:border-muted-foreground/30",
+            )}
+          >
+            <div className="flex items-center justify-between">
+              <div className="space-y-1">
+                <p
+                  className="text-sm font-medium text-foreground"
+                  style={{ fontFamily: THEME_FONTS[font] }}
+                >
+                  {FONT_DISPLAY_NAMES[font]}
+                  {isDefault && (
+                    <span className="ml-1.5 text-xs text-muted-foreground font-normal">
+                      (default)
+                    </span>
+                  )}
+                </p>
+                <p
+                  className="text-xs text-muted-foreground"
+                  style={{ fontFamily: THEME_FONTS[font] }}
+                >
+                  The quick brown fox jumps over the lazy dog
+                </p>
+              </div>
+              {isSelected && (
+                <div className="w-5 h-5 rounded-full bg-primary flex items-center justify-center shrink-0 ml-2">
+                  <Check className="w-3 h-3 text-white" />
+                </div>
+              )}
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/trip/theme-picker.tsx
+++ b/apps/web/src/components/trip/theme-picker.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { THEME_PRESETS } from "@tripful/shared/config";
+import type { ThemePreset } from "@tripful/shared/types";
+import { buildBackground } from "@/lib/theme-styles";
+import { cn } from "@/lib/utils";
+import { Check, X } from "lucide-react";
+
+const TAG_ORDER = [
+  "dark",
+  "light",
+  "nature",
+  "beach",
+  "bold",
+  "pastel",
+  "festive",
+] as const;
+
+const TAG_LABELS: Record<string, string> = {
+  dark: "Dark",
+  light: "Light",
+  nature: "Nature & Earthy",
+  beach: "Beach & Tropical",
+  bold: "Bold & Vibrant",
+  pastel: "Pastel & Soft",
+  festive: "Festive & Seasonal",
+};
+
+/** Group presets by their first tag */
+function groupPresets(): Map<string, ThemePreset[]> {
+  const groups = new Map<string, ThemePreset[]>();
+
+  for (const preset of THEME_PRESETS) {
+    const primaryTag = preset.tags[0];
+    if (!primaryTag) continue;
+
+    const existing = groups.get(primaryTag) ?? [];
+    existing.push(preset);
+    groups.set(primaryTag, existing);
+  }
+
+  return groups;
+}
+
+interface ThemePickerProps {
+  value: string | null;
+  onChange: (themeId: string | null) => void;
+}
+
+export function ThemePicker({ value, onChange }: ThemePickerProps) {
+  const groups = groupPresets();
+
+  return (
+    <div className="max-h-[60vh] overflow-y-auto rounded-lg border border-border p-3 space-y-4">
+      {/* No theme option */}
+      <div className="grid grid-cols-3 gap-2">
+        <button
+          type="button"
+          onClick={() => onChange(null)}
+          className={cn(
+            "h-20 rounded-lg overflow-hidden relative cursor-pointer",
+            "flex flex-col items-center justify-center gap-1",
+            "bg-muted border border-border",
+            "transition-all",
+            value === null &&
+              "ring-2 ring-primary ring-offset-2 ring-offset-background",
+          )}
+        >
+          {value === null && (
+            <div className="absolute top-1.5 right-1.5 w-4 h-4 rounded-full bg-primary flex items-center justify-center">
+              <Check className="w-2.5 h-2.5 text-white" />
+            </div>
+          )}
+          <X className="w-4 h-4 text-muted-foreground" />
+          <span className="text-[10px] font-medium text-muted-foreground">
+            None
+          </span>
+        </button>
+      </div>
+
+      {/* Grouped presets */}
+      {TAG_ORDER.map((tag) => {
+        const presets = groups.get(tag);
+        if (!presets || presets.length === 0) return null;
+
+        return (
+          <div key={tag}>
+            <h4 className="text-xs font-medium text-muted-foreground mb-2">
+              {TAG_LABELS[tag] ?? tag}
+            </h4>
+            <div className="grid grid-cols-3 gap-2">
+              {presets.map((preset) => {
+                const isSelected = value === preset.id;
+
+                return (
+                  <button
+                    key={preset.id}
+                    type="button"
+                    onClick={() => onChange(preset.id)}
+                    className={cn(
+                      "h-20 rounded-lg overflow-hidden relative cursor-pointer",
+                      "transition-all",
+                      isSelected &&
+                        "ring-2 ring-primary ring-offset-2 ring-offset-background",
+                    )}
+                    style={{ background: buildBackground(preset.background) }}
+                    title={preset.name}
+                  >
+                    {/* Theme name */}
+                    <span
+                      className={cn(
+                        "absolute top-1.5 left-2 text-[10px] font-medium",
+                        preset.background.isDark
+                          ? "text-white/80"
+                          : "text-black/60",
+                      )}
+                    >
+                      {preset.name}
+                    </span>
+
+                    {/* Selected indicator */}
+                    {isSelected && (
+                      <div className="absolute top-1.5 right-1.5 w-4 h-4 rounded-full bg-primary flex items-center justify-center">
+                        <Check className="w-2.5 h-2.5 text-white" />
+                      </div>
+                    )}
+
+                    {/* Palette swatches */}
+                    <div className="absolute bottom-2 left-2 right-2 flex items-center gap-1">
+                      {preset.palette.map((color, i) => (
+                        <div
+                          key={i}
+                          className="w-[6px] h-[6px] rounded-full shrink-0"
+                          style={{ backgroundColor: color }}
+                        />
+                      ))}
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/trip/theme-picker.tsx
+++ b/apps/web/src/components/trip/theme-picker.tsx
@@ -6,24 +6,11 @@ import { buildBackground } from "@/lib/theme-styles";
 import { cn } from "@/lib/utils";
 import { Check, X } from "lucide-react";
 
-const TAG_ORDER = [
-  "dark",
-  "light",
-  "nature",
-  "beach",
-  "bold",
-  "pastel",
-  "festive",
-] as const;
+const TAG_ORDER = ["dark", "light"] as const;
 
 const TAG_LABELS: Record<string, string> = {
   dark: "Dark",
   light: "Light",
-  nature: "Nature & Earthy",
-  beach: "Beach & Tropical",
-  bold: "Bold & Vibrant",
-  pastel: "Pastel & Soft",
-  festive: "Festive & Seasonal",
 };
 
 /** Group presets by their first tag */

--- a/apps/web/src/components/trip/trip-card.tsx
+++ b/apps/web/src/components/trip/trip-card.tsx
@@ -8,6 +8,10 @@ import { Badge } from "@/components/ui/badge";
 import { RsvpBadge } from "@/components/ui/rsvp-badge";
 import { formatDateRange, getInitials } from "@/lib/format";
 import { getUploadUrl } from "@/lib/api";
+import { TripThemeProvider } from "@/components/trip/trip-theme-provider";
+import { buildBackground } from "@/lib/theme-styles";
+import { THEME_PRESETS } from "@tripful/shared/config";
+import { THEME_FONTS } from "@tripful/shared/config";
 import { usePrefetchTrip } from "@/hooks/use-trips";
 import { supportsHover } from "@/lib/supports-hover";
 import { cn } from "@/lib/utils";
@@ -29,6 +33,8 @@ interface TripCardProps {
     }>;
     memberCount: number;
     eventCount: number;
+    themeId?: string | null;
+    themeFont?: string | null;
   };
   index?: number;
   className?: string;
@@ -42,6 +48,9 @@ export const TripCard = memo(function TripCard({
   const prefetchTrip = usePrefetchTrip(trip.id);
 
   const dateRange = formatDateRange(trip.startDate, trip.endDate);
+  const preset = trip.themeId
+    ? (THEME_PRESETS.find((p) => p.id === trip.themeId) ?? null)
+    : null;
 
   // Show up to 3 organizers
   const displayedOrganizers = (trip.organizerInfo ?? []).slice(0, 3);
@@ -51,7 +60,8 @@ export const TripCard = memo(function TripCard({
     : "";
 
   return (
-    <Link
+    <TripThemeProvider themeId={trip.themeId} themeFont={trip.themeFont}>
+      <Link
       href={`/trips/${trip.id}`}
       {...(supportsHover ? { onMouseEnter: prefetchTrip } : {})}
       onTouchStart={prefetchTrip}
@@ -84,6 +94,20 @@ export const TripCard = memo(function TripCard({
             <RsvpBadge status={trip.rsvpStatus} variant="overlay" />
           </div>
         </div>
+      ) : preset ? (
+        <div className="relative h-48 overflow-hidden">
+          <div className="absolute inset-0" style={{ background: buildBackground(preset.background) }} />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-transparent" />
+          {/* Badges overlay */}
+          <div className="absolute top-3 left-3 flex gap-2">
+            {trip.isOrganizer && (
+              <Badge className="bg-black/50 backdrop-blur-md text-white border-white/20 shadow-sm">
+                Organizing
+              </Badge>
+            )}
+            <RsvpBadge status={trip.rsvpStatus} variant="overlay" />
+          </div>
+        </div>
       ) : (
         <div className="relative h-48 overflow-hidden bg-gradient-to-br from-primary/20 via-accent/15 to-secondary/20">
           <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-transparent" />
@@ -106,7 +130,10 @@ export const TripCard = memo(function TripCard({
       {/* Content */}
       <div className="p-4 space-y-3">
         <div>
-          <h3 className="text-lg font-semibold text-foreground mb-1 truncate font-[family-name:var(--font-playfair)]">
+          <h3
+            className="text-lg font-semibold text-foreground mb-1 truncate font-[family-name:var(--font-playfair)]"
+            style={trip.themeFont ? { fontFamily: THEME_FONTS[trip.themeFont as keyof typeof THEME_FONTS] } : undefined}
+          >
             {trip.name}
           </h3>
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
@@ -159,6 +186,7 @@ export const TripCard = memo(function TripCard({
           </div>
         </div>
       </div>
-    </Link>
+      </Link>
+    </TripThemeProvider>
   );
 });

--- a/apps/web/src/components/trip/trip-theme-provider.tsx
+++ b/apps/web/src/components/trip/trip-theme-provider.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { THEME_PRESETS } from "@tripful/shared/config";
+import { THEME_FONTS } from "@tripful/shared/config";
+import { resolveThemeStyles } from "@/lib/theme-styles";
+
+interface TripThemeProviderProps {
+  themeId: string | null | undefined;
+  themeFont: string | null | undefined;
+  children: ReactNode;
+}
+
+/**
+ * Wraps children in a div that overrides event-type CSS custom properties
+ * based on the selected theme preset. Uses `className="contents"` so the
+ * wrapper does not affect layout.
+ *
+ * When no theme is selected (themeId is null/undefined or not found),
+ * children are rendered directly without a wrapper.
+ */
+export function TripThemeProvider({
+  themeId,
+  themeFont,
+  children,
+}: TripThemeProviderProps) {
+  const preset = THEME_PRESETS.find((p) => p.id === themeId) ?? null;
+
+  if (!preset) {
+    return <>{children}</>;
+  }
+
+  const styleOverrides: Record<string, string> = resolveThemeStyles(preset);
+
+  if (themeFont && themeFont in THEME_FONTS) {
+    styleOverrides.fontFamily =
+      THEME_FONTS[themeFont as keyof typeof THEME_FONTS];
+  }
+
+  return (
+    <div style={styleOverrides} className="contents">
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/components/trip/trip-theme-provider.tsx
+++ b/apps/web/src/components/trip/trip-theme-provider.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useLayoutEffect, type ReactNode } from "react";
-import { THEME_PRESETS } from "@tripful/shared/config";
-import { THEME_FONTS } from "@tripful/shared/config";
+import { THEME_PRESETS, THEME_FONTS } from "@tripful/shared/config";
 import { resolveThemeStyles, resolvePaletteStyles } from "@/lib/theme-styles";
 
 interface TripThemeProviderProps {

--- a/apps/web/src/components/trip/trip-theme-provider.tsx
+++ b/apps/web/src/components/trip/trip-theme-provider.tsx
@@ -1,44 +1,82 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 import { THEME_PRESETS } from "@tripful/shared/config";
 import { THEME_FONTS } from "@tripful/shared/config";
-import { resolveThemeStyles } from "@/lib/theme-styles";
+import { resolveThemeStyles, resolvePaletteStyles } from "@/lib/theme-styles";
 
 interface TripThemeProviderProps {
   themeId: string | null | undefined;
   themeFont: string | null | undefined;
   children: ReactNode;
+  /**
+   * "page" — sets full semantic + palette CSS vars on document root
+   *          (themes header, dialogs, everything). Cleans up on unmount.
+   * "local" — only palette colors on a scoped wrapper div (for trip cards).
+   */
+  scope?: "page" | "local";
 }
 
 /**
- * Wraps children in a div that overrides event-type CSS custom properties
- * based on the selected theme preset. Uses `className="contents"` so the
- * wrapper does not affect layout.
+ * Applies trip theme CSS custom properties.
  *
- * When no theme is selected (themeId is null/undefined or not found),
- * children are rendered directly without a wrapper.
+ * - scope="page": sets vars on `document.documentElement` so they cascade
+ *   to the entire page — header, portaled dialogs, everything.
+ * - scope="local": wraps children in a `className="contents"` div with
+ *   only palette color overrides (no semantic tokens).
  */
 export function TripThemeProvider({
   themeId,
   themeFont,
   children,
+  scope = "local",
 }: TripThemeProviderProps) {
   const preset = THEME_PRESETS.find((p) => p.id === themeId) ?? null;
 
+  // Page-scoped: set all vars on document root
+  useEffect(() => {
+    if (scope !== "page" || !preset) return;
+
+    const styles = resolveThemeStyles(preset);
+
+    if (themeFont && themeFont in THEME_FONTS) {
+      styles["--font-theme"] =
+        THEME_FONTS[themeFont as keyof typeof THEME_FONTS];
+    }
+
+    const root = document.documentElement;
+    const keys = Object.keys(styles);
+
+    for (const key of keys) {
+      root.style.setProperty(key, styles[key] ?? "");
+    }
+
+    return () => {
+      for (const key of keys) {
+        root.style.removeProperty(key);
+      }
+    };
+  }, [scope, preset, themeFont]);
+
+  // Page-scoped rendering: no wrapper needed (vars are on root)
+  if (scope === "page") {
+    return <>{children}</>;
+  }
+
+  // Local-scoped: palette-only vars on a wrapper div
   if (!preset) {
     return <>{children}</>;
   }
 
-  const styleOverrides: Record<string, string> = resolveThemeStyles(preset);
+  const localStyles: Record<string, string> = resolvePaletteStyles(preset);
 
   if (themeFont && themeFont in THEME_FONTS) {
-    styleOverrides.fontFamily =
+    localStyles.fontFamily =
       THEME_FONTS[themeFont as keyof typeof THEME_FONTS];
   }
 
   return (
-    <div style={styleOverrides} className="contents">
+    <div style={localStyles} className="contents">
       {children}
     </div>
   );

--- a/apps/web/src/components/trip/trip-theme-provider.tsx
+++ b/apps/web/src/components/trip/trip-theme-provider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, type ReactNode } from "react";
+import { useLayoutEffect, type ReactNode } from "react";
 import { THEME_PRESETS } from "@tripful/shared/config";
 import { THEME_FONTS } from "@tripful/shared/config";
 import { resolveThemeStyles, resolvePaletteStyles } from "@/lib/theme-styles";
@@ -33,8 +33,8 @@ export function TripThemeProvider({
 }: TripThemeProviderProps) {
   const preset = THEME_PRESETS.find((p) => p.id === themeId) ?? null;
 
-  // Page-scoped: set all vars on document root
-  useEffect(() => {
+  // Page-scoped: set all vars on document root (layout effect to avoid flash)
+  useLayoutEffect(() => {
     if (scope !== "page" || !preset) return;
 
     const styles = resolveThemeStyles(preset);

--- a/apps/web/src/hooks/use-theme-preview.ts
+++ b/apps/web/src/hooks/use-theme-preview.ts
@@ -1,0 +1,161 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+import { THEME_PRESETS, THEME_FONTS } from "@tripful/shared/config";
+import type { ThemeFont } from "@tripful/shared/types";
+import { resolveThemeStyles, ALL_THEME_CSS_KEYS } from "@/lib/theme-styles";
+
+interface UseThemePreviewOptions {
+  /** Currently selected theme ID (null = "None") */
+  themeId: string | null;
+  /** Currently selected font (null = default) */
+  themeFont: string | null;
+  /** Theme ID the page already shows (what to restore on cancel) */
+  initialThemeId: string | null;
+  /** Font the page already shows */
+  initialThemeFont: string | null;
+  /** Tied to dialog open state — false pauses all side-effects */
+  enabled?: boolean;
+}
+
+/**
+ * Snapshot of inline style values for every theme CSS key.
+ * `undefined` means the property was not set inline.
+ */
+type CssSnapshot = Map<string, string | undefined>;
+
+function snapshotInlineStyles(): CssSnapshot {
+  const root = document.documentElement;
+  const snap: CssSnapshot = new Map();
+  for (const key of ALL_THEME_CSS_KEYS) {
+    const val = root.style.getPropertyValue(key);
+    snap.set(key, val || undefined);
+  }
+  return snap;
+}
+
+function restoreSnapshot(snap: CssSnapshot) {
+  const root = document.documentElement;
+  for (const [key, val] of snap) {
+    if (val !== undefined) {
+      root.style.setProperty(key, val);
+    } else {
+      root.style.removeProperty(key);
+    }
+  }
+}
+
+function applyThemeToRoot(themeId: string | null, themeFont: string | null) {
+  const root = document.documentElement;
+  const preset = themeId
+    ? (THEME_PRESETS.find((p) => p.id === themeId) ?? null)
+    : null;
+  const styles = resolveThemeStyles(preset);
+
+  if (themeFont && themeFont in THEME_FONTS) {
+    styles["--font-theme"] = THEME_FONTS[themeFont as ThemeFont];
+  }
+
+  // Remove all theme keys first (handles dark→light where dark has extra keys)
+  for (const key of ALL_THEME_CSS_KEYS) {
+    root.style.removeProperty(key);
+  }
+
+  // Apply new values
+  for (const [key, val] of Object.entries(styles)) {
+    root.style.setProperty(key, val);
+  }
+}
+
+/**
+ * Live-previews a trip theme on the page while a dialog is open.
+ *
+ * - Snapshots inline CSS vars when enabled
+ * - Applies theme changes as user picks options
+ * - Restores snapshot on unmount/disable (cancel)
+ * - `commit()` prevents restore (submit case)
+ */
+export function useThemePreview({
+  themeId,
+  themeFont,
+  initialThemeId,
+  initialThemeFont,
+  enabled = true,
+}: UseThemePreviewOptions): { commit: () => void } {
+  const snapshotRef = useRef<CssSnapshot | null>(null);
+  const committedRef = useRef(false);
+  const hasSeenInitialRef = useRef(false);
+
+  // Take snapshot when enabled transitions to true
+  useEffect(() => {
+    if (!enabled) {
+      // Reset state for next open
+      hasSeenInitialRef.current = false;
+      committedRef.current = false;
+      return;
+    }
+
+    // Snapshot current inline styles
+    snapshotRef.current = snapshotInlineStyles();
+    committedRef.current = false;
+    hasSeenInitialRef.current = false;
+
+    return () => {
+      // Restore on unmount/disable unless committed
+      if (!committedRef.current && snapshotRef.current) {
+        restoreSnapshot(snapshotRef.current);
+      }
+      snapshotRef.current = null;
+    };
+    // Only run on enabled transitions, not on themeId/themeFont changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled]);
+
+  // Apply theme preview when selection changes
+  useEffect(() => {
+    if (!enabled || !snapshotRef.current) return;
+
+    // Wait for the form to settle to the initial value before previewing.
+    // This prevents a flash in the edit dialog where the form briefly has
+    // themeId=null before form.reset() sets the trip's actual themeId.
+    if (!hasSeenInitialRef.current) {
+      if (themeId === initialThemeId && themeFont === initialThemeFont) {
+        hasSeenInitialRef.current = true;
+      }
+      return;
+    }
+
+    // If returning to initial selection, restore the snapshot exactly
+    if (themeId === initialThemeId && themeFont === initialThemeFont) {
+      restoreSnapshot(snapshotRef.current);
+      return;
+    }
+
+    // "None" selection — remove all inline overrides so @theme defaults show
+    if (themeId === null) {
+      const root = document.documentElement;
+      for (const key of ALL_THEME_CSS_KEYS) {
+        root.style.removeProperty(key);
+      }
+      // Point --theme-background at the default so elements using
+      // var(--theme-background) fall back to the unthemed background color
+      root.style.setProperty("--theme-background", "var(--color-background)");
+      // Re-apply font if selected
+      if (themeFont && themeFont in THEME_FONTS) {
+        root.style.setProperty(
+          "--font-theme",
+          THEME_FONTS[themeFont as ThemeFont],
+        );
+      }
+      return;
+    }
+
+    applyThemeToRoot(themeId, themeFont);
+  }, [enabled, themeId, themeFont, initialThemeId, initialThemeFont]);
+
+  const commit = useCallback(() => {
+    committedRef.current = true;
+  }, []);
+
+  return { commit };
+}

--- a/apps/web/src/hooks/use-theme-preview.ts
+++ b/apps/web/src/hooks/use-theme-preview.ts
@@ -108,7 +108,6 @@ export function useThemePreview({
       snapshotRef.current = null;
     };
     // Only run on enabled transitions, not on themeId/themeFont changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabled]);
 
   // Apply theme preview when selection changes

--- a/apps/web/src/hooks/use-trips.ts
+++ b/apps/web/src/hooks/use-trips.ts
@@ -167,6 +167,8 @@ export function useCreateTrip() {
         preferredTimezone: newTrip.timezone,
         description: newTrip.description || null,
         coverImageUrl: newTrip.coverImageUrl || null,
+        themeId: newTrip.themeId ?? null,
+        themeFont: newTrip.themeFont ?? null,
         createdBy: "current-user", // Placeholder - will be replaced by server response
         allowMembersToAddEvents: newTrip.allowMembersToAddEvents ?? true,
         showAllMembers: newTrip.showAllMembers ?? false,

--- a/apps/web/src/lib/fonts.ts
+++ b/apps/web/src/lib/fonts.ts
@@ -1,4 +1,7 @@
 import {
+  Caveat,
+  Nunito,
+  Oswald,
   Playfair_Display,
   Plus_Jakarta_Sans,
   Space_Grotesk,
@@ -21,4 +24,22 @@ export const spaceGrotesk = Space_Grotesk({
   variable: "--font-space-grotesk",
   display: "swap",
   weight: ["400", "500", "600", "700"],
+});
+
+export const nunito = Nunito({
+  subsets: ["latin"],
+  variable: "--font-nunito",
+  display: "swap",
+});
+
+export const caveat = Caveat({
+  subsets: ["latin"],
+  variable: "--font-caveat",
+  display: "swap",
+});
+
+export const oswald = Oswald({
+  subsets: ["latin"],
+  variable: "--font-oswald",
+  display: "swap",
 });

--- a/apps/web/src/lib/theme-styles.ts
+++ b/apps/web/src/lib/theme-styles.ts
@@ -1,0 +1,57 @@
+import type { ThemePreset, ThemeBackground } from "@tripful/shared/types";
+import { derivePaletteVariants } from "@tripful/shared/utils";
+
+/**
+ * Resolve a theme preset into CSS custom property overrides.
+ * Returns an empty object when no theme is provided, so downstream
+ * components fall back to the global default colors defined in globals.css.
+ */
+export function resolveThemeStyles(
+  theme: ThemePreset | null,
+): Record<string, string> {
+  if (!theme) return {};
+
+  // Palette is always 5 entries: [travel, meal, activity, accommodation, highlight]
+  const [travel, meal, activity, accommodation, highlight] = theme.palette as [
+    string,
+    string,
+    string,
+    string,
+    string,
+  ];
+
+  const travelV = derivePaletteVariants(travel);
+  const mealV = derivePaletteVariants(meal);
+  const activityV = derivePaletteVariants(activity);
+  const accommodationV = derivePaletteVariants(accommodation);
+
+  return {
+    "--color-event-travel": travel,
+    "--color-event-travel-light": travelV.light,
+    "--color-event-travel-border": travelV.border,
+    "--color-event-meal": meal,
+    "--color-event-meal-light": mealV.light,
+    "--color-event-meal-border": mealV.border,
+    "--color-event-activity": activity,
+    "--color-event-activity-light": activityV.light,
+    "--color-event-activity-border": activityV.border,
+    "--color-accommodation": accommodation,
+    "--color-accommodation-light": accommodationV.light,
+    "--color-accommodation-border": accommodationV.border,
+    "--color-primary": highlight,
+  };
+}
+
+/**
+ * Build a CSS background value from a ThemeBackground discriminated union.
+ */
+export function buildBackground(bg: ThemeBackground): string {
+  switch (bg.type) {
+    case "solid":
+      return bg.color;
+    case "gradient":
+      return `linear-gradient(${bg.angle}deg, ${bg.stops.join(", ")})`;
+    case "image":
+      return `url(${bg.url}) center/cover`;
+  }
+}

--- a/apps/web/src/lib/theme-styles.ts
+++ b/apps/web/src/lib/theme-styles.ts
@@ -85,6 +85,7 @@ export function resolveThemeStyles(
 
   return {
     ...semantic,
+    "--theme-background": buildBackground(theme.background),
     "--color-event-travel": travel,
     "--color-event-travel-light": travelV.light,
     "--color-event-travel-border": travelV.border,
@@ -139,6 +140,51 @@ export function resolvePaletteStyles(
     "--color-primary": highlight,
   };
 }
+
+/**
+ * Every CSS custom property key that `resolveThemeStyles()` can produce
+ * (union of dark + light semantic keys, palette keys, and font).
+ * Used by `useThemePreview` to snapshot / restore inline styles.
+ */
+export const ALL_THEME_CSS_KEYS: readonly string[] = [
+  // Semantic UI tokens (both light and dark)
+  "--color-background",
+  "--color-foreground",
+  "--color-card",
+  "--color-card-foreground",
+  "--color-popover",
+  "--color-popover-foreground",
+  "--color-secondary",
+  "--color-secondary-foreground",
+  "--color-muted",
+  "--color-muted-foreground",
+  "--color-accent-foreground",
+  "--color-border",
+  "--color-input",
+  "--color-ring",
+  // Dark-only semantic tokens
+  "--color-member-travel",
+  "--color-member-travel-light",
+  "--color-member-travel-border",
+  // Palette tokens
+  "--color-event-travel",
+  "--color-event-travel-light",
+  "--color-event-travel-border",
+  "--color-event-meal",
+  "--color-event-meal-light",
+  "--color-event-meal-border",
+  "--color-event-activity",
+  "--color-event-activity-light",
+  "--color-event-activity-border",
+  "--color-accommodation",
+  "--color-accommodation-light",
+  "--color-accommodation-border",
+  "--color-primary",
+  // Full background (gradient/solid/image)
+  "--theme-background",
+  // Font
+  "--font-theme",
+] as const;
 
 /**
  * Build a CSS background value from a ThemeBackground discriminated union.

--- a/apps/web/src/lib/theme-styles.ts
+++ b/apps/web/src/lib/theme-styles.ts
@@ -1,8 +1,23 @@
 import type { ThemePreset, ThemeBackground } from "@tripful/shared/types";
-import { derivePaletteVariants } from "@tripful/shared/utils";
+import {
+  derivePaletteVariants,
+  deriveDarkPaletteVariants,
+} from "@tripful/shared/utils";
+
+/**
+ * Extract the base solid color from a ThemeBackground (first stop or solid).
+ */
+function getBaseColor(bg: ThemeBackground): string {
+  if (bg.type === "solid") return bg.color;
+  if (bg.type === "gradient") return bg.stops[0] ?? "#000000";
+  return "#000000";
+}
 
 /**
  * Resolve a theme preset into CSS custom property overrides.
+ * Includes both event palette colors and semantic UI tokens
+ * (foreground, card, border, etc.) so the entire page adapts.
+ *
  * Returns an empty object when no theme is provided, so downstream
  * components fall back to the global default colors defined in globals.css.
  */
@@ -12,6 +27,89 @@ export function resolveThemeStyles(
   if (!theme) return {};
 
   // Palette is always 5 entries: [travel, meal, activity, accommodation, highlight]
+  const [travel, meal, activity, accommodation, highlight] = theme.palette as [
+    string,
+    string,
+    string,
+    string,
+    string,
+  ];
+
+  const derive = theme.background.isDark
+    ? deriveDarkPaletteVariants
+    : derivePaletteVariants;
+  const travelV = derive(travel);
+  const mealV = derive(meal);
+  const activityV = derive(activity);
+  const accommodationV = derive(accommodation);
+
+  const baseColor = getBaseColor(theme.background);
+
+  // Semantic UI tokens adapt to dark/light themes
+  const semantic: Record<string, string> = theme.background.isDark
+    ? {
+        "--color-background": baseColor,
+        "--color-foreground": "#e2e8f0",
+        "--color-card": "rgba(255,255,255,0.06)",
+        "--color-card-foreground": "#e2e8f0",
+        "--color-popover": baseColor,
+        "--color-popover-foreground": "#e2e8f0",
+        "--color-secondary": "rgba(255,255,255,0.08)",
+        "--color-secondary-foreground": "#e2e8f0",
+        "--color-muted": "rgba(255,255,255,0.08)",
+        "--color-muted-foreground": "#94a3b8",
+        "--color-accent-foreground": "#e2e8f0",
+        "--color-border": "rgba(255,255,255,0.10)",
+        "--color-input": "rgba(255,255,255,0.12)",
+        "--color-ring": highlight,
+        // Member-travel (neutral gray) — defaults are light-mode, override for dark
+        "--color-member-travel": "#9ca3af",
+        "--color-member-travel-light": "#1f2937",
+        "--color-member-travel-border": "#374151",
+      }
+    : {
+        "--color-background": baseColor,
+        "--color-foreground": "#1e293b",
+        "--color-card": "rgba(255,255,255,0.70)",
+        "--color-card-foreground": "#1e293b",
+        "--color-popover": "#ffffff",
+        "--color-popover-foreground": "#1e293b",
+        "--color-secondary": "rgba(0,0,0,0.04)",
+        "--color-secondary-foreground": "#1e293b",
+        "--color-muted": "rgba(0,0,0,0.04)",
+        "--color-muted-foreground": "#64748b",
+        "--color-border": "rgba(0,0,0,0.08)",
+        "--color-input": "rgba(0,0,0,0.10)",
+        "--color-ring": highlight,
+      };
+
+  return {
+    ...semantic,
+    "--color-event-travel": travel,
+    "--color-event-travel-light": travelV.light,
+    "--color-event-travel-border": travelV.border,
+    "--color-event-meal": meal,
+    "--color-event-meal-light": mealV.light,
+    "--color-event-meal-border": mealV.border,
+    "--color-event-activity": activity,
+    "--color-event-activity-light": activityV.light,
+    "--color-event-activity-border": activityV.border,
+    "--color-accommodation": accommodation,
+    "--color-accommodation-light": accommodationV.light,
+    "--color-accommodation-border": accommodationV.border,
+    "--color-primary": highlight,
+  };
+}
+
+/**
+ * Resolve only event palette CSS vars (no semantic UI tokens).
+ * Used for locally-scoped theming (e.g. trip cards on the list page).
+ */
+export function resolvePaletteStyles(
+  theme: ThemePreset | null,
+): Record<string, string> {
+  if (!theme) return {};
+
   const [travel, meal, activity, accommodation, highlight] = theme.palette as [
     string,
     string,

--- a/shared/__tests__/theme-config.test.ts
+++ b/shared/__tests__/theme-config.test.ts
@@ -1,0 +1,190 @@
+// Tests for theme configuration (presets, fonts, types)
+
+import { describe, it, expect } from "vitest";
+import { THEME_PRESETS, THEME_IDS } from "../config/themes";
+import { THEME_FONTS, FONT_DISPLAY_NAMES } from "../config/theme-fonts";
+import { THEME_FONT_VALUES } from "../types/theme";
+import type { ThemePreset, ThemeBackground } from "../types/theme";
+
+describe("THEME_PRESETS", () => {
+  it("should contain at least 20 presets", () => {
+    expect(THEME_PRESETS.length).toBeGreaterThanOrEqual(20);
+  });
+
+  it("should have unique IDs", () => {
+    const ids = THEME_PRESETS.map((p) => p.id);
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(ids.length);
+  });
+
+  it("should have unique names", () => {
+    const names = THEME_PRESETS.map((p) => p.name);
+    const uniqueNames = new Set(names);
+    expect(uniqueNames.size).toBe(names.length);
+  });
+
+  it("should use kebab-case IDs", () => {
+    const kebabCaseRegex = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
+    THEME_PRESETS.forEach((preset) => {
+      expect(preset.id).toMatch(kebabCaseRegex);
+    });
+  });
+
+  it("should have exactly 5 palette colors per preset", () => {
+    THEME_PRESETS.forEach((preset) => {
+      expect(preset.palette).toHaveLength(5);
+    });
+  });
+
+  it("should use only hex colors in palettes (no hsl)", () => {
+    const hexRegex = /^#[0-9a-fA-F]{6}$/;
+    THEME_PRESETS.forEach((preset) => {
+      preset.palette.forEach((color) => {
+        expect(color).toMatch(hexRegex);
+      });
+    });
+  });
+
+  it("should have at least one tag per preset", () => {
+    THEME_PRESETS.forEach((preset) => {
+      expect(preset.tags.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it("should have a valid background on each preset", () => {
+    THEME_PRESETS.forEach((preset) => {
+      const bg = preset.background;
+      expect(["solid", "gradient", "image"]).toContain(bg.type);
+      expect(typeof bg.isDark).toBe("boolean");
+
+      if (bg.type === "solid") {
+        expect(bg.color).toMatch(/^#[0-9a-fA-F]{6}$/);
+      } else if (bg.type === "gradient") {
+        expect(bg.angle).toBeGreaterThanOrEqual(0);
+        expect(bg.angle).toBeLessThanOrEqual(360);
+        expect(bg.stops.length).toBeGreaterThanOrEqual(2);
+        bg.stops.forEach((stop) => {
+          expect(stop).toMatch(/^#[0-9a-fA-F]{6}$/);
+        });
+      } else if (bg.type === "image") {
+        expect(typeof bg.url).toBe("string");
+        expect(bg.url.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  it("should include a mix of dark and light themes", () => {
+    const darkCount = THEME_PRESETS.filter((p) => p.background.isDark).length;
+    const lightCount = THEME_PRESETS.filter((p) => !p.background.isDark).length;
+    expect(darkCount).toBeGreaterThanOrEqual(3);
+    expect(lightCount).toBeGreaterThanOrEqual(4);
+  });
+
+  it("should include themes across different tag categories", () => {
+    const allTags = new Set(THEME_PRESETS.flatMap((p) => p.tags));
+    // Verify we have a good spread of categories
+    expect(allTags.has("dark")).toBe(true);
+    expect(allTags.has("light")).toBe(true);
+    expect(allTags.has("nature")).toBe(true);
+    expect(allTags.has("beach")).toBe(true);
+    expect(allTags.has("bold")).toBe(true);
+    expect(allTags.has("pastel")).toBe(true);
+    expect(allTags.has("festive")).toBe(true);
+  });
+
+  it("should have no hsl values anywhere in backgrounds", () => {
+    THEME_PRESETS.forEach((preset) => {
+      const bg = preset.background;
+      if (bg.type === "solid") {
+        expect(bg.color).not.toContain("hsl");
+      } else if (bg.type === "gradient") {
+        bg.stops.forEach((stop) => {
+          expect(stop).not.toContain("hsl");
+        });
+      }
+    });
+  });
+});
+
+describe("THEME_IDS", () => {
+  it("should match the IDs from THEME_PRESETS", () => {
+    const expectedIds = THEME_PRESETS.map((p) => p.id);
+    expect(THEME_IDS).toEqual(expectedIds);
+  });
+
+  it("should be a non-empty array", () => {
+    expect(THEME_IDS.length).toBeGreaterThan(0);
+  });
+});
+
+describe("THEME_FONTS", () => {
+  it("should have an entry for every font in THEME_FONT_VALUES", () => {
+    THEME_FONT_VALUES.forEach((fontId) => {
+      expect(THEME_FONTS[fontId]).toBeDefined();
+      expect(typeof THEME_FONTS[fontId]).toBe("string");
+    });
+  });
+
+  it("should contain CSS custom property references", () => {
+    Object.values(THEME_FONTS).forEach((fontFamily) => {
+      expect(fontFamily).toContain("var(--font-");
+    });
+  });
+
+  it("should include fallback fonts", () => {
+    // Each font-family string should have at least one comma (font + fallback)
+    Object.values(THEME_FONTS).forEach((fontFamily) => {
+      expect(fontFamily).toContain(",");
+    });
+  });
+});
+
+describe("FONT_DISPLAY_NAMES", () => {
+  it("should have an entry for every font in THEME_FONT_VALUES", () => {
+    THEME_FONT_VALUES.forEach((fontId) => {
+      expect(FONT_DISPLAY_NAMES[fontId]).toBeDefined();
+      expect(typeof FONT_DISPLAY_NAMES[fontId]).toBe("string");
+    });
+  });
+
+  it("should have non-empty display names", () => {
+    Object.values(FONT_DISPLAY_NAMES).forEach((name) => {
+      expect(name.length).toBeGreaterThan(0);
+    });
+  });
+});
+
+describe("ThemePreset type", () => {
+  it("should allow creating a valid preset object", () => {
+    const preset: ThemePreset = {
+      id: "test-theme",
+      name: "Test Theme",
+      tags: ["dark", "bold"],
+      palette: ["#ff0000", "#00ff00", "#0000ff", "#ff00ff", "#ffff00"],
+      background: { type: "solid", color: "#000000", isDark: true },
+    };
+    expect(preset.id).toBe("test-theme");
+    expect(preset.palette).toHaveLength(5);
+  });
+
+  it("should allow gradient backgrounds", () => {
+    const bg: ThemeBackground = {
+      type: "gradient",
+      angle: 90,
+      stops: ["#000000", "#ffffff"],
+      isDark: false,
+    };
+    expect(bg.type).toBe("gradient");
+    expect(bg.stops).toHaveLength(2);
+  });
+
+  it("should allow image backgrounds", () => {
+    const bg: ThemeBackground = {
+      type: "image",
+      url: "https://example.com/bg.jpg",
+      isDark: true,
+    };
+    expect(bg.type).toBe("image");
+    expect(bg.url).toContain("https://");
+  });
+});

--- a/shared/__tests__/theme-config.test.ts
+++ b/shared/__tests__/theme-config.test.ts
@@ -7,8 +7,8 @@ import { THEME_FONT_VALUES } from "../types/theme";
 import type { ThemePreset, ThemeBackground } from "../types/theme";
 
 describe("THEME_PRESETS", () => {
-  it("should contain at least 20 presets", () => {
-    expect(THEME_PRESETS.length).toBeGreaterThanOrEqual(20);
+  it("should contain at least 6 presets", () => {
+    expect(THEME_PRESETS.length).toBeGreaterThanOrEqual(6);
   });
 
   it("should have unique IDs", () => {
@@ -77,19 +77,13 @@ describe("THEME_PRESETS", () => {
     const darkCount = THEME_PRESETS.filter((p) => p.background.isDark).length;
     const lightCount = THEME_PRESETS.filter((p) => !p.background.isDark).length;
     expect(darkCount).toBeGreaterThanOrEqual(3);
-    expect(lightCount).toBeGreaterThanOrEqual(4);
+    expect(lightCount).toBeGreaterThanOrEqual(3);
   });
 
-  it("should include themes across different tag categories", () => {
+  it("should include both dark and light tag categories", () => {
     const allTags = new Set(THEME_PRESETS.flatMap((p) => p.tags));
-    // Verify we have a good spread of categories
     expect(allTags.has("dark")).toBe(true);
     expect(allTags.has("light")).toBe(true);
-    expect(allTags.has("nature")).toBe(true);
-    expect(allTags.has("beach")).toBe(true);
-    expect(allTags.has("bold")).toBe(true);
-    expect(allTags.has("pastel")).toBe(true);
-    expect(allTags.has("festive")).toBe(true);
   });
 
   it("should have no hsl values anywhere in backgrounds", () => {

--- a/shared/config/index.ts
+++ b/shared/config/index.ts
@@ -1,0 +1,4 @@
+// Barrel exports for @tripful/shared/config
+
+export { THEME_PRESETS, THEME_IDS } from "./themes";
+export { THEME_FONTS, FONT_DISPLAY_NAMES } from "./theme-fonts";

--- a/shared/config/theme-fonts.ts
+++ b/shared/config/theme-fonts.ts
@@ -1,0 +1,30 @@
+// Font configuration for trip themes
+
+import type { ThemeFont } from "../types/theme";
+
+/**
+ * Maps font IDs to CSS font-family values.
+ * Each value uses a CSS custom property set by Next.js font loading,
+ * with appropriate fallback font stacks.
+ */
+export const THEME_FONTS: Record<ThemeFont, string> = {
+  "plus-jakarta": "var(--font-plus-jakarta), system-ui, sans-serif",
+  playfair: "var(--font-playfair), Georgia, serif",
+  "space-grotesk": "var(--font-space-grotesk), monospace",
+  nunito: "var(--font-nunito), system-ui, sans-serif",
+  caveat: "var(--font-caveat), cursive",
+  oswald: "var(--font-oswald), Impact, sans-serif",
+};
+
+/**
+ * Human-readable display names for each font option.
+ * Used in font picker UI.
+ */
+export const FONT_DISPLAY_NAMES: Record<ThemeFont, string> = {
+  "plus-jakarta": "Plus Jakarta Sans",
+  playfair: "Playfair Display",
+  "space-grotesk": "Space Grotesk",
+  nunito: "Nunito",
+  caveat: "Caveat",
+  oswald: "Oswald",
+};

--- a/shared/config/themes.ts
+++ b/shared/config/themes.ts
@@ -1,0 +1,319 @@
+// Curated theme presets for trip customization
+
+import type { ThemePreset } from "../types/theme";
+
+/**
+ * ~20 curated theme presets spanning multiple visual categories.
+ * Each preset includes a background style and 5-color palette:
+ *   [0] travel, [1] meal, [2] activity, [3] accommodation, [4] highlight
+ *
+ * All colors are hex values (never hsl — Tailwind v4 @theme bug).
+ */
+export const THEME_PRESETS: ThemePreset[] = [
+  // --- Dark themes ---
+  {
+    id: "midnight",
+    name: "Midnight",
+    tags: ["dark", "city"],
+    palette: ["#60a5fa", "#fbbf24", "#34d399", "#c084fc", "#f472b6"],
+    background: {
+      type: "gradient",
+      angle: 135,
+      stops: ["#0f172a", "#1e293b"],
+      isDark: true,
+    },
+  },
+  {
+    id: "deep-ocean",
+    name: "Deep Ocean",
+    tags: ["dark", "cool"],
+    palette: ["#38bdf8", "#fb923c", "#2dd4bf", "#a78bfa", "#22d3ee"],
+    background: {
+      type: "gradient",
+      angle: 180,
+      stops: ["#0c1426", "#0e2a47", "#0a1628"],
+      isDark: true,
+    },
+  },
+  {
+    id: "aurora",
+    name: "Aurora",
+    tags: ["dark", "nature", "bold"],
+    palette: ["#67e8f9", "#fcd34d", "#6ee7b7", "#d8b4fe", "#a78bfa"],
+    background: {
+      type: "gradient",
+      angle: 160,
+      stops: ["#0f172a", "#1a2e44", "#162e2e"],
+      isDark: true,
+    },
+  },
+  {
+    id: "noir",
+    name: "Noir",
+    tags: ["dark", "city", "bold"],
+    palette: ["#f9a8d4", "#fde68a", "#86efac", "#c4b5fd", "#fb7185"],
+    background: {
+      type: "solid",
+      color: "#18181b",
+      isDark: true,
+    },
+  },
+
+  // --- Light themes ---
+  {
+    id: "cotton-candy",
+    name: "Cotton Candy",
+    tags: ["light", "pastel"],
+    palette: ["#818cf8", "#f472b6", "#34d399", "#a78bfa", "#ec4899"],
+    background: {
+      type: "gradient",
+      angle: 135,
+      stops: ["#fdf2f8", "#ede9fe", "#f0f9ff"],
+      isDark: false,
+    },
+  },
+  {
+    id: "vanilla",
+    name: "Vanilla",
+    tags: ["light", "warm"],
+    palette: ["#2563eb", "#d97706", "#059669", "#9333ea", "#e11d48"],
+    background: {
+      type: "solid",
+      color: "#fefce8",
+      isDark: false,
+    },
+  },
+  {
+    id: "cloud",
+    name: "Cloud",
+    tags: ["light", "cool"],
+    palette: ["#3b82f6", "#f59e0b", "#10b981", "#8b5cf6", "#6366f1"],
+    background: {
+      type: "gradient",
+      angle: 180,
+      stops: ["#f8fafc", "#eef2ff"],
+      isDark: false,
+    },
+  },
+  {
+    id: "linen",
+    name: "Linen",
+    tags: ["light", "warm", "vintage"],
+    palette: ["#7c3aed", "#b45309", "#047857", "#9333ea", "#be185d"],
+    background: {
+      type: "solid",
+      color: "#faf5f0",
+      isDark: false,
+    },
+  },
+  {
+    id: "paper",
+    name: "Paper",
+    tags: ["light", "cool"],
+    palette: ["#2563eb", "#ea580c", "#0d9488", "#7c3aed", "#0284c7"],
+    background: {
+      type: "solid",
+      color: "#f8fafc",
+      isDark: false,
+    },
+  },
+
+  // --- Nature / Earthy themes ---
+  {
+    id: "forest",
+    name: "Forest",
+    tags: ["dark", "nature", "earthy"],
+    palette: ["#86efac", "#fbbf24", "#5eead4", "#c084fc", "#4ade80"],
+    background: {
+      type: "gradient",
+      angle: 170,
+      stops: ["#14261c", "#1a3a2a"],
+      isDark: true,
+    },
+  },
+  {
+    id: "desert",
+    name: "Desert",
+    tags: ["light", "nature", "earthy", "warm"],
+    palette: ["#0369a1", "#c2410c", "#15803d", "#7e22ce", "#dc2626"],
+    background: {
+      type: "gradient",
+      angle: 135,
+      stops: ["#fef3c7", "#fed7aa", "#fef3c7"],
+      isDark: false,
+    },
+  },
+  {
+    id: "moss",
+    name: "Moss",
+    tags: ["light", "nature", "earthy"],
+    palette: ["#1d4ed8", "#ca8a04", "#15803d", "#6d28d9", "#059669"],
+    background: {
+      type: "gradient",
+      angle: 160,
+      stops: ["#f0fdf4", "#ecfdf5"],
+      isDark: false,
+    },
+  },
+  {
+    id: "clay",
+    name: "Clay",
+    tags: ["light", "earthy", "warm"],
+    palette: ["#1e40af", "#92400e", "#166534", "#7e22ce", "#b91c1c"],
+    background: {
+      type: "gradient",
+      angle: 145,
+      stops: ["#fef2f2", "#fef9ee"],
+      isDark: false,
+    },
+  },
+
+  // --- Beach / Tropical themes ---
+  {
+    id: "turquoise-coast",
+    name: "Turquoise Coast",
+    tags: ["light", "beach", "tropical"],
+    palette: ["#0284c7", "#ea580c", "#0d9488", "#7c3aed", "#0891b2"],
+    background: {
+      type: "gradient",
+      angle: 135,
+      stops: ["#ecfeff", "#cffafe", "#e0f2fe"],
+      isDark: false,
+    },
+  },
+  {
+    id: "sunset-beach",
+    name: "Sunset Beach",
+    tags: ["dark", "beach", "warm"],
+    palette: ["#38bdf8", "#fbbf24", "#34d399", "#e879f9", "#fb923c"],
+    background: {
+      type: "gradient",
+      angle: 180,
+      stops: ["#431407", "#7c2d12", "#1c1917"],
+      isDark: true,
+    },
+  },
+  {
+    id: "lagoon",
+    name: "Lagoon",
+    tags: ["light", "beach", "tropical", "cool"],
+    palette: ["#0369a1", "#d97706", "#047857", "#7c3aed", "#0e7490"],
+    background: {
+      type: "gradient",
+      angle: 150,
+      stops: ["#f0fdfa", "#ccfbf1"],
+      isDark: false,
+    },
+  },
+  {
+    id: "coral-reef",
+    name: "Coral Reef",
+    tags: ["light", "beach", "tropical", "warm"],
+    palette: ["#0284c7", "#c2410c", "#0d9488", "#9333ea", "#e11d48"],
+    background: {
+      type: "gradient",
+      angle: 135,
+      stops: ["#fff1f2", "#ffe4e6", "#fce7f3"],
+      isDark: false,
+    },
+  },
+
+  // --- Bold / Vibrant themes ---
+  {
+    id: "neon",
+    name: "Neon",
+    tags: ["dark", "bold", "city"],
+    palette: ["#22d3ee", "#facc15", "#4ade80", "#e879f9", "#f43f5e"],
+    background: {
+      type: "gradient",
+      angle: 135,
+      stops: ["#18181b", "#27272a"],
+      isDark: true,
+    },
+  },
+  {
+    id: "carnival",
+    name: "Carnival",
+    tags: ["light", "bold", "festive"],
+    palette: ["#2563eb", "#dc2626", "#16a34a", "#9333ea", "#ea580c"],
+    background: {
+      type: "gradient",
+      angle: 135,
+      stops: ["#fef9c3", "#fef3c7", "#ffedd5"],
+      isDark: false,
+    },
+  },
+  {
+    id: "electric",
+    name: "Electric",
+    tags: ["dark", "bold"],
+    palette: ["#06b6d4", "#eab308", "#22c55e", "#d946ef", "#f97316"],
+    background: {
+      type: "gradient",
+      angle: 145,
+      stops: ["#0a0a0a", "#1a1a2e"],
+      isDark: true,
+    },
+  },
+
+  // --- Pastel / Soft themes ---
+  {
+    id: "lavender",
+    name: "Lavender",
+    tags: ["light", "pastel", "cool"],
+    palette: ["#6366f1", "#e879f9", "#14b8a6", "#8b5cf6", "#a855f7"],
+    background: {
+      type: "gradient",
+      angle: 135,
+      stops: ["#f5f3ff", "#ede9fe"],
+      isDark: false,
+    },
+  },
+  {
+    id: "peach",
+    name: "Peach",
+    tags: ["light", "pastel", "warm"],
+    palette: ["#3b82f6", "#f97316", "#10b981", "#a855f7", "#f43f5e"],
+    background: {
+      type: "gradient",
+      angle: 145,
+      stops: ["#fff7ed", "#fef3c7"],
+      isDark: false,
+    },
+  },
+
+  // --- Festive / Seasonal themes ---
+  {
+    id: "winter-lodge",
+    name: "Winter Lodge",
+    tags: ["dark", "snow", "festive", "cool"],
+    palette: ["#93c5fd", "#fcd34d", "#6ee7b7", "#d8b4fe", "#f9a8d4"],
+    background: {
+      type: "gradient",
+      angle: 160,
+      stops: ["#1e293b", "#334155"],
+      isDark: true,
+    },
+  },
+  {
+    id: "holiday",
+    name: "Holiday",
+    tags: ["light", "festive", "warm"],
+    palette: ["#1d4ed8", "#dc2626", "#15803d", "#9333ea", "#b91c1c"],
+    background: {
+      type: "gradient",
+      angle: 135,
+      stops: ["#fef2f2", "#f0fdf4"],
+      isDark: false,
+    },
+  },
+];
+
+/**
+ * Tuple of all theme preset IDs, suitable for use with z.enum().
+ * Cast as non-empty tuple to satisfy Zod's requirement.
+ */
+export const THEME_IDS = THEME_PRESETS.map((t) => t.id) as [
+  string,
+  ...string[],
+];

--- a/shared/config/themes.ts
+++ b/shared/config/themes.ts
@@ -3,7 +3,7 @@
 import type { ThemePreset } from "../types/theme";
 
 /**
- * ~20 curated theme presets spanning multiple visual categories.
+ * 6 curated theme presets: 3 dark + 3 light.
  * Each preset includes a background style and 5-color palette:
  *   [0] travel, [1] meal, [2] activity, [3] accommodation, [4] highlight
  *
@@ -14,7 +14,7 @@ export const THEME_PRESETS: ThemePreset[] = [
   {
     id: "midnight",
     name: "Midnight",
-    tags: ["dark", "city"],
+    tags: ["dark"],
     palette: ["#60a5fa", "#fbbf24", "#34d399", "#c084fc", "#f472b6"],
     background: {
       type: "gradient",
@@ -24,33 +24,9 @@ export const THEME_PRESETS: ThemePreset[] = [
     },
   },
   {
-    id: "deep-ocean",
-    name: "Deep Ocean",
-    tags: ["dark", "cool"],
-    palette: ["#38bdf8", "#fb923c", "#2dd4bf", "#a78bfa", "#22d3ee"],
-    background: {
-      type: "gradient",
-      angle: 180,
-      stops: ["#0c1426", "#0e2a47", "#0a1628"],
-      isDark: true,
-    },
-  },
-  {
-    id: "aurora",
-    name: "Aurora",
-    tags: ["dark", "nature", "bold"],
-    palette: ["#67e8f9", "#fcd34d", "#6ee7b7", "#d8b4fe", "#a78bfa"],
-    background: {
-      type: "gradient",
-      angle: 160,
-      stops: ["#0f172a", "#1a2e44", "#162e2e"],
-      isDark: true,
-    },
-  },
-  {
     id: "noir",
     name: "Noir",
-    tags: ["dark", "city", "bold"],
+    tags: ["dark"],
     palette: ["#f9a8d4", "#fde68a", "#86efac", "#c4b5fd", "#fb7185"],
     background: {
       type: "solid",
@@ -58,35 +34,24 @@ export const THEME_PRESETS: ThemePreset[] = [
       isDark: true,
     },
   },
+  {
+    id: "sunset-beach",
+    name: "Sunset Beach",
+    tags: ["dark"],
+    palette: ["#38bdf8", "#fbbf24", "#34d399", "#e879f9", "#fb923c"],
+    background: {
+      type: "gradient",
+      angle: 180,
+      stops: ["#431407", "#7c2d12", "#1c1917"],
+      isDark: true,
+    },
+  },
 
   // --- Light themes ---
   {
-    id: "cotton-candy",
-    name: "Cotton Candy",
-    tags: ["light", "pastel"],
-    palette: ["#818cf8", "#f472b6", "#34d399", "#a78bfa", "#ec4899"],
-    background: {
-      type: "gradient",
-      angle: 135,
-      stops: ["#fdf2f8", "#ede9fe", "#f0f9ff"],
-      isDark: false,
-    },
-  },
-  {
-    id: "vanilla",
-    name: "Vanilla",
-    tags: ["light", "warm"],
-    palette: ["#2563eb", "#d97706", "#059669", "#9333ea", "#e11d48"],
-    background: {
-      type: "solid",
-      color: "#fefce8",
-      isDark: false,
-    },
-  },
-  {
     id: "cloud",
     name: "Cloud",
-    tags: ["light", "cool"],
+    tags: ["light"],
     palette: ["#3b82f6", "#f59e0b", "#10b981", "#8b5cf6", "#6366f1"],
     background: {
       type: "gradient",
@@ -96,214 +61,25 @@ export const THEME_PRESETS: ThemePreset[] = [
     },
   },
   {
+    id: "cotton-candy",
+    name: "Cotton Candy",
+    tags: ["light"],
+    palette: ["#818cf8", "#f472b6", "#34d399", "#a78bfa", "#ec4899"],
+    background: {
+      type: "gradient",
+      angle: 135,
+      stops: ["#fdf2f8", "#ede9fe", "#f0f9ff"],
+      isDark: false,
+    },
+  },
+  {
     id: "linen",
     name: "Linen",
-    tags: ["light", "warm", "vintage"],
+    tags: ["light"],
     palette: ["#7c3aed", "#b45309", "#047857", "#9333ea", "#be185d"],
     background: {
       type: "solid",
       color: "#faf5f0",
-      isDark: false,
-    },
-  },
-  {
-    id: "paper",
-    name: "Paper",
-    tags: ["light", "cool"],
-    palette: ["#2563eb", "#ea580c", "#0d9488", "#7c3aed", "#0284c7"],
-    background: {
-      type: "solid",
-      color: "#f8fafc",
-      isDark: false,
-    },
-  },
-
-  // --- Nature / Earthy themes ---
-  {
-    id: "forest",
-    name: "Forest",
-    tags: ["dark", "nature", "earthy"],
-    palette: ["#86efac", "#fbbf24", "#5eead4", "#c084fc", "#4ade80"],
-    background: {
-      type: "gradient",
-      angle: 170,
-      stops: ["#14261c", "#1a3a2a"],
-      isDark: true,
-    },
-  },
-  {
-    id: "desert",
-    name: "Desert",
-    tags: ["light", "nature", "earthy", "warm"],
-    palette: ["#0369a1", "#c2410c", "#15803d", "#7e22ce", "#dc2626"],
-    background: {
-      type: "gradient",
-      angle: 135,
-      stops: ["#fef3c7", "#fed7aa", "#fef3c7"],
-      isDark: false,
-    },
-  },
-  {
-    id: "moss",
-    name: "Moss",
-    tags: ["light", "nature", "earthy"],
-    palette: ["#1d4ed8", "#ca8a04", "#15803d", "#6d28d9", "#059669"],
-    background: {
-      type: "gradient",
-      angle: 160,
-      stops: ["#f0fdf4", "#ecfdf5"],
-      isDark: false,
-    },
-  },
-  {
-    id: "clay",
-    name: "Clay",
-    tags: ["light", "earthy", "warm"],
-    palette: ["#1e40af", "#92400e", "#166534", "#7e22ce", "#b91c1c"],
-    background: {
-      type: "gradient",
-      angle: 145,
-      stops: ["#fef2f2", "#fef9ee"],
-      isDark: false,
-    },
-  },
-
-  // --- Beach / Tropical themes ---
-  {
-    id: "turquoise-coast",
-    name: "Turquoise Coast",
-    tags: ["light", "beach", "tropical"],
-    palette: ["#0284c7", "#ea580c", "#0d9488", "#7c3aed", "#0891b2"],
-    background: {
-      type: "gradient",
-      angle: 135,
-      stops: ["#ecfeff", "#cffafe", "#e0f2fe"],
-      isDark: false,
-    },
-  },
-  {
-    id: "sunset-beach",
-    name: "Sunset Beach",
-    tags: ["dark", "beach", "warm"],
-    palette: ["#38bdf8", "#fbbf24", "#34d399", "#e879f9", "#fb923c"],
-    background: {
-      type: "gradient",
-      angle: 180,
-      stops: ["#431407", "#7c2d12", "#1c1917"],
-      isDark: true,
-    },
-  },
-  {
-    id: "lagoon",
-    name: "Lagoon",
-    tags: ["light", "beach", "tropical", "cool"],
-    palette: ["#0369a1", "#d97706", "#047857", "#7c3aed", "#0e7490"],
-    background: {
-      type: "gradient",
-      angle: 150,
-      stops: ["#f0fdfa", "#ccfbf1"],
-      isDark: false,
-    },
-  },
-  {
-    id: "coral-reef",
-    name: "Coral Reef",
-    tags: ["light", "beach", "tropical", "warm"],
-    palette: ["#0284c7", "#c2410c", "#0d9488", "#9333ea", "#e11d48"],
-    background: {
-      type: "gradient",
-      angle: 135,
-      stops: ["#fff1f2", "#ffe4e6", "#fce7f3"],
-      isDark: false,
-    },
-  },
-
-  // --- Bold / Vibrant themes ---
-  {
-    id: "neon",
-    name: "Neon",
-    tags: ["dark", "bold", "city"],
-    palette: ["#22d3ee", "#facc15", "#4ade80", "#e879f9", "#f43f5e"],
-    background: {
-      type: "gradient",
-      angle: 135,
-      stops: ["#18181b", "#27272a"],
-      isDark: true,
-    },
-  },
-  {
-    id: "carnival",
-    name: "Carnival",
-    tags: ["light", "bold", "festive"],
-    palette: ["#2563eb", "#dc2626", "#16a34a", "#9333ea", "#ea580c"],
-    background: {
-      type: "gradient",
-      angle: 135,
-      stops: ["#fef9c3", "#fef3c7", "#ffedd5"],
-      isDark: false,
-    },
-  },
-  {
-    id: "electric",
-    name: "Electric",
-    tags: ["dark", "bold"],
-    palette: ["#06b6d4", "#eab308", "#22c55e", "#d946ef", "#f97316"],
-    background: {
-      type: "gradient",
-      angle: 145,
-      stops: ["#0a0a0a", "#1a1a2e"],
-      isDark: true,
-    },
-  },
-
-  // --- Pastel / Soft themes ---
-  {
-    id: "lavender",
-    name: "Lavender",
-    tags: ["light", "pastel", "cool"],
-    palette: ["#6366f1", "#e879f9", "#14b8a6", "#8b5cf6", "#a855f7"],
-    background: {
-      type: "gradient",
-      angle: 135,
-      stops: ["#f5f3ff", "#ede9fe"],
-      isDark: false,
-    },
-  },
-  {
-    id: "peach",
-    name: "Peach",
-    tags: ["light", "pastel", "warm"],
-    palette: ["#3b82f6", "#f97316", "#10b981", "#a855f7", "#f43f5e"],
-    background: {
-      type: "gradient",
-      angle: 145,
-      stops: ["#fff7ed", "#fef3c7"],
-      isDark: false,
-    },
-  },
-
-  // --- Festive / Seasonal themes ---
-  {
-    id: "winter-lodge",
-    name: "Winter Lodge",
-    tags: ["dark", "snow", "festive", "cool"],
-    palette: ["#93c5fd", "#fcd34d", "#6ee7b7", "#d8b4fe", "#f9a8d4"],
-    background: {
-      type: "gradient",
-      angle: 160,
-      stops: ["#1e293b", "#334155"],
-      isDark: true,
-    },
-  },
-  {
-    id: "holiday",
-    name: "Holiday",
-    tags: ["light", "festive", "warm"],
-    palette: ["#1d4ed8", "#dc2626", "#15803d", "#9333ea", "#b91c1c"],
-    background: {
-      type: "gradient",
-      angle: 135,
-      stops: ["#fef2f2", "#f0fdf4"],
       isDark: false,
     },
   },

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -42,3 +42,17 @@ export type {
 
 // Utils
 export { convertToUTC, formatInTimeZone } from "./utils/index";
+export {
+  hexToHsl,
+  hslToHex,
+  derivePaletteVariants,
+  readableForeground,
+} from "./utils/index";
+
+// Config
+export { THEME_PRESETS, THEME_IDS } from "./config/index";
+export { THEME_FONTS, FONT_DISPLAY_NAMES } from "./config/index";
+
+// Theme types (re-exported for convenience)
+export { THEME_FONT_VALUES } from "./types/index";
+export type { ThemeFont, ThemeBackground, ThemePreset } from "./types/index";

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -46,6 +46,7 @@ export {
   hexToHsl,
   hslToHex,
   derivePaletteVariants,
+  deriveDarkPaletteVariants,
   readableForeground,
 } from "./utils/index";
 

--- a/shared/package.json
+++ b/shared/package.json
@@ -8,7 +8,8 @@
     ".": "./index.ts",
     "./types": "./types/index.ts",
     "./schemas": "./schemas/index.ts",
-    "./utils": "./utils/index.ts"
+    "./utils": "./utils/index.ts",
+    "./config": "./config/index.ts"
   },
   "scripts": {
     "build": "tsc",

--- a/shared/schemas/trip.ts
+++ b/shared/schemas/trip.ts
@@ -3,6 +3,8 @@
 import { z } from "zod";
 import { phoneNumberSchema } from "./phone";
 import { stripControlChars } from "../utils/sanitize";
+import { THEME_IDS } from "../config/themes";
+import { THEME_FONT_VALUES } from "../types/theme";
 
 /**
  * Validates IANA timezone strings using Intl.supportedValuesOf
@@ -75,6 +77,8 @@ const baseTripSchema = z.object({
   allowMembersToAddEvents: z.boolean().default(true),
   showAllMembers: z.boolean().default(false),
   coOrganizerPhones: z.array(phoneNumberSchema).optional(),
+  themeId: z.enum(THEME_IDS).nullable().optional(),
+  themeFont: z.enum(THEME_FONT_VALUES).nullable().optional(),
 });
 
 /**
@@ -158,6 +162,8 @@ const tripEntitySchema = z.object({
   preferredTimezone: z.string(),
   description: z.string().nullable(),
   coverImageUrl: z.string().nullable(),
+  themeId: z.string().nullable(),
+  themeFont: z.string().nullable(),
   createdBy: z.string(),
   allowMembersToAddEvents: z.boolean(),
   showAllMembers: z.boolean(),
@@ -181,6 +187,8 @@ const tripSummarySchema = z.object({
   startDate: z.string().nullable(),
   endDate: z.string().nullable(),
   coverImageUrl: z.string().nullable(),
+  themeId: z.string().nullable(),
+  themeFont: z.string().nullable(),
   isOrganizer: z.boolean(),
   rsvpStatus: z.enum(["going", "not_going", "maybe", "no_response"]),
   organizerInfo: z.array(organizerInfoSchema),

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -120,3 +120,11 @@ export type {
 
 // Re-export mutuals types
 export type { Mutual, GetMutualsResponse } from "./mutuals";
+
+// Re-export theme types
+export { THEME_FONT_VALUES } from "./theme";
+export type {
+  ThemeFont,
+  ThemeBackground,
+  ThemePreset,
+} from "./theme";

--- a/shared/types/theme.ts
+++ b/shared/types/theme.ts
@@ -1,0 +1,43 @@
+// Theme-related types for the Tripful platform
+
+/**
+ * Available font options for trip themes.
+ * Each value maps to a Google Font loaded in the web app.
+ */
+export const THEME_FONT_VALUES = [
+  "plus-jakarta", // already loaded — default clean sans
+  "playfair", // already loaded — elegant serif
+  "space-grotesk", // already loaded — techy accent
+  "nunito", // to add — playful/rounded
+  "caveat", // to add — handwritten
+  "oswald", // to add — bold/condensed
+] as const;
+
+/** Font identifier type derived from available font options */
+export type ThemeFont = (typeof THEME_FONT_VALUES)[number];
+
+/**
+ * Discriminated union for theme backgrounds.
+ * `isDark` determines whether overlaid text should be white (true) or dark (false).
+ */
+export type ThemeBackground =
+  | { type: "solid"; color: string; isDark: boolean }
+  | { type: "gradient"; angle: number; stops: string[]; isDark: boolean }
+  | { type: "image"; url: string; isDark: boolean };
+
+/**
+ * A curated theme preset with background and 5-color palette.
+ * Presets are defined in shared config and referenced by ID in the database.
+ */
+export interface ThemePreset {
+  /** Unique preset identifier (kebab-case) */
+  id: string;
+  /** Human-readable display name */
+  name: string;
+  /** Categorization tags for filtering/grouping */
+  tags: string[];
+  /** 5 hex color strings: [travel, meal, activity, accommodation, highlight] */
+  palette: string[];
+  /** Background style with dark/light indicator */
+  background: ThemeBackground;
+}

--- a/shared/types/trip.ts
+++ b/shared/types/trip.ts
@@ -27,6 +27,10 @@ export interface Trip {
   allowMembersToAddEvents: boolean;
   /** Whether all members are visible to each other (vs only organizers visible) */
   showAllMembers: boolean;
+  /** Theme preset ID (references THEME_PRESETS, not a DB FK) */
+  themeId: string | null;
+  /** Font choice, independent of theme */
+  themeFont: string | null;
   /** Whether the trip has been cancelled (soft delete) */
   cancelled: boolean;
   /** Trip creation timestamp */
@@ -52,6 +56,10 @@ export interface TripSummary {
   endDate: string | null;
   /** Optional cover image URL */
   coverImageUrl: string | null;
+  /** Theme preset ID */
+  themeId: string | null;
+  /** Font choice */
+  themeFont: string | null;
   /** Whether the current user is an organizer of this trip */
   isOrganizer: boolean;
   /** Current user's RSVP status for this trip */

--- a/shared/utils/color-utils.test.ts
+++ b/shared/utils/color-utils.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect } from "vitest";
+import {
+  hexToHsl,
+  hslToHex,
+  derivePaletteVariants,
+  readableForeground,
+} from "./color-utils";
+
+describe("hexToHsl", () => {
+  it("should convert pure red", () => {
+    expect(hexToHsl("#ff0000")).toEqual([0, 100, 50]);
+  });
+
+  it("should convert pure green", () => {
+    expect(hexToHsl("#00ff00")).toEqual([120, 100, 50]);
+  });
+
+  it("should convert pure blue", () => {
+    expect(hexToHsl("#0000ff")).toEqual([240, 100, 50]);
+  });
+
+  it("should convert white", () => {
+    expect(hexToHsl("#ffffff")).toEqual([0, 0, 100]);
+  });
+
+  it("should convert black", () => {
+    expect(hexToHsl("#000000")).toEqual([0, 0, 0]);
+  });
+
+  it("should handle hex without # prefix", () => {
+    expect(hexToHsl("ff0000")).toEqual([0, 100, 50]);
+    expect(hexToHsl("00ff00")).toEqual([120, 100, 50]);
+  });
+
+  it("should handle 3-character hex", () => {
+    expect(hexToHsl("#f00")).toEqual([0, 100, 50]);
+    expect(hexToHsl("#0f0")).toEqual([120, 100, 50]);
+    expect(hexToHsl("#00f")).toEqual([240, 100, 50]);
+    expect(hexToHsl("#fff")).toEqual([0, 0, 100]);
+    expect(hexToHsl("#000")).toEqual([0, 0, 0]);
+  });
+
+  it("should handle 3-character hex without # prefix", () => {
+    expect(hexToHsl("f00")).toEqual([0, 100, 50]);
+  });
+
+  it("should convert a mid-range color", () => {
+    // #2563eb is a blue (roughly hue 217, sat 84, light 53)
+    const [h, s, l] = hexToHsl("#2563eb");
+    expect(h).toBeGreaterThanOrEqual(215);
+    expect(h).toBeLessThanOrEqual(225);
+    expect(s).toBeGreaterThanOrEqual(80);
+    expect(s).toBeLessThanOrEqual(90);
+    expect(l).toBeGreaterThanOrEqual(50);
+    expect(l).toBeLessThanOrEqual(56);
+  });
+
+  it("should convert gray colors (zero saturation)", () => {
+    const [, s] = hexToHsl("#808080");
+    expect(s).toBe(0);
+  });
+});
+
+describe("hslToHex", () => {
+  it("should convert known HSL values to hex", () => {
+    expect(hslToHex(0, 100, 50)).toBe("#ff0000");
+    expect(hslToHex(120, 100, 50)).toBe("#00ff00");
+    expect(hslToHex(240, 100, 50)).toBe("#0000ff");
+  });
+
+  it("should convert white and black", () => {
+    expect(hslToHex(0, 0, 100)).toBe("#ffffff");
+    expect(hslToHex(0, 0, 0)).toBe("#000000");
+  });
+
+  it("should handle zero saturation (grays)", () => {
+    const gray = hslToHex(0, 0, 50);
+    // Should be a mid-gray
+    expect(gray).toBe("#808080");
+  });
+
+  it("should produce valid 7-character hex strings", () => {
+    const result = hslToHex(210, 50, 60);
+    expect(result).toMatch(/^#[0-9a-f]{6}$/);
+  });
+
+  it("should roundtrip with hexToHsl for primary colors", () => {
+    const colors = ["#ff0000", "#00ff00", "#0000ff", "#ffffff", "#000000"];
+    for (const color of colors) {
+      const [h, s, l] = hexToHsl(color);
+      expect(hslToHex(h, s, l)).toBe(color);
+    }
+  });
+
+  it("should roundtrip with hexToHsl for arbitrary colors", () => {
+    // Due to rounding, roundtrip may differ by 1-2 in each RGB channel.
+    // We test that the result is close rather than exact.
+    const colors = ["#2563eb", "#d97706", "#059669", "#9333ea", "#6b7280"];
+    for (const color of colors) {
+      const [h, s, l] = hexToHsl(color);
+      const roundtripped = hslToHex(h, s, l);
+
+      // Parse both and compare channels within tolerance
+      const parseHex = (hex: string) => {
+        const n = hex.replace("#", "");
+        return [
+          parseInt(n.slice(0, 2), 16),
+          parseInt(n.slice(2, 4), 16),
+          parseInt(n.slice(4, 6), 16),
+        ];
+      };
+
+      const [r1 = 0, g1 = 0, b1 = 0] = parseHex(color);
+      const [r2 = 0, g2 = 0, b2 = 0] = parseHex(roundtripped);
+
+      expect(Math.abs(r1 - r2)).toBeLessThanOrEqual(2);
+      expect(Math.abs(g1 - g2)).toBeLessThanOrEqual(2);
+      expect(Math.abs(b1 - b2)).toBeLessThanOrEqual(2);
+    }
+  });
+
+  it("should handle edge hue values", () => {
+    // Hue 0 and 360 should produce the same color
+    expect(hslToHex(0, 100, 50)).toBe(hslToHex(360, 100, 50));
+  });
+});
+
+describe("derivePaletteVariants", () => {
+  it("should return an object with base, light, and border keys", () => {
+    const result = derivePaletteVariants("#2563eb");
+    expect(result).toHaveProperty("base");
+    expect(result).toHaveProperty("light");
+    expect(result).toHaveProperty("border");
+  });
+
+  it("should return valid hex color strings", () => {
+    const result = derivePaletteVariants("#2563eb");
+    const hexPattern = /^#[0-9a-f]{6}$/;
+    expect(result.base).toMatch(hexPattern);
+    expect(result.light).toMatch(hexPattern);
+    expect(result.border).toMatch(hexPattern);
+  });
+
+  it("should preserve the base color", () => {
+    const result = derivePaletteVariants("#2563eb");
+    expect(result.base).toBe("#2563eb");
+  });
+
+  it("should preserve the base color when input lacks # prefix", () => {
+    const result = derivePaletteVariants("2563eb");
+    expect(result.base).toBe("#2563eb");
+  });
+
+  it("should produce a very light variant (high lightness)", () => {
+    const result = derivePaletteVariants("#2563eb");
+    const [, , lightL] = hexToHsl(result.light);
+    expect(lightL).toBeGreaterThanOrEqual(93);
+    expect(lightL).toBeLessThanOrEqual(100);
+  });
+
+  it("should produce a border lighter than base but darker than light", () => {
+    const result = derivePaletteVariants("#2563eb");
+    const [, , baseL] = hexToHsl(result.base);
+    const [, , borderL] = hexToHsl(result.border);
+    const [, , lightL] = hexToHsl(result.light);
+
+    expect(borderL).toBeGreaterThan(baseL);
+    expect(borderL).toBeLessThan(lightL);
+  });
+
+  it("should preserve hue across all variants", () => {
+    const result = derivePaletteVariants("#2563eb");
+    const [baseH] = hexToHsl(result.base);
+    const [lightH] = hexToHsl(result.light);
+    const [borderH] = hexToHsl(result.border);
+
+    // Hue should be within a few degrees (rounding in HSL conversion can shift by up to 5)
+    expect(Math.abs(baseH - lightH)).toBeLessThanOrEqual(5);
+    expect(Math.abs(baseH - borderH)).toBeLessThanOrEqual(5);
+  });
+
+  it("should produce subtle tints for theme colors from the plan", () => {
+    // Blue: #2563eb
+    const blue = derivePaletteVariants("#2563eb");
+    const [, , blueLL] = hexToHsl(blue.light);
+    expect(blueLL).toBeGreaterThanOrEqual(93);
+
+    // Amber: #d97706
+    const amber = derivePaletteVariants("#d97706");
+    const [amberH] = hexToHsl(amber.light);
+    const [amberBaseH] = hexToHsl("#d97706");
+    expect(Math.abs(amberH - amberBaseH)).toBeLessThanOrEqual(3);
+
+    // Green: #059669
+    const green = derivePaletteVariants("#059669");
+    const [, , greenLL] = hexToHsl(green.light);
+    expect(greenLL).toBeGreaterThanOrEqual(93);
+
+    // Purple: #9333ea
+    const purple = derivePaletteVariants("#9333ea");
+    const [, , purpleBL] = hexToHsl(purple.border);
+    expect(purpleBL).toBeGreaterThanOrEqual(84);
+    expect(purpleBL).toBeLessThanOrEqual(90);
+  });
+
+  it("should work with achromatic colors", () => {
+    // Gray has no hue, should still produce valid variants
+    const result = derivePaletteVariants("#6b7280");
+    expect(result.light).toMatch(/^#[0-9a-f]{6}$/);
+    expect(result.border).toMatch(/^#[0-9a-f]{6}$/);
+  });
+});
+
+describe("readableForeground", () => {
+  it("should return black text for white background", () => {
+    expect(readableForeground("#ffffff")).toBe("#000000");
+  });
+
+  it("should return white text for black background", () => {
+    expect(readableForeground("#000000")).toBe("#ffffff");
+  });
+
+  it("should return white text for dark blue", () => {
+    expect(readableForeground("#0f172a")).toBe("#ffffff");
+  });
+
+  it("should return black text for light yellow", () => {
+    expect(readableForeground("#fffbeb")).toBe("#000000");
+  });
+
+  it("should return white text for dark colors", () => {
+    expect(readableForeground("#1e293b")).toBe("#ffffff"); // slate-800
+    expect(readableForeground("#1a1a1a")).toBe("#ffffff"); // near-black
+    expect(readableForeground("#7c3aed")).toBe("#ffffff"); // violet-600
+  });
+
+  it("should return black text for light colors", () => {
+    expect(readableForeground("#f8fafc")).toBe("#000000"); // slate-50
+    expect(readableForeground("#eff6ff")).toBe("#000000"); // blue-50
+    expect(readableForeground("#fbbf24")).toBe("#000000"); // amber-400
+  });
+
+  it("should handle 3-character hex", () => {
+    expect(readableForeground("#fff")).toBe("#000000");
+    expect(readableForeground("#000")).toBe("#ffffff");
+  });
+
+  it("should handle hex without # prefix", () => {
+    expect(readableForeground("ffffff")).toBe("#000000");
+    expect(readableForeground("000000")).toBe("#ffffff");
+  });
+
+  it("should handle mid-range grays", () => {
+    // #808080 has luminance ~0.216 which is above the 0.179 threshold
+    expect(readableForeground("#808080")).toBe("#000000");
+    // #6b6b6b has luminance ~0.139 which is below the 0.179 threshold
+    expect(readableForeground("#5a5a5a")).toBe("#ffffff");
+  });
+});

--- a/shared/utils/color-utils.ts
+++ b/shared/utils/color-utils.ts
@@ -1,0 +1,160 @@
+/**
+ * Color utility functions for theme palette derivation.
+ * Pure functions with no external dependencies.
+ */
+
+/**
+ * Expand a 3-character hex string to 6 characters.
+ * e.g., "f0a" → "ff00aa"
+ */
+function expandShortHex(hex: string): string {
+  if (hex.length === 3) {
+    return hex.charAt(0) + hex.charAt(0) + hex.charAt(1) + hex.charAt(1) + hex.charAt(2) + hex.charAt(2);
+  }
+  return hex;
+}
+
+/**
+ * Parse a hex color string into RGB components (0-255).
+ * Accepts "#abc", "abc", "#aabbcc", or "aabbcc".
+ */
+function parseHex(hex: string): [number, number, number] {
+  const normalized = expandShortHex(hex.replace("#", ""));
+  const r = parseInt(normalized.slice(0, 2), 16);
+  const g = parseInt(normalized.slice(2, 4), 16);
+  const b = parseInt(normalized.slice(4, 6), 16);
+  return [r, g, b];
+}
+
+/**
+ * Convert hex color to HSL values.
+ * @param hex - Hex color string (e.g., "#2563eb", "2563eb", "#f00")
+ * @returns [h, s, l] where h is 0-360, s and l are 0-100
+ */
+export function hexToHsl(hex: string): [number, number, number] {
+  const [ri, gi, bi] = parseHex(hex);
+  const r = ri / 255;
+  const g = gi / 255;
+  const b = bi / 255;
+
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+
+  if (max === min) {
+    return [0, 0, Math.round(l * 100)];
+  }
+
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+
+  let h = 0;
+  if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+  else if (max === g) h = ((b - r) / d + 2) / 6;
+  else h = ((r - g) / d + 4) / 6;
+
+  return [Math.round(h * 360), Math.round(s * 100), Math.round(l * 100)];
+}
+
+/**
+ * Convert HSL values to hex color string.
+ * @param h - Hue (0-360)
+ * @param s - Saturation (0-100)
+ * @param l - Lightness (0-100)
+ * @returns Hex color string with # prefix
+ */
+export function hslToHex(h: number, s: number, l: number): string {
+  const sNorm = s / 100;
+  const lNorm = l / 100;
+
+  const c = (1 - Math.abs(2 * lNorm - 1)) * sNorm;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = lNorm - c / 2;
+
+  let r = 0,
+    g = 0,
+    b = 0;
+
+  if (h < 60) {
+    r = c;
+    g = x;
+  } else if (h < 120) {
+    r = x;
+    g = c;
+  } else if (h < 180) {
+    g = c;
+    b = x;
+  } else if (h < 240) {
+    g = x;
+    b = c;
+  } else if (h < 300) {
+    r = x;
+    b = c;
+  } else {
+    r = c;
+    b = x;
+  }
+
+  const toHex = (v: number) =>
+    Math.round((v + m) * 255)
+      .toString(16)
+      .padStart(2, "0");
+
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+/**
+ * Derive light background and border variants from a base color.
+ * Used to generate the *-light and *-border CSS variable values.
+ * @param hex - Base hex color
+ * @returns { base, light, border } hex strings
+ */
+export function derivePaletteVariants(hex: string): {
+  base: string;
+  light: string;
+  border: string;
+} {
+  const [h] = hexToHsl(hex);
+
+  // light: same hue, low saturation (~18%), very high lightness (~96%)
+  // Produces a subtle tinted background (e.g., #2563eb → pale blue like #eff6ff)
+  const light = hslToHex(h, 18, 96);
+
+  // border: same hue, medium saturation (~45%), high lightness (~87%)
+  // Produces a medium-pale tint (e.g., #2563eb → medium blue like #bfdbfe)
+  const border = hslToHex(h, 45, 87);
+
+  return {
+    base: hex.startsWith("#") ? hex : `#${hex}`,
+    light,
+    border,
+  };
+}
+
+/**
+ * Calculate the WCAG 2.0 relative luminance of a color from RGB components (0-255).
+ */
+function relativeLuminance(r: number, g: number, b: number): number {
+  const linearize = (c: number) => {
+    const sRGB = c / 255;
+    return sRGB <= 0.03928
+      ? sRGB / 12.92
+      : Math.pow((sRGB + 0.055) / 1.055, 2.4);
+  };
+
+  return 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b);
+}
+
+/**
+ * Determine readable foreground color (black or white) for a given background.
+ * Uses WCAG relative luminance formula.
+ * @param hex - Background hex color
+ * @returns "#000000" or "#ffffff"
+ */
+export function readableForeground(hex: string): string {
+  const [r, g, b] = parseHex(hex);
+  const lum = relativeLuminance(r, g, b);
+  // Threshold of 0.179 corresponds roughly to the midpoint where
+  // white text has better contrast than black text
+  return lum > 0.179 ? "#000000" : "#ffffff";
+}

--- a/shared/utils/color-utils.ts
+++ b/shared/utils/color-utils.ts
@@ -132,6 +132,34 @@ export function derivePaletteVariants(hex: string): {
 }
 
 /**
+ * Derive dark background and border variants from a base color.
+ * Used for event cards on dark theme backgrounds.
+ * @param hex - Base hex color
+ * @returns { base, light, border } hex strings
+ */
+export function deriveDarkPaletteVariants(hex: string): {
+  base: string;
+  light: string;
+  border: string;
+} {
+  const [h] = hexToHsl(hex);
+
+  // light: same hue, moderate saturation, very low lightness
+  // Produces a subtle dark-tinted background
+  const light = hslToHex(h, 25, 14);
+
+  // border: same hue, moderate saturation, low-medium lightness
+  // Produces a slightly visible colored border
+  const border = hslToHex(h, 30, 25);
+
+  return {
+    base: hex.startsWith("#") ? hex : `#${hex}`,
+    light,
+    border,
+  };
+}
+
+/**
  * Calculate the WCAG 2.0 relative luminance of a color from RGB components (0-255).
  */
 function relativeLuminance(r: number, g: number, b: number): number {

--- a/shared/utils/index.ts
+++ b/shared/utils/index.ts
@@ -36,3 +36,10 @@ export function formatInTimeZone(
 ): string {
   return formatInTz(date, timezone, format);
 }
+
+export {
+  hexToHsl,
+  hslToHex,
+  derivePaletteVariants,
+  readableForeground,
+} from "./color-utils";

--- a/shared/utils/index.ts
+++ b/shared/utils/index.ts
@@ -41,5 +41,6 @@ export {
   hexToHsl,
   hslToHex,
   derivePaletteVariants,
+  deriveDarkPaletteVariants,
   readableForeground,
 } from "./color-utils";


### PR DESCRIPTION
## Summary
- Adds trip theme system with 6 curated presets (3 dark, 3 light) stored as `themeId` + `themeFont` on the trips table
- Themes apply page-wide via CSS custom properties on the document root — covers header, content, dialogs, and itinerary cards
- Dark themes get adapted semantic tokens (foreground, card, border, muted) and dark-tinted event card backgrounds via `deriveDarkPaletteVariants`
- Theme picker in create/edit trip dialogs with visual preview, plus optional font picker (6 Google Fonts)
- Instant theme preview: selecting a theme in the create/edit dialog applies it to the page in real-time behind the dialog, with revert on cancel and persist on submit

## Test plan
- [ ] Create a trip with each of the 6 themes — verify hero, content area, header, and event cards all adapt correctly
- [ ] Verify dark themes have readable text (light foreground on dark background) and dark-tinted event cards
- [ ] Verify light themes have readable text and properly tinted event cards
- [ ] Switch between day-by-day and group-by-type views — check icons, dates, and card backgrounds
- [ ] Navigate away from a themed trip and back — verify theme applies/cleans up correctly
- [ ] Test with a cover image — theme background should only show in hero when no cover image
- [ ] Test "None" theme option — should revert to default styling
- [ ] Open create trip dialog → select a theme in step 2 → verify page background/colors change instantly behind the dialog
- [ ] Select "None" in create dialog → verify page returns to default look
- [ ] Close create dialog → verify page returns to default (no theme on list page)
- [ ] Open edit dialog for a themed trip → select different theme → verify page updates instantly
- [ ] Cancel edit dialog → verify page returns to the trip's original theme
- [ ] Select a new theme in edit dialog → submit → verify theme persists without flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)