### PR TITLE
Add tappable RSVP dropdown to trip detail

### DIFF
--- a/apps/web/src/app/(app)/trips/[id]/loading.tsx
+++ b/apps/web/src/app/(app)/trips/[id]/loading.tsx
@@ -15,7 +15,7 @@ export default function TripDetailLoading() {
           <Skeleton className="h-5 w-24" />
           <Skeleton className="h-5 w-20" />
         </div>
-        <Skeleton className="h-28 w-full rounded-2xl" />
+        <Skeleton className="h-28 w-full rounded-md" />
       </div>
     </div>
   );

--- a/apps/web/src/app/(app)/trips/[id]/trip-detail-content.tsx
+++ b/apps/web/src/app/(app)/trips/[id]/trip-detail-content.tsx
@@ -30,7 +30,7 @@ import type { MemberWithProfile } from "@/hooks/use-invitations";
 import { useAuth } from "@/app/providers/auth-provider";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { RsvpBadge } from "@/components/ui/rsvp-badge";
+import { RsvpBadgeDropdown } from "@/components/trip/rsvp-badge-dropdown";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Collapsible,
@@ -271,14 +271,13 @@ export function TripDetailContent({ tripId }: { tripId: string }) {
         )}
 
         {/* Badges overlay — top-left */}
-        <div className="absolute top-4 left-4 flex gap-2 z-10">
-          <RsvpBadge status={trip.userRsvpStatus} variant="overlay" />
-          {isOrganizer && (
+        {isOrganizer && (
+          <div className="absolute top-4 left-4 z-10">
             <Badge className="bg-black/50 backdrop-blur-md text-white border-white/20 shadow-sm">
               Organizing
             </Badge>
-          )}
-        </div>
+          </div>
+        )}
 
         {/* Bottom: title + metadata overlay */}
         <div className="absolute bottom-0 left-0 right-0 pb-5 sm:pb-6">
@@ -380,6 +379,7 @@ export function TripDetailContent({ tripId }: { tripId: string }) {
 
           {/* Stats */}
           <div className="flex flex-wrap items-center gap-x-6 gap-y-2 mb-6">
+            <RsvpBadgeDropdown tripId={trip.id} status={trip.userRsvpStatus} />
             <button
               onClick={() => setIsMembersOpen(true)}
               className="flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors cursor-pointer"

--- a/apps/web/src/app/(app)/trips/[id]/trip-detail-content.tsx
+++ b/apps/web/src/app/(app)/trips/[id]/trip-detail-content.tsx
@@ -270,6 +270,16 @@ export function TripDetailContent({ tripId }: { tripId: string }) {
           </Button>
         )}
 
+        {/* Badges overlay — top-left */}
+        <div className="absolute top-4 left-4 flex gap-2 z-10">
+          <RsvpBadge status={trip.userRsvpStatus} variant="overlay" />
+          {isOrganizer && (
+            <Badge className="bg-black/50 backdrop-blur-md text-white border-white/20 shadow-sm">
+              Organizing
+            </Badge>
+          )}
+        </div>
+
         {/* Bottom: title + metadata overlay */}
         <div className="absolute bottom-0 left-0 right-0 pb-5 sm:pb-6">
           <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -302,43 +312,34 @@ export function TripDetailContent({ tripId }: { tripId: string }) {
       {/* Content */}
       <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="mb-8">
-          {/* Badges */}
-          <div className="flex flex-wrap items-center gap-2 mb-6">
-            <RsvpBadge status={trip.userRsvpStatus} />
-            {isOrganizer && (
-              <Badge className="bg-gradient-to-r from-primary to-accent text-white">
-                Organizing
-              </Badge>
-            )}
-          </div>
-
           {/* Organizer actions */}
           {isOrganizer && (
-            <div className="flex items-center gap-3 rounded-md border border-primary/20 bg-primary/5 px-4 py-3 mb-6">
-              <span className="text-sm text-muted-foreground">
+            <div className="flex items-center justify-between rounded-md border border-primary/20 bg-primary/5 px-4 py-3 mb-6">
+              <span className="text-sm text-muted-foreground hidden sm:inline">
                 You&apos;re organizing this trip
               </span>
-              <span className="text-border">|</span>
-              <button
-                onClick={() => setIsInviteOpen(true)}
-                onMouseEnter={supportsHover ? preloadInviteMembersDialog : undefined}
-                onTouchStart={preloadInviteMembersDialog}
-                onFocus={preloadInviteMembersDialog}
-                className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:text-primary/80 transition-colors cursor-pointer"
-              >
-                <UserPlus className="w-3.5 h-3.5" />
-                Invite
-              </button>
-              <button
-                onClick={() => setIsEditOpen(true)}
-                onMouseEnter={supportsHover ? preloadEditTripDialog : undefined}
-                onTouchStart={preloadEditTripDialog}
-                onFocus={preloadEditTripDialog}
-                className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:text-primary/80 transition-colors cursor-pointer"
-              >
-                <Pencil className="w-3.5 h-3.5" />
-                Edit trip
-              </button>
+              <div className="flex items-center gap-3">
+                <button
+                  onClick={() => setIsInviteOpen(true)}
+                  onMouseEnter={supportsHover ? preloadInviteMembersDialog : undefined}
+                  onTouchStart={preloadInviteMembersDialog}
+                  onFocus={preloadInviteMembersDialog}
+                  className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:text-primary/80 transition-colors cursor-pointer"
+                >
+                  <UserPlus className="w-3.5 h-3.5" />
+                  Invite
+                </button>
+                <button
+                  onClick={() => setIsEditOpen(true)}
+                  onMouseEnter={supportsHover ? preloadEditTripDialog : undefined}
+                  onTouchStart={preloadEditTripDialog}
+                  onFocus={preloadEditTripDialog}
+                  className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:text-primary/80 transition-colors cursor-pointer"
+                >
+                  <Pencil className="w-3.5 h-3.5" />
+                  Edit trip
+                </button>
+              </div>
             </div>
           )}
 
@@ -427,20 +428,22 @@ export function TripDetailContent({ tripId }: { tripId: string }) {
             </Collapsible>
           ) : null}
         </div>
+      </div>
 
-        {/* Itinerary */}
-        <div
-          id="itinerary"
-          ref={itineraryRef as RefObject<HTMLDivElement>}
-          className="scroll-mt-14"
-        >
-          <ItineraryView
-            tripId={tripId}
-            onAddTravel={() => setShowOnboarding(true)}
-          />
-        </div>
+      {/* Itinerary — outside padded container so sticky header works */}
+      <div
+        id="itinerary"
+        ref={itineraryRef as RefObject<HTMLDivElement>}
+        className="scroll-mt-14"
+      >
+        <ItineraryView
+          tripId={tripId}
+          onAddTravel={() => setShowOnboarding(true)}
+        />
+      </div>
 
-        {/* Discussion */}
+      {/* Discussion */}
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="border-t border-border mt-6 pt-6">
           <ErrorBoundary>
             <TripMessages

--- a/apps/web/src/app/(app)/trips/[id]/trip-detail-content.tsx
+++ b/apps/web/src/app/(app)/trips/[id]/trip-detail-content.tsx
@@ -102,7 +102,7 @@ function SkeletonDetail() {
           <Skeleton className="h-5 w-24" />
           <Skeleton className="h-5 w-20" />
         </div>
-        <Skeleton className="h-28 w-full rounded-2xl" />
+        <Skeleton className="h-28 w-full rounded-md" />
       </div>
     </div>
   );
@@ -130,8 +130,7 @@ export function TripDetailContent({ tripId }: { tripId: string }) {
       data.map((m) => ({ id: m.id, userId: m.userId, isMuted: m.isMuted })),
   });
   const currentMember = members?.find((m) => m.userId === user?.id);
-  const { ref: itineraryRef, isRevealed: itineraryRevealed } =
-    useScrollReveal();
+  const { ref: itineraryRef } = useScrollReveal();
 
   const handleUpdateRole = (
     member: MemberWithProfile,
@@ -183,7 +182,7 @@ export function TripDetailContent({ tripId }: { tripId: string }) {
   if (isError || !trip) {
     return (
       <div className="min-h-screen bg-background flex items-center justify-center p-4">
-        <div className="bg-card rounded-2xl border border-destructive/30 p-8 text-center max-w-md">
+        <div className="bg-card rounded-md border border-destructive/30 p-8 text-center max-w-md">
           <AlertCircle className="w-12 h-12 text-destructive mx-auto mb-4" />
           <h2 className="text-2xl font-semibold text-foreground mb-2 font-accent">
             Trip not found
@@ -191,7 +190,7 @@ export function TripDetailContent({ tripId }: { tripId: string }) {
           <p className="text-muted-foreground mb-6">
             This trip doesn't exist or you don't have access to it.
           </p>
-          <Button variant="gradient" asChild className="h-12 px-8 rounded-xl">
+          <Button variant="gradient" asChild className="h-12 px-8 rounded-md">
             <Link href="/trips">Return to trips</Link>
           </Button>
         </div>
@@ -315,7 +314,7 @@ export function TripDetailContent({ tripId }: { tripId: string }) {
 
           {/* Organizer actions */}
           {isOrganizer && (
-            <div className="flex items-center gap-3 rounded-xl border border-primary/20 bg-primary/5 px-4 py-3 mb-6">
+            <div className="flex items-center gap-3 rounded-md border border-primary/20 bg-primary/5 px-4 py-3 mb-6">
               <span className="text-sm text-muted-foreground">
                 You&apos;re organizing this trip
               </span>
@@ -419,7 +418,7 @@ export function TripDetailContent({ tripId }: { tripId: string }) {
                 About this trip
               </CollapsibleTrigger>
               <CollapsibleContent forceMount className="overflow-hidden data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:h-0">
-                <div className="mt-3 bg-card rounded-2xl border border-border p-6">
+                <div className="mt-3 bg-card rounded-md border border-border p-6 linen-texture">
                   <p className="text-muted-foreground whitespace-pre-wrap">
                     {trip.description}
                   </p>
@@ -433,7 +432,7 @@ export function TripDetailContent({ tripId }: { tripId: string }) {
         <div
           id="itinerary"
           ref={itineraryRef as RefObject<HTMLDivElement>}
-          className={`scroll-mt-14 ${itineraryRevealed ? "motion-safe:animate-[revealScale_500ms_ease-out_both]" : "motion-safe:opacity-0"}`}
+          className="scroll-mt-14"
         >
           <ItineraryView
             tripId={tripId}

--- a/apps/web/src/app/(app)/trips/trips-content.test.tsx
+++ b/apps/web/src/app/(app)/trips/trips-content.test.tsx
@@ -284,7 +284,7 @@ describe("TripsContent", () => {
 
       renderWithClient(<TripsContent />);
 
-      expect(screen.getByText("No trips yet")).toBeDefined();
+      expect(screen.getByText("Your adventures await")).toBeDefined();
       expect(
         screen.getByText(
           "Start planning your next adventure by creating your first trip.",

--- a/apps/web/src/app/(app)/trips/trips-content.tsx
+++ b/apps/web/src/app/(app)/trips/trips-content.tsx
@@ -16,26 +16,9 @@ import { TopoPattern } from "@/components/ui/topo-pattern";
 
 function SkeletonCard() {
   return (
-    <div className="bg-card rounded-2xl overflow-hidden border border-border">
-      <div className="relative h-48">
-        <Skeleton className="h-full w-full rounded-none" />
-        <div className="absolute top-3 left-3 flex gap-2">
-          <Skeleton className="h-5 w-16 rounded-full" />
-        </div>
-      </div>
-      <div className="p-4 space-y-3">
-        <div className="space-y-2">
-          <Skeleton className="h-6 w-3/4" />
-          <Skeleton className="h-4 w-1/2" />
-        </div>
-        <Skeleton className="h-4 w-2/3" />
-        <div className="flex items-center justify-between pt-3 border-t border-border">
-          <div className="flex items-center gap-2">
-            <Skeleton className="h-6 w-6 rounded-full" />
-            <Skeleton className="h-4 w-20" />
-          </div>
-          <Skeleton className="h-4 w-20" />
-        </div>
+    <div className="postcard-mat" style={{ background: "var(--color-secondary)" }}>
+      <div className="postcard-image">
+        <Skeleton className="absolute inset-0 rounded-none" />
       </div>
     </div>
   );
@@ -168,7 +151,7 @@ export function TripsContent() {
 
         {/* Loading State */}
         {isPending && (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
             <SkeletonCard />
             <SkeletonCard />
             <SkeletonCard />
@@ -250,18 +233,9 @@ export function TripsContent() {
                 <h2 className="text-xl sm:text-2xl font-semibold text-foreground mb-4 font-[family-name:var(--font-playfair)]">
                   Upcoming trips
                 </h2>
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
                   {upcomingTrips.map((trip, index) => (
-                    <div
-                      key={trip.id}
-                      className={index === 0 ? "lg:row-span-2" : ""}
-                    >
-                      <TripCard
-                        trip={trip}
-                        index={index}
-                        className={index === 0 ? "lg:h-full" : ""}
-                      />
-                    </div>
+                    <TripCard key={trip.id} trip={trip} index={index} />
                   ))}
                 </div>
               </section>
@@ -278,7 +252,7 @@ export function TripsContent() {
                 <h2 className="text-xl sm:text-2xl font-semibold text-foreground mb-4 font-[family-name:var(--font-playfair)]">
                   Past trips
                 </h2>
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
                   {pastTrips.map((trip, index) => (
                     <TripCard key={trip.id} trip={trip} index={index} />
                   ))}

--- a/apps/web/src/app/(app)/trips/trips-content.tsx
+++ b/apps/web/src/app/(app)/trips/trips-content.tsx
@@ -13,6 +13,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { useMounted } from "@/hooks/use-mounted";
 import { useScrollReveal } from "@/hooks/use-scroll-reveal";
 import { TopoPattern } from "@/components/ui/topo-pattern";
+import { PostmarkStamp } from "@/components/ui/postmark-stamp";
 
 function SkeletonCard() {
   return (
@@ -123,8 +124,8 @@ export function TripsContent() {
   const isEmpty = trips.length === 0 && !isPending;
 
   return (
-    <div className="min-h-screen bg-background pb-24 motion-safe:animate-[revealUp_400ms_ease-out_both] gradient-mesh">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <div className="min-h-screen bg-background pb-24 motion-safe:animate-[revealUp_400ms_ease-out_both] gradient-mesh linen-texture">
+      <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Header */}
         <header className="mb-8">
           <h1 className="text-2xl sm:text-4xl font-bold text-foreground mb-2 font-[family-name:var(--font-playfair)]">
@@ -145,7 +146,7 @@ export function TripsContent() {
             placeholder="Search trips..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="h-12 pl-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl"
+            className="h-12 pl-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
           />
         </div>
 
@@ -160,7 +161,7 @@ export function TripsContent() {
 
         {/* Error State */}
         {isError && (
-          <div className="bg-card rounded-2xl border border-destructive/30 p-8 text-center">
+          <div className="bg-card rounded-md border border-destructive/30 p-8 text-center">
             <AlertCircle className="w-12 h-12 text-destructive mx-auto mb-4" />
             <h2 className="text-2xl font-semibold text-foreground mb-2 font-accent">
               Failed to load trips
@@ -172,7 +173,7 @@ export function TripsContent() {
               onClick={() => refetch()}
               disabled={isFetching}
               variant="gradient"
-              className="h-12 px-8 rounded-xl disabled:opacity-50 disabled:cursor-not-allowed"
+              className="h-12 px-8 rounded-md disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {isFetching && <Loader2 className="w-4 h-4 animate-spin mr-2" />}
               {isFetching ? "Loading..." : "Try again"}
@@ -182,11 +183,16 @@ export function TripsContent() {
 
         {/* Empty State (no trips at all) */}
         {isEmpty && (
-          <div className="relative overflow-hidden bg-card rounded-2xl border border-border p-12 text-center card-noise">
-            <TopoPattern />
+          <div className="relative overflow-hidden bg-card rounded-md border border-border p-12 text-center linen-texture">
+            <div className="absolute top-4 right-4 opacity-50">
+              <PostmarkStamp date="2026" city="TRIPFUL" size="lg" />
+            </div>
             <div className="relative max-w-md mx-auto">
-              <h2 className="text-2xl font-semibold text-foreground mb-2 font-accent">
-                No trips yet
+              <p className="text-2xl text-accent mb-2 font-[family-name:var(--font-script)]">
+                No postcards yet...
+              </p>
+              <h2 className="text-xl font-semibold text-foreground mb-2 font-accent">
+                Your adventures await
               </h2>
               <p className="text-muted-foreground mb-6">
                 Start planning your next adventure by creating your first trip.
@@ -194,7 +200,7 @@ export function TripsContent() {
               <Button
                 onClick={() => setCreateDialogOpen(true)}
                 variant="gradient"
-                className="h-12 px-8 rounded-xl"
+                className="h-12 px-8"
               >
                 <Plus className="w-5 h-5 mr-2" strokeWidth={2.5} />
                 Create your first trip
@@ -205,7 +211,7 @@ export function TripsContent() {
 
         {/* No Search Results */}
         {noResults && (
-          <div className="relative overflow-hidden bg-card rounded-2xl border border-border p-8 text-center card-noise">
+          <div className="relative overflow-hidden bg-card rounded-md border border-border p-8 text-center card-noise">
             <TopoPattern />
             <div className="relative">
               <Search className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
@@ -232,6 +238,7 @@ export function TripsContent() {
               >
                 <h2 className="text-xl sm:text-2xl font-semibold text-foreground mb-4 font-[family-name:var(--font-playfair)]">
                   Upcoming trips
+                  <span className="block text-xs font-normal text-muted-foreground font-accent tracking-wider uppercase mt-1">Departures</span>
                 </h2>
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
                   {upcomingTrips.map((trip, index) => (
@@ -251,6 +258,7 @@ export function TripsContent() {
               >
                 <h2 className="text-xl sm:text-2xl font-semibold text-foreground mb-4 font-[family-name:var(--font-playfair)]">
                   Past trips
+                  <span className="block text-xs font-normal text-muted-foreground font-accent tracking-wider uppercase mt-1">Memories</span>
                 </h2>
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
                   {pastTrips.map((trip, index) => (

--- a/apps/web/src/app/(auth)/layout.tsx
+++ b/apps/web/src/app/(auth)/layout.tsx
@@ -1,59 +1,17 @@
 import type { ReactNode } from "react";
+import { PostmarkStamp } from "@/components/ui/postmark-stamp";
 
 export default function AuthLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="relative min-h-screen w-full overflow-hidden bg-background gradient-mesh">
-      {/* Decorative compass rose pattern */}
-      <div className="absolute inset-0 opacity-[0.08]" aria-hidden="true">
-        <svg
-          className="absolute top-12 right-12 w-64 h-64 text-primary hidden sm:block"
-          viewBox="0 0 200 200"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <circle
-            cx="100"
-            cy="100"
-            r="90"
-            stroke="currentColor"
-            strokeWidth="1"
-          />
-          <circle
-            cx="100"
-            cy="100"
-            r="60"
-            stroke="currentColor"
-            strokeWidth="0.5"
-          />
-          <path d="M100 10L105 100L100 190L95 100Z" fill="currentColor" />
-          <path d="M10 100L100 95L190 100L100 105Z" fill="currentColor" />
-          <path
-            d="M30 30L103 97L170 30L97 103Z"
-            fill="currentColor"
-            opacity="0.5"
-          />
-          <path
-            d="M30 170L103 103L170 170L97 97Z"
-            fill="currentColor"
-            opacity="0.5"
-          />
-        </svg>
-        <svg
-          className="absolute bottom-16 left-16 w-48 h-48 text-accent hidden sm:block"
-          viewBox="0 0 200 200"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <circle
-            cx="100"
-            cy="100"
-            r="90"
-            stroke="currentColor"
-            strokeWidth="1"
-          />
-          <path d="M100 10L105 100L100 190L95 100Z" fill="currentColor" />
-          <path d="M10 100L100 95L190 100L100 105Z" fill="currentColor" />
-        </svg>
+    <div className="relative min-h-screen w-full overflow-hidden bg-background linen-texture">
+      {/* Decorative postmark stamps */}
+      <div className="absolute inset-0" aria-hidden="true">
+        <div className="absolute top-12 right-12 hidden sm:block">
+          <PostmarkStamp date="EST. 2026" city="TRIPFUL" size="lg" />
+        </div>
+        <div className="absolute bottom-16 left-16 hidden sm:block">
+          <PostmarkStamp date="PAR AVION" city="AIR MAIL" size="md" />
+        </div>
       </div>
 
       <main

--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -46,10 +46,12 @@ export default function LoginPage() {
 
   return (
     <div className="w-full max-w-md">
-      <div className="bg-card rounded-3xl shadow-2xl p-8 lg:p-12 border border-border/50 motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-4 duration-700">
-        <div className="space-y-6">
+      <div className="relative bg-card rounded-md shadow-2xl p-8 lg:p-12 border border-border/50 linen-texture overflow-hidden motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-4 duration-700">
+        {/* Airmail stripe top */}
+        <div className="space-y-6 relative pt-2">
           <div className="space-y-2">
-            <h1 className="text-3xl font-semibold text-foreground tracking-tight">
+            <p className="text-sm text-accent font-[family-name:var(--font-typewriter)] uppercase tracking-widest">Par Avion</p>
+            <h1 className="text-3xl font-semibold text-foreground tracking-tight font-[family-name:var(--font-playfair)]">
               Get started
             </h1>
             <p className="text-muted-foreground">
@@ -92,7 +94,7 @@ export default function LoginPage() {
                 type="submit"
                 disabled={isSubmitting}
                 variant="gradient"
-                className="w-full h-12 rounded-xl"
+                className="w-full h-12"
               >
                 {isSubmitting ? "Sending..." : "Continue"}
               </Button>

--- a/apps/web/src/app/(auth)/verify/page.tsx
+++ b/apps/web/src/app/(auth)/verify/page.tsx
@@ -83,10 +83,10 @@ function VerifyPageContent() {
 
   return (
     <div className="w-full max-w-md">
-      <div className="bg-card rounded-3xl shadow-2xl p-8 lg:p-12 border border-border/50 motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-4 duration-700">
-        <div className="space-y-6">
+      <div className="relative bg-card rounded-md shadow-2xl p-8 lg:p-12 border border-border/50 linen-texture overflow-hidden motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-4 duration-700">
+        <div className="space-y-6 relative pt-2">
           <div className="space-y-2">
-            <h1 className="text-3xl font-semibold text-foreground tracking-tight">
+            <h1 className="text-3xl font-semibold text-foreground tracking-tight font-[family-name:var(--font-playfair)]">
               Verify your number
             </h1>
             <p className="text-muted-foreground">

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,54 +1,59 @@
 @import "tailwindcss";
 
 @theme {
-  --color-background: #fbf6ef;
-  --color-foreground: #3a2d22;
-  --color-card: #ffffff;
-  --color-card-foreground: #3a2d22;
-  --color-popover: #ffffff;
-  --color-popover-foreground: #3a2d22;
-  --color-primary: #1a5c9e;
-  --color-primary-foreground: #ffffff;
-  --color-secondary: #eee9e2;
-  --color-secondary-foreground: #3a2d22;
-  --color-muted: #eee9e2;
-  --color-muted-foreground: #5a5046;
-  --color-accent: #d1643d;
-  --color-accent-foreground: #ffffff;
-  --color-destructive: #c6372a;
-  --color-destructive-foreground: #ffffff;
-  --color-success: #497e5a;
-  --color-success-foreground: #ffffff;
-  --color-warning: #c78d29;
-  --color-warning-foreground: #ffffff;
-  --color-border: #e5ddd1;
-  --color-input: #e5ddd1;
-  --color-ring: #1a5c9e;
-  --radius: 0.5rem;
+  /* Vintage linen postcard palette — all hex, never hsl() */
+  --color-background: #f5edd6;
+  --color-foreground: #2c2217;
+  --color-card: #faf5e8;
+  --color-card-foreground: #2c2217;
+  --color-popover: #faf5e8;
+  --color-popover-foreground: #2c2217;
+  --color-primary: #2e5984;
+  --color-primary-foreground: #faf5e8;
+  --color-secondary: #e8dcc8;
+  --color-secondary-foreground: #2c2217;
+  --color-muted: #e8dcc8;
+  --color-muted-foreground: #5c4e3e;
+  --color-accent: #b8432e;
+  --color-accent-foreground: #faf5e8;
+  --color-destructive: #9e2f24;
+  --color-destructive-foreground: #faf5e8;
+  --color-success: #3d6b4a;
+  --color-success-foreground: #faf5e8;
+  --color-warning: #a87a28;
+  --color-warning-foreground: #faf5e8;
+  --color-border: #d4c9b5;
+  --color-input: #d4c9b5;
+  --color-ring: #2e5984;
+  --radius: 0.375rem;
   --font-sans: var(--font-plus-jakarta);
-  --font-accent: var(--font-space-grotesk);
+  --font-accent: var(--font-typewriter);
 
-  /* Event type colors */
-  --color-event-travel: #2563eb;
-  --color-event-travel-light: #eff6ff;
-  --color-event-travel-border: #bfdbfe;
-  --color-event-meal: #d97706;
-  --color-event-meal-light: #fffbeb;
-  --color-event-meal-border: #fde68a;
-  --color-event-activity: #059669;
-  --color-event-activity-light: #ecfdf5;
-  --color-event-activity-border: #a7f3d0;
-  --color-accommodation: #9333ea;
-  --color-accommodation-light: #faf5ff;
-  --color-accommodation-border: #e9d5ff;
-  --color-member-travel: #6b7280;
-  --color-member-travel-light: #f9fafb;
-  --color-member-travel-border: #e5e7eb;
+  /* Airmail stripe colors */
+  --color-airmail-red: #b8432e;
+  --color-airmail-blue: #2e5984;
+
+  /* Event type colors — desaturated linen tones */
+  --color-event-travel: #3b6898;
+  --color-event-travel-light: #f0ead8;
+  --color-event-travel-border: #a8bdd0;
+  --color-event-meal: #b07920;
+  --color-event-meal-light: #f5edd6;
+  --color-event-meal-border: #dbc391;
+  --color-event-activity: #2d7a58;
+  --color-event-activity-light: #e8f0e3;
+  --color-event-activity-border: #8fc4a8;
+  --color-accommodation: #6e3ca8;
+  --color-accommodation-light: #f0e8f5;
+  --color-accommodation-border: #c5aed9;
+  --color-member-travel: #6b6259;
+  --color-member-travel-light: #f3ede0;
+  --color-member-travel-border: #d4c9b5;
 
   /* Overlay text colors (bright on dark backgrounds like bg-black/50) */
-  --color-overlay-success: #6ee7b7;
-  --color-overlay-warning: #fcd34d;
-  --color-overlay-muted: #d4d4d4;
+  --color-overlay-success: #8ed4aa;
+  --color-overlay-warning: #e8c86e;
+  --color-overlay-muted: #c8c4bc;
 }
 
 @layer base {
@@ -180,11 +185,12 @@
   }
 }
 
+/* Subtle vintage paper mesh */
 .gradient-mesh {
   background:
-    radial-gradient(ellipse at 20% 50%, #1a5c9e10 0%, transparent 50%),
-    radial-gradient(ellipse at 80% 20%, #d1643d08 0%, transparent 50%),
-    radial-gradient(ellipse at 50% 80%, #497e5a08 0%, transparent 50%);
+    radial-gradient(ellipse at 20% 50%, rgba(46, 89, 132, 0.04) 0%, transparent 50%),
+    radial-gradient(ellipse at 80% 20%, rgba(184, 67, 46, 0.03) 0%, transparent 50%),
+    radial-gradient(ellipse at 50% 80%, rgba(61, 107, 74, 0.03) 0%, transparent 50%);
 }
 
 .card-noise {
@@ -203,6 +209,104 @@
   background-size: 256px 256px;
 }
 
+/* Linen paper texture — subtle fiber grain for vintage postcard feel */
+.linen-texture {
+  position: relative;
+}
+
+.linen-texture::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  opacity: 0.045;
+  pointer-events: none;
+  border-radius: inherit;
+  z-index: 0;
+  background-image: url("data:image/svg+xml,%3Csvg width='200' height='200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='linen'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch' seed='2'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23linen)'/%3E%3C/svg%3E");
+  background-repeat: repeat;
+  background-size: 200px 200px;
+}
+
+/* Airmail chevron stripe — horizontal red-blue-gap repeating pattern */
+.airmail-stripe {
+  background-image: repeating-linear-gradient(
+    90deg,
+    var(--color-airmail-red) 0px,
+    var(--color-airmail-red) 12px,
+    #faf5e8 12px,
+    #faf5e8 18px,
+    var(--color-airmail-blue) 18px,
+    var(--color-airmail-blue) 30px,
+    #faf5e8 30px,
+    #faf5e8 36px
+  );
+}
+
+/* Airmail border — pseudo-element stripe along an edge */
+.airmail-border-top {
+  position: relative;
+}
+
+.airmail-border-top::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 6px;
+  z-index: 2;
+  pointer-events: none;
+  background-image: repeating-linear-gradient(
+    90deg,
+    var(--color-airmail-red) 0px,
+    var(--color-airmail-red) 12px,
+    #faf5e8 12px,
+    #faf5e8 18px,
+    var(--color-airmail-blue) 18px,
+    var(--color-airmail-blue) 30px,
+    #faf5e8 30px,
+    #faf5e8 36px
+  );
+}
+
+.airmail-border-bottom {
+  position: relative;
+}
+
+.airmail-border-bottom::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 6px;
+  z-index: 2;
+  pointer-events: none;
+  background-image: repeating-linear-gradient(
+    90deg,
+    var(--color-airmail-red) 0px,
+    var(--color-airmail-red) 12px,
+    #faf5e8 12px,
+    #faf5e8 18px,
+    var(--color-airmail-blue) 18px,
+    var(--color-airmail-blue) 30px,
+    #faf5e8 30px,
+    #faf5e8 36px
+  );
+}
+
+/* Postcard back writing lines */
+.writing-lines {
+  background-image: repeating-linear-gradient(
+    to bottom,
+    transparent 0px,
+    transparent 27px,
+    var(--color-border) 27px,
+    var(--color-border) 28px
+  );
+  background-position: 0 8px;
+}
+
 @utility pb-safe {
   padding-bottom: env(safe-area-inset-bottom);
 }
@@ -215,27 +319,34 @@
   bottom: calc(2rem + env(safe-area-inset-bottom));
 }
 
-/* Postcard card style */
+/* Postcard card style — vintage with rounded corners */
 .postcard {
   display: block;
   transition: translate 0.3s ease, box-shadow 0.3s ease;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  box-shadow:
+    0 2px 8px rgba(44, 34, 23, 0.08),
+    0 0 0 1px rgba(44, 34, 23, 0.04);
+  border-radius: 6px;
+  overflow: hidden;
 }
 
 @media (hover: hover) {
   .postcard:hover {
-    translate: 0 -6px;
-    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
+    translate: 0 -4px;
+    box-shadow:
+      0 8px 24px rgba(44, 34, 23, 0.15),
+      0 0 0 1px rgba(44, 34, 23, 0.06);
   }
 }
 
 .postcard-mat {
-  padding: 16px;
-  /* background set via inline style for theme background */
+  padding: 12px;
+  border-radius: 6px;
 }
 
 .postcard-image {
   position: relative;
-  aspect-ratio: 4/3;
+  aspect-ratio: 3/2;
   overflow: hidden;
+  border-radius: 2px;
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -214,3 +214,28 @@
 @utility bottom-safe-8 {
   bottom: calc(2rem + env(safe-area-inset-bottom));
 }
+
+/* Postcard card style */
+.postcard {
+  display: block;
+  transition: translate 0.3s ease, box-shadow 0.3s ease;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+@media (hover: hover) {
+  .postcard:hover {
+    translate: 0 -6px;
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
+  }
+}
+
+.postcard-mat {
+  padding: 16px;
+  /* background set via inline style for theme background */
+}
+
+.postcard-image {
+  position: relative;
+  aspect-ratio: 4/3;
+  overflow: hidden;
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,12 +3,15 @@ import type { ReactNode } from "react";
 import "./globals.css";
 import { Providers } from "./providers/providers";
 import {
+  bungeeShade,
   caveat,
   nunito,
   oswald,
+  italiana,
   playfairDisplay,
   plusJakartaSans,
   spaceGrotesk,
+  specialElite,
 } from "@/lib/fonts";
 import { cn } from "@/lib/utils";
 import { SkipLink } from "@/components/skip-link";
@@ -69,6 +72,9 @@ export default function RootLayout({
       lang="en"
       suppressHydrationWarning
       className={cn(
+        bungeeShade.variable,
+        italiana.variable,
+        specialElite.variable,
         playfairDisplay.variable,
         plusJakartaSans.variable,
         spaceGrotesk.variable,

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 import Link from "next/link";
 import { Calendar, Building2, PartyPopper, Plane } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { PostmarkStamp } from "@/components/ui/postmark-stamp";
 import { JsonLd } from "@/components/json-ld";
 
 export const metadata: Metadata = {
@@ -70,21 +71,27 @@ export default async function Home() {
 
   return (
     <>
-      <main className="flex min-h-screen flex-col bg-background">
+      <main className="flex min-h-screen flex-col bg-background linen-texture">
         {/* Hero Section */}
-        <section className="flex flex-col items-center justify-center px-4 pt-24 pb-20 text-center sm:pt-32 sm:pb-28">
-          <div className="mb-6 h-1 w-16 rounded-full bg-accent" />
-          <h1 className="mb-4 max-w-2xl text-5xl font-bold tracking-tight text-foreground sm:text-6xl lg:text-7xl font-[family-name:var(--font-playfair)]">
+        <section className="relative flex flex-col items-center justify-center px-4 pt-24 pb-20 text-center sm:pt-32 sm:pb-28">
+          {/* Postmark decoration */}
+          <div className="absolute top-8 right-8 sm:top-12 sm:right-16 hidden sm:block">
+            <PostmarkStamp date="EST. 2026" city="TRIPFUL" size="lg" />
+          </div>
+          <h1 className="mb-4 max-w-2xl text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl font-[family-name:var(--font-display)]">
             Plan Group Trips Together
           </h1>
-          <p className="mb-10 max-w-lg text-center text-lg text-muted-foreground sm:text-xl">
+          <p className="mb-3 max-w-lg text-center text-lg text-muted-foreground sm:text-xl">
             The trip planning app that brings your travel group together.
             Coordinate everything in one place.
+          </p>
+          <p className="mb-10 text-xl text-accent font-[family-name:var(--font-script)]">
+            Wish you were here...
           </p>
           <Button
             variant="gradient"
             size="lg"
-            className="rounded-xl px-10 font-accent"
+            className="px-10 font-accent"
             asChild
           >
             <Link href="/login">Get started</Link>
@@ -101,7 +108,7 @@ export default async function Home() {
               {features.map((feature) => (
                 <div
                   key={feature.title}
-                  className="rounded-xl border border-border bg-card p-6"
+                  className="rounded-md border border-border bg-card p-6 linen-texture"
                 >
                   <feature.icon className="mb-3 h-6 w-6 text-accent" />
                   <h3 className="mb-2 text-lg font-semibold text-foreground font-accent">
@@ -125,7 +132,7 @@ export default async function Home() {
             <div className="grid gap-8 sm:grid-cols-3">
               {steps.map((step) => (
                 <div key={step.number} className="text-center">
-                  <div className="mx-auto mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-accent text-sm font-bold text-accent-foreground font-accent">
+                  <div className="mx-auto mb-4 flex h-10 w-10 items-center justify-center rounded-sm border-2 border-dashed border-accent text-sm font-bold text-accent font-accent">
                     {step.number}
                   </div>
                   <h3 className="mb-2 text-lg font-semibold text-foreground font-accent">
@@ -142,18 +149,16 @@ export default async function Home() {
 
         {/* Bottom CTA Section */}
         <section className="flex flex-col items-center px-4 pt-12 pb-24 text-center sm:pb-32">
-          <div className="mb-8 flex items-center gap-3">
-            <div className="h-px w-12 bg-border" />
-            <div className="h-2 w-2 rotate-45 border border-primary/40" />
-            <div className="h-px w-12 bg-border" />
-          </div>
+          <p className="mb-2 text-lg text-accent font-[family-name:var(--font-script)]">
+            Wish you were here?
+          </p>
           <h2 className="mb-6 text-2xl font-bold tracking-tight text-foreground sm:text-3xl font-[family-name:var(--font-playfair)]">
             Ready to plan your next adventure?
           </h2>
           <Button
             variant="gradient"
             size="lg"
-            className="rounded-xl px-10 font-accent"
+            className="px-10 font-accent"
             asChild
           >
             <Link href="/login">Start planning</Link>

--- a/apps/web/src/components/app-header.tsx
+++ b/apps/web/src/components/app-header.tsx
@@ -58,7 +58,7 @@ export function AppHeader() {
 
   return (
     <>
-      <header className="sticky top-0 z-40 w-full border-b bg-background">
+      <header className="sticky top-0 z-40 w-full bg-background border-b border-border linen-texture">
         <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
           <div className="flex items-center gap-2">
             {/* Mobile hamburger button */}
@@ -75,7 +75,7 @@ export function AppHeader() {
 
             <Link
               href="/trips"
-              className="font-[family-name:var(--font-playfair)] text-xl font-bold tracking-tight"
+              className="font-[family-name:var(--font-display)] text-xl font-bold tracking-tight"
             >
               Tripful
             </Link>

--- a/apps/web/src/components/itinerary/__tests__/create-event-dialog.test.tsx
+++ b/apps/web/src/components/itinerary/__tests__/create-event-dialog.test.tsx
@@ -506,7 +506,7 @@ describe("CreateEventDialog", () => {
       expect(nameInput.className).toContain("h-12");
     });
 
-    it("applies rounded-xl to inputs and buttons", () => {
+    it("applies rounded-md to inputs and buttons", () => {
       renderWithQueryClient(
         <CreateEventDialog
           open={true}
@@ -517,12 +517,12 @@ describe("CreateEventDialog", () => {
       );
 
       const nameInput = screen.getByLabelText(/event name/i);
-      expect(nameInput.className).toContain("rounded-xl");
+      expect(nameInput.className).toContain("rounded-md");
 
       const submitButton = screen.getByRole("button", {
         name: /create event/i,
       });
-      expect(submitButton.className).toContain("rounded-xl");
+      expect(submitButton.className).toContain("rounded-md");
     });
   });
 });

--- a/apps/web/src/components/itinerary/__tests__/edit-event-dialog.test.tsx
+++ b/apps/web/src/components/itinerary/__tests__/edit-event-dialog.test.tsx
@@ -487,7 +487,7 @@ describe("EditEventDialog", () => {
       );
     });
 
-    it("applies rounded-xl to buttons", () => {
+    it("applies rounded-md to buttons", () => {
       renderWithQueryClient(
         <EditEventDialog
           open={true}
@@ -500,7 +500,7 @@ describe("EditEventDialog", () => {
       const submitButton = screen.getByRole("button", {
         name: /update event/i,
       });
-      expect(submitButton.className).toContain("rounded-xl");
+      expect(submitButton.className).toContain("rounded-md");
     });
   });
 });

--- a/apps/web/src/components/itinerary/accommodation-card.tsx
+++ b/apps/web/src/components/itinerary/accommodation-card.tsx
@@ -43,7 +43,7 @@ export const AccommodationCard = memo(function AccommodationCard({
       role="button"
       tabIndex={0}
       aria-expanded={isExpanded}
-      className="rounded-xl border border-border/60 border-l-2 border-l-[var(--color-accommodation)] py-2 px-3 transition-all hover:shadow-md motion-safe:hover:-translate-y-0.5 motion-safe:active:scale-[0.98] cursor-pointer"
+      className="rounded-md border border-border/60 border-l-2 border-l-[var(--color-accommodation)] py-2 px-3 transition-all hover:shadow-md motion-safe:hover:-translate-y-0.5 motion-safe:active:scale-[0.98] cursor-pointer"
       onClick={() => setIsExpanded((prev) => !prev)}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {

--- a/apps/web/src/components/itinerary/create-accommodation-dialog.tsx
+++ b/apps/web/src/components/itinerary/create-accommodation-dialog.tsx
@@ -210,7 +210,7 @@ export function CreateAccommodationDialog({
                       <Input
                         type="text"
                         placeholder="Oceanview Hotel"
-                        className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl"
+                        className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
                         disabled={isPending}
                         aria-required="true"
                         {...field}
@@ -234,7 +234,7 @@ export function CreateAccommodationDialog({
                       <Input
                         type="text"
                         placeholder="123 Beach Blvd, Miami Beach, FL 33139"
-                        className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl"
+                        className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
                         disabled={isPending}
                         {...field}
                       />
@@ -315,7 +315,7 @@ export function CreateAccommodationDialog({
                       <FormControl>
                         <Textarea
                           placeholder="Tell your group about this accommodation..."
-                          className="h-32 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl resize-none"
+                          className="h-32 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md resize-none"
                           disabled={isPending}
                           {...field}
                           value={field.value || ""}
@@ -394,7 +394,7 @@ export function CreateAccommodationDialog({
                             }
                           }}
                           disabled={isPending}
-                          className="flex-1 h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl"
+                          className="flex-1 h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
                           aria-label="Link URL"
                           aria-describedby={
                             linkError ? "accommodation-link-error" : undefined
@@ -404,7 +404,7 @@ export function CreateAccommodationDialog({
                           type="button"
                           onClick={handleAddLink}
                           disabled={isPending}
-                          className="h-12 px-4 bg-muted hover:bg-muted text-foreground rounded-xl"
+                          className="h-12 px-4 bg-muted hover:bg-muted text-foreground rounded-md"
                           variant="outline"
                           aria-label="Add link"
                         >
@@ -434,7 +434,7 @@ export function CreateAccommodationDialog({
                   variant="outline"
                   onClick={() => onOpenChange(false)}
                   disabled={isPending}
-                  className="flex-1 h-12 rounded-xl border-input"
+                  className="flex-1 h-12 rounded-md border-input"
                 >
                   Cancel
                 </Button>
@@ -442,7 +442,7 @@ export function CreateAccommodationDialog({
                   type="submit"
                   disabled={isPending}
                   variant="gradient"
-                  className="flex-1 h-12 rounded-xl"
+                  className="flex-1 h-12 rounded-md"
                 >
                   {isPending && (
                     <Loader2 className="w-4 h-4 animate-spin mr-2" />

--- a/apps/web/src/components/itinerary/create-event-dialog.tsx
+++ b/apps/web/src/components/itinerary/create-event-dialog.tsx
@@ -229,7 +229,7 @@ export function CreateEventDialog({
                       <Input
                         type="text"
                         placeholder="Dinner at Seaside Restaurant"
-                        className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl"
+                        className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
                         disabled={isPending}
                         aria-required="true"
                         {...field}
@@ -259,7 +259,7 @@ export function CreateEventDialog({
                         <SelectTrigger
                           ref={field.ref}
                           onBlur={field.onBlur}
-                          className="h-12 text-base rounded-xl"
+                          className="h-12 text-base rounded-md"
                           aria-required="true"
                         >
                           <SelectValue />
@@ -289,7 +289,7 @@ export function CreateEventDialog({
                       <Input
                         type="text"
                         placeholder="123 Main St, Miami Beach"
-                        className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl"
+                        className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
                         disabled={isPending}
                         {...field}
                       />
@@ -317,7 +317,7 @@ export function CreateEventDialog({
                         <SelectTrigger
                           ref={field.ref}
                           onBlur={field.onBlur}
-                          className="h-12 text-base rounded-xl"
+                          className="h-12 text-base rounded-md"
                         >
                           <SelectValue />
                         </SelectTrigger>
@@ -404,7 +404,7 @@ export function CreateEventDialog({
                       <Input
                         type="text"
                         placeholder="Hotel lobby, parking lot, etc."
-                        className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl"
+                        className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
                         disabled={isPending}
                         {...field}
                       />
@@ -451,7 +451,7 @@ export function CreateEventDialog({
                 control={form.control}
                 name="allDay"
                 render={({ field }) => (
-                  <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-xl border border-border p-4">
+                  <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border border-border p-4">
                     <FormControl>
                       <Checkbox
                         checked={field.value}
@@ -480,7 +480,7 @@ export function CreateEventDialog({
                 control={form.control}
                 name="isOptional"
                 render={({ field }) => (
-                  <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-xl border border-border p-4">
+                  <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border border-border p-4">
                     <FormControl>
                       <Checkbox
                         checked={field.value}
@@ -520,7 +520,7 @@ export function CreateEventDialog({
                       <FormControl>
                         <Textarea
                           placeholder="Tell your group about this event..."
-                          className="h-32 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl resize-none"
+                          className="h-32 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md resize-none"
                           disabled={isPending}
                           {...field}
                           value={field.value || ""}
@@ -598,7 +598,7 @@ export function CreateEventDialog({
                             }
                           }}
                           disabled={isPending}
-                          className="flex-1 h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl"
+                          className="flex-1 h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
                           aria-label="Link URL"
                           aria-describedby={
                             linkError ? "event-link-error" : undefined
@@ -608,7 +608,7 @@ export function CreateEventDialog({
                           type="button"
                           onClick={handleAddLink}
                           disabled={isPending}
-                          className="h-12 px-4 bg-muted hover:bg-muted text-foreground rounded-xl"
+                          className="h-12 px-4 bg-muted hover:bg-muted text-foreground rounded-md"
                           variant="outline"
                           aria-label="Add link"
                         >
@@ -638,7 +638,7 @@ export function CreateEventDialog({
                   variant="outline"
                   onClick={() => onOpenChange(false)}
                   disabled={isPending}
-                  className="flex-1 h-12 rounded-xl border-input"
+                  className="flex-1 h-12 rounded-md border-input"
                 >
                   Cancel
                 </Button>
@@ -646,7 +646,7 @@ export function CreateEventDialog({
                   type="submit"
                   disabled={isPending}
                   variant="gradient"
-                  className="flex-1 h-12 rounded-xl"
+                  className="flex-1 h-12 rounded-md"
                 >
                   {isPending && (
                     <Loader2 className="w-4 h-4 animate-spin mr-2" />

--- a/apps/web/src/components/itinerary/create-member-travel-dialog.tsx
+++ b/apps/web/src/components/itinerary/create-member-travel-dialog.tsx
@@ -175,7 +175,7 @@ export function CreateMemberTravelDialog({
                   >
                     <FormControl>
                       <SelectTrigger
-                        className="h-12 text-base rounded-xl"
+                        className="h-12 text-base rounded-md"
                         data-testid="member-selector"
                       >
                         <SelectValue placeholder="Select a member" />
@@ -218,7 +218,7 @@ export function CreateMemberTravelDialog({
                     <FormLabel className="text-base font-semibold text-foreground">
                       Member
                     </FormLabel>
-                    <div className="flex items-center gap-2 h-12 px-3 rounded-xl border border-input bg-muted/50">
+                    <div className="flex items-center gap-2 h-12 px-3 rounded-md border border-input bg-muted/50">
                       <Avatar size="sm">
                         {currentMember.profilePhotoUrl && (
                           <AvatarImage
@@ -295,7 +295,7 @@ export function CreateMemberTravelDialog({
                   disabled={isPending}
                 >
                   <FormControl>
-                    <SelectTrigger className="h-12 text-base rounded-xl">
+                    <SelectTrigger className="h-12 text-base rounded-md">
                       <SelectValue />
                     </SelectTrigger>
                   </FormControl>
@@ -353,7 +353,7 @@ export function CreateMemberTravelDialog({
                       <Input
                         type="text"
                         placeholder="Miami International Airport (MIA)"
-                        className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl"
+                        className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
                         disabled={isPending}
                         {...field}
                       />
@@ -382,7 +382,7 @@ export function CreateMemberTravelDialog({
                       <FormControl>
                         <Textarea
                           placeholder="Flight number, terminal, or other relevant details..."
-                          className="h-32 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl resize-none"
+                          className="h-32 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md resize-none"
                           disabled={isPending}
                           {...field}
                           value={field.value || ""}
@@ -409,7 +409,7 @@ export function CreateMemberTravelDialog({
                   variant="outline"
                   onClick={() => onOpenChange(false)}
                   disabled={isPending}
-                  className="flex-1 h-12 rounded-xl border-input"
+                  className="flex-1 h-12 rounded-md border-input"
                 >
                   Cancel
                 </Button>
@@ -417,7 +417,7 @@ export function CreateMemberTravelDialog({
                   type="submit"
                   disabled={isPending}
                   variant="gradient"
-                  className="flex-1 h-12 rounded-xl"
+                  className="flex-1 h-12 rounded-md"
                 >
                   {isPending && (
                     <Loader2 className="w-4 h-4 animate-spin mr-2" />

--- a/apps/web/src/components/itinerary/day-by-day-view.tsx
+++ b/apps/web/src/components/itinerary/day-by-day-view.tsx
@@ -197,7 +197,7 @@ export function DayByDayView({
 
   return (
     <div className="divide-y divide-border">
-      {dayData.map((day, index) => {
+      {dayData.map((day) => {
         const isToday = day.date === todayString;
         const hasContent =
           day.events.length > 0 ||
@@ -357,10 +357,8 @@ export function DayByDayView({
             id={isToday ? "day-today" : undefined}
             className={cn(
               "grid grid-cols-[3.5rem_1fr] sm:grid-cols-[4rem_1fr] gap-x-3 py-4",
-              "motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-bottom-4 duration-500",
               isToday && "scroll-mt-28",
             )}
-            style={{ animationDelay: `${index * 50}ms` }}
           >
             {/* Date gutter — outer cell stretches to row height so sticky works */}
             <div className="relative">

--- a/apps/web/src/components/itinerary/day-by-day-view.tsx
+++ b/apps/web/src/components/itinerary/day-by-day-view.tsx
@@ -412,7 +412,7 @@ export function DayByDayView({
       })}
 
       {dayData.length === 0 && (
-        <div className="bg-card rounded-2xl border border-border p-8 text-center">
+        <div className="bg-card rounded-md border border-border p-8 text-center">
           <p className="text-muted-foreground">
             No trip dates set. Set trip dates to see a day-by-day view.
           </p>

--- a/apps/web/src/components/itinerary/edit-accommodation-dialog.tsx
+++ b/apps/web/src/components/itinerary/edit-accommodation-dialog.tsx
@@ -253,7 +253,7 @@ export function EditAccommodationDialog({
                       <Input
                         type="text"
                         placeholder="Oceanview Hotel"
-                        className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl"
+                        className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
                         disabled={isPending || isDeleting}
                         aria-required="true"
                         {...field}
@@ -277,7 +277,7 @@ export function EditAccommodationDialog({
                       <Input
                         type="text"
                         placeholder="123 Beach Blvd, Miami Beach, FL 33139"
-                        className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl"
+                        className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
                         disabled={isPending || isDeleting}
                         {...field}
                       />
@@ -358,7 +358,7 @@ export function EditAccommodationDialog({
                       <FormControl>
                         <Textarea
                           placeholder="Tell your group about this accommodation..."
-                          className="h-32 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl resize-none"
+                          className="h-32 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md resize-none"
                           disabled={isPending || isDeleting}
                           {...field}
                           value={field.value || ""}
@@ -437,7 +437,7 @@ export function EditAccommodationDialog({
                             }
                           }}
                           disabled={isPending || isDeleting}
-                          className="flex-1 h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl"
+                          className="flex-1 h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
                           aria-label="Link URL"
                           aria-describedby={
                             linkError
@@ -449,7 +449,7 @@ export function EditAccommodationDialog({
                           type="button"
                           onClick={handleAddLink}
                           disabled={isPending || isDeleting}
-                          className="h-12 px-4 bg-muted hover:bg-muted text-foreground rounded-xl"
+                          className="h-12 px-4 bg-muted hover:bg-muted text-foreground rounded-md"
                           variant="outline"
                         >
                           <Plus className="w-5 h-5" />
@@ -478,7 +478,7 @@ export function EditAccommodationDialog({
                   variant="outline"
                   onClick={() => onOpenChange(false)}
                   disabled={isPending || isDeleting}
-                  className="flex-1 h-12 rounded-xl border-input"
+                  className="flex-1 h-12 rounded-md border-input"
                 >
                   Cancel
                 </Button>
@@ -486,7 +486,7 @@ export function EditAccommodationDialog({
                   type="submit"
                   disabled={isPending || isDeleting}
                   variant="gradient"
-                  className="flex-1 h-12 rounded-xl"
+                  className="flex-1 h-12 rounded-md"
                 >
                   {isPending && (
                     <Loader2 className="w-4 h-4 animate-spin mr-2" />

--- a/apps/web/src/components/itinerary/edit-event-dialog.tsx
+++ b/apps/web/src/components/itinerary/edit-event-dialog.tsx
@@ -285,7 +285,7 @@ export function EditEventDialog({
                       <Input
                         type="text"
                         placeholder="Dinner at Seaside Restaurant"
-                        className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl"
+                        className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
                         disabled={isPending || isDeleting}
                         aria-required="true"
                         {...field}
@@ -315,7 +315,7 @@ export function EditEventDialog({
                         <SelectTrigger
                           ref={field.ref}
                           onBlur={field.onBlur}
-                          className="h-12 text-base rounded-xl"
+                          className="h-12 text-base rounded-md"
                           aria-required="true"
                         >
                           <SelectValue />
@@ -345,7 +345,7 @@ export function EditEventDialog({
                       <Input
                         type="text"
                         placeholder="123 Main St, Miami Beach"
-                        className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl"
+                        className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
                         disabled={isPending || isDeleting}
                         {...field}
                       />
@@ -373,7 +373,7 @@ export function EditEventDialog({
                         <SelectTrigger
                           ref={field.ref}
                           onBlur={field.onBlur}
-                          className="h-12 text-base rounded-xl"
+                          className="h-12 text-base rounded-md"
                         >
                           <SelectValue />
                         </SelectTrigger>
@@ -460,7 +460,7 @@ export function EditEventDialog({
                       <Input
                         type="text"
                         placeholder="Hotel lobby, parking lot, etc."
-                        className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl"
+                        className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
                         disabled={isPending || isDeleting}
                         {...field}
                       />
@@ -507,7 +507,7 @@ export function EditEventDialog({
                 control={form.control}
                 name="allDay"
                 render={({ field }) => (
-                  <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-xl border border-border p-4">
+                  <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border border-border p-4">
                     <FormControl>
                       <Checkbox
                         checked={field.value ?? false}
@@ -536,7 +536,7 @@ export function EditEventDialog({
                 control={form.control}
                 name="isOptional"
                 render={({ field }) => (
-                  <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-xl border border-border p-4">
+                  <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border border-border p-4">
                     <FormControl>
                       <Checkbox
                         checked={field.value ?? false}
@@ -576,7 +576,7 @@ export function EditEventDialog({
                       <FormControl>
                         <Textarea
                           placeholder="Tell your group about this event..."
-                          className="h-32 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl resize-none"
+                          className="h-32 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md resize-none"
                           disabled={isPending || isDeleting}
                           {...field}
                           value={field.value || ""}
@@ -654,7 +654,7 @@ export function EditEventDialog({
                             }
                           }}
                           disabled={isPending || isDeleting}
-                          className="flex-1 h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl"
+                          className="flex-1 h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
                           aria-label="Link URL"
                           aria-describedby={
                             linkError ? "edit-event-link-error" : undefined
@@ -664,7 +664,7 @@ export function EditEventDialog({
                           type="button"
                           onClick={handleAddLink}
                           disabled={isPending || isDeleting}
-                          className="h-12 px-4 bg-muted hover:bg-muted text-foreground rounded-xl"
+                          className="h-12 px-4 bg-muted hover:bg-muted text-foreground rounded-md"
                           variant="outline"
                         >
                           <Plus className="w-5 h-5" />
@@ -693,7 +693,7 @@ export function EditEventDialog({
                   variant="outline"
                   onClick={() => onOpenChange(false)}
                   disabled={isPending || isDeleting}
-                  className="flex-1 h-12 rounded-xl border-input"
+                  className="flex-1 h-12 rounded-md border-input"
                 >
                   Cancel
                 </Button>
@@ -701,7 +701,7 @@ export function EditEventDialog({
                   type="submit"
                   disabled={isPending || isDeleting}
                   variant="gradient"
-                  className="flex-1 h-12 rounded-xl"
+                  className="flex-1 h-12 rounded-md"
                 >
                   {isPending && (
                     <Loader2 className="w-4 h-4 animate-spin mr-2" />

--- a/apps/web/src/components/itinerary/edit-member-travel-dialog.tsx
+++ b/apps/web/src/components/itinerary/edit-member-travel-dialog.tsx
@@ -235,7 +235,7 @@ export function EditMemberTravelDialog({
                   onValueChange={setSelectedTimezone}
                   disabled={isPending || isDeleting}
                 >
-                  <SelectTrigger className="h-12 text-base rounded-xl mt-2">
+                  <SelectTrigger className="h-12 text-base rounded-md mt-2">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -292,7 +292,7 @@ export function EditMemberTravelDialog({
                       <Input
                         type="text"
                         placeholder="Miami International Airport (MIA)"
-                        className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl"
+                        className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
                         disabled={isPending || isDeleting}
                         {...field}
                       />
@@ -321,7 +321,7 @@ export function EditMemberTravelDialog({
                       <FormControl>
                         <Textarea
                           placeholder="Flight number, terminal, or other relevant details..."
-                          className="h-32 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl resize-none"
+                          className="h-32 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md resize-none"
                           disabled={isPending || isDeleting}
                           {...field}
                           value={field.value || ""}
@@ -348,7 +348,7 @@ export function EditMemberTravelDialog({
                   variant="outline"
                   onClick={() => onOpenChange(false)}
                   disabled={isPending || isDeleting}
-                  className="flex-1 h-12 rounded-xl border-input"
+                  className="flex-1 h-12 rounded-md border-input"
                 >
                   Cancel
                 </Button>
@@ -356,7 +356,7 @@ export function EditMemberTravelDialog({
                   type="submit"
                   disabled={isPending || isDeleting}
                   variant="gradient"
-                  className="flex-1 h-12 rounded-xl"
+                  className="flex-1 h-12 rounded-md"
                 >
                   {isPending && (
                     <Loader2 className="w-4 h-4 animate-spin mr-2" />

--- a/apps/web/src/components/itinerary/event-card.tsx
+++ b/apps/web/src/components/itinerary/event-card.tsx
@@ -82,7 +82,7 @@ export const EventCard = memo(function EventCard({
       role="button"
       tabIndex={0}
       aria-expanded={isExpanded}
-      className={`rounded-xl border border-border/60 border-l-4 ${config.accent} ${config.bg} py-2 px-3 transition-all hover:shadow-lg motion-safe:hover:-translate-y-1 motion-safe:active:scale-[0.98] cursor-pointer`}
+      className={`rounded-md border border-border/60 border-l-4 ${config.accent} ${config.bg} py-2 px-3 transition-all hover:shadow-lg motion-safe:hover:-translate-y-1 motion-safe:active:scale-[0.98] cursor-pointer`}
       onClick={() => setIsExpanded((prev) => !prev)}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {

--- a/apps/web/src/components/itinerary/itinerary-header.tsx
+++ b/apps/web/src/components/itinerary/itinerary-header.tsx
@@ -92,7 +92,7 @@ export function ItineraryHeader({
     <>
       <div
         data-testid="itinerary-header"
-        className="sticky top-14 z-20 bg-background border-b border-border py-4 px-4 sm:px-6 lg:px-8"
+        className="sticky top-0 z-30 bg-background border-b border-border py-2 px-4 sm:px-6 lg:px-8"
       >
         <div className="max-w-5xl mx-auto">
           <div className="flex items-center justify-between gap-3 flex-wrap">

--- a/apps/web/src/components/itinerary/itinerary-header.tsx
+++ b/apps/web/src/components/itinerary/itinerary-header.tsx
@@ -98,7 +98,7 @@ export function ItineraryHeader({
           <div className="flex items-center justify-between gap-3 flex-wrap">
             {/* Left: View mode toggle + timezone */}
             <TooltipProvider>
-              <div className="inline-flex items-center gap-1 p-1 bg-muted rounded-xl border border-border">
+              <div className="inline-flex items-center gap-1 p-1 bg-muted rounded-md border border-border">
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button

--- a/apps/web/src/components/itinerary/itinerary-view.tsx
+++ b/apps/web/src/components/itinerary/itinerary-view.tsx
@@ -148,9 +148,9 @@ export function ItineraryView({ tripId, onAddTravel }: ItineraryViewProps) {
           </div>
         </div>
         <div className="max-w-5xl mx-auto px-4 space-y-6">
-          <Skeleton className="h-20 w-full rounded-xl" />
-          <Skeleton className="h-20 w-full rounded-xl" />
-          <Skeleton className="h-20 w-full rounded-xl" />
+          <Skeleton className="h-20 w-full rounded-md" />
+          <Skeleton className="h-20 w-full rounded-md" />
+          <Skeleton className="h-20 w-full rounded-md" />
         </div>
       </div>
     );
@@ -162,7 +162,7 @@ export function ItineraryView({ tripId, onAddTravel }: ItineraryViewProps) {
   if (hasError) {
     return (
       <div className="max-w-5xl mx-auto px-4 py-8">
-        <div className="bg-card rounded-2xl border border-destructive/30 p-8 text-center">
+        <div className="bg-card rounded-md border border-destructive/30 p-8 text-center">
           <AlertCircle className="w-12 h-12 text-destructive mx-auto mb-4" />
           <h2 className="text-2xl font-semibold text-foreground mb-2 font-accent">
             Failed to load itinerary
@@ -178,7 +178,7 @@ export function ItineraryView({ tripId, onAddTravel }: ItineraryViewProps) {
               refetchAccommodations();
               refetchMemberTravels();
             }}
-            className="h-12 px-8 rounded-xl"
+            className="h-12 px-8 rounded-md"
           >
             Retry
           </Button>
@@ -197,7 +197,7 @@ export function ItineraryView({ tripId, onAddTravel }: ItineraryViewProps) {
     return (
       <>
         <div className="max-w-5xl mx-auto px-4 py-8">
-          <div className="relative overflow-hidden bg-card rounded-2xl border border-border p-8 text-center card-noise">
+          <div className="relative overflow-hidden bg-card rounded-md border border-border p-8 text-center card-noise">
             <TopoPattern />
             <div className="relative">
               <CalendarX className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
@@ -209,7 +209,7 @@ export function ItineraryView({ tripId, onAddTravel }: ItineraryViewProps) {
                 travel details.
               </p>
               {isLocked && (
-                <div className="bg-muted/50 border border-border rounded-xl p-4 text-center text-sm text-muted-foreground">
+                <div className="bg-muted/50 border border-border rounded-md p-4 text-center text-sm text-muted-foreground">
                   <Lock className="w-4 h-4 inline mr-2" />
                   This trip has ended. The itinerary is read-only.
                 </div>
@@ -218,14 +218,14 @@ export function ItineraryView({ tripId, onAddTravel }: ItineraryViewProps) {
                 <div className="flex flex-wrap items-center justify-center gap-3">
                   <Button
                     variant="gradient"
-                    className="h-12 px-8 rounded-xl"
+                    className="h-12 px-8 rounded-md"
                     onClick={() => setIsCreateEventOpen(true)}
                   >
                     Add Event
                   </Button>
                   <Button
                     variant="outline"
-                    className="h-12 px-8 rounded-xl"
+                    className="h-12 px-8 rounded-md"
                     onClick={() => setIsCreateAccommodationOpen(true)}
                   >
                     Add Accommodation
@@ -305,7 +305,7 @@ export function ItineraryView({ tripId, onAddTravel }: ItineraryViewProps) {
             />
           )}
         {isLocked && (
-          <div className="bg-muted/50 border border-border rounded-xl p-4 text-center text-sm text-muted-foreground mb-6">
+          <div className="bg-muted/50 border border-border rounded-md p-4 text-center text-sm text-muted-foreground mb-6">
             <Lock className="w-4 h-4 inline mr-2" />
             This trip has ended. The itinerary is read-only.
           </div>

--- a/apps/web/src/components/itinerary/member-travel-card.tsx
+++ b/apps/web/src/components/itinerary/member-travel-card.tsx
@@ -50,7 +50,7 @@ export const MemberTravelCard = memo(function MemberTravelCard({
       role="button"
       tabIndex={0}
       aria-expanded={isExpanded}
-      className="rounded-xl border border-border/60 border-l-2 border-l-[var(--color-member-travel)] py-2 px-3 transition-all hover:shadow-md motion-safe:hover:-translate-y-0.5 motion-safe:active:scale-[0.98] cursor-pointer"
+      className="rounded-md border border-border/60 border-l-2 border-l-[var(--color-member-travel)] py-2 px-3 transition-all hover:shadow-md motion-safe:hover:-translate-y-0.5 motion-safe:active:scale-[0.98] cursor-pointer"
       onClick={() => setIsExpanded((prev) => !prev)}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {

--- a/apps/web/src/components/trip/__tests__/create-trip-dialog.test.tsx
+++ b/apps/web/src/components/trip/__tests__/create-trip-dialog.test.tsx
@@ -1367,16 +1367,16 @@ describe("CreateTripDialog", () => {
       expect(nameInput.className).toContain("h-12");
     });
 
-    it("applies rounded-xl to inputs and buttons", () => {
+    it("applies rounded-md to inputs and buttons", () => {
       renderWithQueryClient(
         <CreateTripDialog open={true} onOpenChange={mockOnOpenChange} />,
       );
 
       const nameInput = screen.getByLabelText(/trip name/i);
-      expect(nameInput.className).toContain("rounded-xl");
+      expect(nameInput.className).toContain("rounded-md");
 
       const continueButton = screen.getByRole("button", { name: /continue/i });
-      expect(continueButton.className).toContain("rounded-xl");
+      expect(continueButton.className).toContain("rounded-md");
     });
 
     it("applies pb-6 bottom padding to form for mobile scroll", () => {

--- a/apps/web/src/components/trip/__tests__/rsvp-badge-dropdown.test.tsx
+++ b/apps/web/src/components/trip/__tests__/rsvp-badge-dropdown.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { RsvpBadgeDropdown } from "../rsvp-badge-dropdown";
+
+// Mock sonner
+const mockToast = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
+vi.mock("sonner", () => ({
+  toast: mockToast,
+}));
+
+// Mock useUpdateRsvp hook
+const mockUpdateRsvp = vi.fn();
+vi.mock("@/hooks/use-invitations", () => ({
+  useUpdateRsvp: () => ({
+    mutate: mockUpdateRsvp,
+    isPending: false,
+  }),
+  getUpdateRsvpErrorMessage: (error: Error | null) =>
+    error?.message ?? "RSVP failed",
+}));
+
+describe("RsvpBadgeDropdown", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders current status label", () => {
+    render(<RsvpBadgeDropdown tripId="trip-1" status="going" />);
+    expect(screen.getByText("Going")).toBeDefined();
+  });
+
+  it("renders Maybe status label", () => {
+    render(<RsvpBadgeDropdown tripId="trip-1" status="maybe" />);
+    expect(screen.getByText("Maybe")).toBeDefined();
+  });
+
+  it("renders Not Going status label", () => {
+    render(<RsvpBadgeDropdown tripId="trip-1" status="not_going" />);
+    expect(screen.getByText("Not Going")).toBeDefined();
+  });
+
+  it("renders No Response status label", () => {
+    render(<RsvpBadgeDropdown tripId="trip-1" status="no_response" />);
+    expect(screen.getByText("No Response")).toBeDefined();
+  });
+
+  it("opens dropdown with options on click", async () => {
+    const user = userEvent.setup();
+    render(<RsvpBadgeDropdown tripId="trip-1" status="going" />);
+
+    await user.click(screen.getByRole("button"));
+
+    const items = screen.getAllByRole("menuitem");
+    expect(items).toHaveLength(3);
+    expect(items[0].textContent).toContain("Going");
+    expect(items[1].textContent).toContain("Maybe");
+    expect(items[2].textContent).toContain("Not Going");
+  });
+
+  it("calls updateRsvp when selecting a different status", async () => {
+    const user = userEvent.setup();
+    render(<RsvpBadgeDropdown tripId="trip-1" status="going" />);
+
+    await user.click(screen.getByRole("button"));
+    await user.click(screen.getByRole("menuitem", { name: /Maybe/ }));
+
+    expect(mockUpdateRsvp).toHaveBeenCalledWith(
+      { status: "maybe" },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      }),
+    );
+  });
+
+  it("does not call updateRsvp when selecting the current status", async () => {
+    const user = userEvent.setup();
+    render(<RsvpBadgeDropdown tripId="trip-1" status="going" />);
+
+    await user.click(screen.getByRole("button"));
+    const items = screen.getAllByRole("menuitem");
+    // First menuitem is "Going" (current status)
+    await user.click(items[0]);
+
+    expect(mockUpdateRsvp).not.toHaveBeenCalled();
+  });
+
+  it("shows success toast on successful update", async () => {
+    mockUpdateRsvp.mockImplementation((_data, options) => {
+      options?.onSuccess?.();
+    });
+
+    const user = userEvent.setup();
+    render(<RsvpBadgeDropdown tripId="trip-1" status="going" />);
+
+    await user.click(screen.getByRole("button"));
+    await user.click(screen.getByRole("menuitem", { name: /Maybe/ }));
+
+    expect(mockToast.success).toHaveBeenCalledWith('RSVP updated to "Maybe"');
+  });
+
+  it("shows error toast on failed update", async () => {
+    const error = new Error("Network error");
+    mockUpdateRsvp.mockImplementation((_data, options) => {
+      options?.onError?.(error);
+    });
+
+    const user = userEvent.setup();
+    render(<RsvpBadgeDropdown tripId="trip-1" status="going" />);
+
+    await user.click(screen.getByRole("button"));
+    await user.click(screen.getByRole("menuitem", { name: /Not Going/ }));
+
+    expect(mockToast.error).toHaveBeenCalledWith("Network error");
+  });
+});

--- a/apps/web/src/components/trip/create-trip-dialog.tsx
+++ b/apps/web/src/components/trip/create-trip-dialog.tsx
@@ -244,7 +244,7 @@ export function CreateTripDialog({
                           <Input
                             type="text"
                             placeholder="Bachelor Party in Miami"
-                            className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl"
+                            className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
                             aria-required="true"
                             {...field}
                           />
@@ -271,7 +271,7 @@ export function CreateTripDialog({
                           <Input
                             type="text"
                             placeholder="Miami Beach, FL"
-                            className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl"
+                            className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
                             aria-required="true"
                             {...field}
                           />
@@ -349,7 +349,7 @@ export function CreateTripDialog({
                             <SelectTrigger
                               ref={field.ref}
                               onBlur={field.onBlur}
-                              className="h-12 text-base rounded-xl"
+                              className="h-12 text-base rounded-md"
                               aria-required="true"
                             >
                               <SelectValue />
@@ -377,7 +377,7 @@ export function CreateTripDialog({
                       type="button"
                       onClick={handleContinue}
                       variant="gradient"
-                      className="h-12 px-8 rounded-xl"
+                      className="h-12 px-8 rounded-md"
                     >
                       Continue
                     </Button>
@@ -403,7 +403,7 @@ export function CreateTripDialog({
                           <FormControl>
                             <Textarea
                               placeholder="Tell your group about this trip..."
-                              className="h-32 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl resize-none"
+                              className="h-32 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md resize-none"
                               disabled={isPending}
                               {...field}
                               value={field.value || ""}
@@ -496,7 +496,7 @@ export function CreateTripDialog({
                     control={form.control}
                     name="allowMembersToAddEvents"
                     render={({ field }) => (
-                      <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-xl border border-border p-4">
+                      <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border border-border p-4">
                         <FormControl>
                           <Checkbox
                             checked={field.value}
@@ -585,7 +585,7 @@ export function CreateTripDialog({
                                   }
                                 }}
                                 disabled={isPending}
-                                className="flex-1 h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl"
+                                className="flex-1 h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
                                 aria-label="Co-organizer phone number"
                                 aria-describedby={
                                   coOrganizerError
@@ -598,7 +598,7 @@ export function CreateTripDialog({
                                 type="button"
                                 onClick={handleAddCoOrganizer}
                                 disabled={isPending}
-                                className="h-12 px-4 bg-muted hover:bg-muted text-foreground rounded-xl"
+                                className="h-12 px-4 bg-muted hover:bg-muted text-foreground rounded-md"
                                 variant="outline"
                               >
                                 <Plus className="w-5 h-5" />
@@ -631,7 +631,7 @@ export function CreateTripDialog({
                       variant="outline"
                       onClick={handleBack}
                       disabled={isPending}
-                      className="flex-1 h-12 rounded-xl border-input"
+                      className="flex-1 h-12 rounded-md border-input"
                     >
                       Back
                     </Button>
@@ -639,7 +639,7 @@ export function CreateTripDialog({
                       type="submit"
                       disabled={isPending}
                       variant="gradient"
-                      className="flex-1 h-12 rounded-xl disabled:opacity-50 disabled:cursor-not-allowed"
+                      className="flex-1 h-12 rounded-md disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       {isPending && (
                         <Loader2 className="w-4 h-4 animate-spin mr-2" />

--- a/apps/web/src/components/trip/edit-trip-dialog.tsx
+++ b/apps/web/src/components/trip/edit-trip-dialog.tsx
@@ -208,7 +208,7 @@ export function EditTripDialog({
                       <Input
                         type="text"
                         placeholder="Bachelor Party in Miami"
-                        className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl"
+                        className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
                         disabled={isPending || isDeleting}
                         aria-required="true"
                         {...field}
@@ -236,7 +236,7 @@ export function EditTripDialog({
                       <Input
                         type="text"
                         placeholder="Miami Beach, FL"
-                        className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl"
+                        className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
                         disabled={isPending || isDeleting}
                         aria-required="true"
                         {...field}
@@ -314,7 +314,7 @@ export function EditTripDialog({
                           <SelectTrigger
                             ref={field.ref}
                             onBlur={field.onBlur}
-                            className="h-12 text-base rounded-xl"
+                            className="h-12 text-base rounded-md"
                             aria-required="true"
                           >
                             <SelectValue />
@@ -353,7 +353,7 @@ export function EditTripDialog({
                       <FormControl>
                         <Textarea
                           placeholder="Tell your group about this trip..."
-                          className="h-32 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl resize-none"
+                          className="h-32 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md resize-none"
                           disabled={isPending || isDeleting}
                           {...field}
                           value={field.value || ""}
@@ -447,7 +447,7 @@ export function EditTripDialog({
                 control={form.control}
                 name="allowMembersToAddEvents"
                 render={({ field }) => (
-                  <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-xl border border-border p-4">
+                  <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border border-border p-4">
                     <FormControl>
                       <Checkbox
                         checked={field.value ?? false}
@@ -477,7 +477,7 @@ export function EditTripDialog({
                 control={form.control}
                 name="showAllMembers"
                 render={({ field }) => (
-                  <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-xl border border-border p-4">
+                  <FormItem className="flex flex-row items-start space-x-3 space-y-0 rounded-md border border-border p-4">
                     <FormControl>
                       <Checkbox
                         checked={field.value ?? false}
@@ -508,7 +508,7 @@ export function EditTripDialog({
                   type="submit"
                   disabled={isPending || isDeleting}
                   variant="gradient"
-                  className="h-12 px-8 rounded-xl disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="h-12 px-8 rounded-md disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {isPending && (
                     <Loader2 className="w-4 h-4 animate-spin mr-2" />

--- a/apps/web/src/components/trip/image-upload.tsx
+++ b/apps/web/src/components/trip/image-upload.tsx
@@ -209,7 +209,7 @@ export function ImageUpload({
 
       {previewUrl ? (
         <div className="relative group">
-          <div className="relative h-48 rounded-xl overflow-hidden border-2 border-border">
+          <div className="relative h-48 rounded-md overflow-hidden border-2 border-border">
             <Image
               src={previewUrl}
               alt="Preview"
@@ -262,7 +262,7 @@ export function ImageUpload({
           tabIndex={disabled ? -1 : 0}
           aria-label="Upload image"
           className={cn(
-            "relative h-48 rounded-xl border-2 border-dashed transition-all duration-200",
+            "relative h-48 rounded-md border-2 border-dashed transition-all duration-200",
             "flex flex-col items-center justify-center gap-3",
             "bg-gradient-to-br from-muted to-primary/10",
             isDragging && !disabled

--- a/apps/web/src/components/trip/invite-members-dialog.tsx
+++ b/apps/web/src/components/trip/invite-members-dialog.tsx
@@ -236,12 +236,12 @@ export function InviteMembersDialog({
                       value={mutualSearch}
                       onChange={(e) => setMutualSearch(e.target.value)}
                       placeholder="Search mutuals..."
-                      className="w-full h-10 pl-9 pr-3 rounded-xl border border-input bg-background text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                      className="w-full h-10 pl-9 pr-3 rounded-md border border-input bg-background text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
                     />
                   </div>
 
                   {/* Scrollable checkbox list */}
-                  <div className="max-h-48 overflow-y-auto space-y-1 rounded-xl border border-border p-2">
+                  <div className="max-h-48 overflow-y-auto space-y-1 rounded-md border border-border p-2">
                     {filteredSuggestions.length === 0 && mutualSearch.trim() ? (
                       <div className="py-6 text-center text-sm text-muted-foreground">
                         <Search className="w-8 h-8 mx-auto mb-2 text-muted-foreground/50" />
@@ -347,7 +347,7 @@ export function InviteMembersDialog({
                             }}
                             disabled={isPending}
                             placeholder="Enter phone number"
-                            className="flex-1 h-12 rounded-xl"
+                            className="flex-1 h-12 rounded-md"
                             aria-describedby={
                               phoneError ? "invite-phone-error" : undefined
                             }
@@ -358,7 +358,7 @@ export function InviteMembersDialog({
                           onClick={handleAddPhone}
                           disabled={isPending}
                           variant="outline"
-                          className="h-12 px-4 rounded-xl"
+                          className="h-12 px-4 rounded-md"
                         >
                           <UserPlus className="w-5 h-5" />
                           Add
@@ -393,7 +393,7 @@ export function InviteMembersDialog({
                   variant="outline"
                   onClick={() => onOpenChange(false)}
                   disabled={isPending}
-                  className="flex-1 h-12 rounded-xl border-input"
+                  className="flex-1 h-12 rounded-md border-input"
                 >
                   Cancel
                 </Button>
@@ -404,7 +404,7 @@ export function InviteMembersDialog({
                     (phoneNumbers.length === 0 && userIds.length === 0)
                   }
                   variant="gradient"
-                  className="flex-1 h-12 rounded-xl disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="flex-1 h-12 rounded-md disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {isPending && (
                     <Loader2 className="w-4 h-4 animate-spin mr-2" />

--- a/apps/web/src/components/trip/member-onboarding-wizard.tsx
+++ b/apps/web/src/components/trip/member-onboarding-wizard.tsx
@@ -440,7 +440,7 @@ export function MemberOnboardingWizard({
                   value={arrivalLocationValue}
                   onChange={(e) => setArrivalLocationValue(e.target.value)}
                   placeholder="e.g., JFK Airport"
-                  className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl"
+                  className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
                 />
               </div>
             </div>
@@ -472,7 +472,7 @@ export function MemberOnboardingWizard({
                   value={departureLocationValue}
                   onChange={(e) => setDepartureLocationValue(e.target.value)}
                   placeholder="e.g., JFK Airport"
-                  className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl"
+                  className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
                 />
               </div>
             </div>
@@ -489,7 +489,7 @@ export function MemberOnboardingWizard({
                   value={eventName}
                   onChange={(e) => setEventName(e.target.value)}
                   placeholder="e.g., Beach day"
-                  className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-xl"
+                  className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
                 />
               </div>
               <div className="space-y-2">
@@ -507,7 +507,7 @@ export function MemberOnboardingWizard({
               <Button
                 type="button"
                 variant="outline"
-                className="h-12 rounded-xl w-full"
+                className="h-12 rounded-md w-full"
                 onClick={handleAddEvent}
                 disabled={
                   !eventName || !eventStartTime || createEvent.isPending
@@ -565,7 +565,7 @@ export function MemberOnboardingWizard({
 
               <div className="space-y-3">
                 {arrivalTime && (
-                  <div className="flex items-start gap-3 p-3 rounded-xl bg-muted/50">
+                  <div className="flex items-start gap-3 p-3 rounded-md bg-muted/50">
                     <Plane className="w-5 h-5 text-primary mt-0.5" />
                     <div>
                       <p className="text-sm font-medium">Arrival</p>
@@ -583,7 +583,7 @@ export function MemberOnboardingWizard({
                 )}
 
                 {departureTime && (
-                  <div className="flex items-start gap-3 p-3 rounded-xl bg-muted/50">
+                  <div className="flex items-start gap-3 p-3 rounded-md bg-muted/50">
                     <Plane className="w-5 h-5 text-primary mt-0.5 rotate-90" />
                     <div>
                       <p className="text-sm font-medium">Departure</p>
@@ -595,7 +595,7 @@ export function MemberOnboardingWizard({
                 )}
 
                 {addedEvents.length > 0 && (
-                  <div className="flex items-start gap-3 p-3 rounded-xl bg-muted/50">
+                  <div className="flex items-start gap-3 p-3 rounded-md bg-muted/50">
                     <Calendar className="w-5 h-5 text-primary mt-0.5" />
                     <div>
                       <p className="text-sm font-medium">Activities</p>
@@ -623,7 +623,7 @@ export function MemberOnboardingWizard({
           <SheetFooter>
             <Button
               variant="gradient"
-              className="h-12 rounded-xl w-full"
+              className="h-12 rounded-md w-full"
               onClick={() => onOpenChange(false)}
             >
               View Itinerary
@@ -635,7 +635,7 @@ export function MemberOnboardingWizard({
               {step > 0 && (
                 <Button
                   variant="outline"
-                  className="h-12 rounded-xl"
+                  className="h-12 rounded-md"
                   onClick={handleBack}
                   disabled={isPending}
                 >
@@ -644,7 +644,7 @@ export function MemberOnboardingWizard({
               )}
               <Button
                 variant="ghost"
-                className="h-12 rounded-xl"
+                className="h-12 rounded-md"
                 onClick={handleSkip}
                 disabled={isPending}
               >
@@ -652,7 +652,7 @@ export function MemberOnboardingWizard({
               </Button>
               <Button
                 variant="gradient"
-                className="h-12 rounded-xl flex-1"
+                className="h-12 rounded-md flex-1"
                 onClick={handleNext}
                 disabled={isPending}
               >

--- a/apps/web/src/components/trip/members-list.tsx
+++ b/apps/web/src/components/trip/members-list.tsx
@@ -365,7 +365,7 @@ export function MembersList({
               onClick={onInvite}
               variant="outline"
               size="sm"
-              className="h-10 px-4 rounded-xl border-input hover:bg-secondary"
+              className="h-10 px-4 rounded-md border-input hover:bg-secondary"
             >
               <UserPlus className="w-4 h-4 mr-2" />
               Invite members
@@ -487,7 +487,7 @@ export function MembersList({
             onClick={onInvite}
             variant="outline"
             size="sm"
-            className="h-10 px-4 rounded-xl border-input hover:bg-secondary"
+            className="h-10 px-4 rounded-md border-input hover:bg-secondary"
           >
             <UserPlus className="w-4 h-4 mr-2" />
             Invite

--- a/apps/web/src/components/trip/rsvp-badge-dropdown.tsx
+++ b/apps/web/src/components/trip/rsvp-badge-dropdown.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { toast } from "sonner";
+import { Check, ChevronDown, CircleCheck, CircleHelp, CircleX } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
+import {
+  useUpdateRsvp,
+  getUpdateRsvpErrorMessage,
+} from "@/hooks/use-invitations";
+import type { UpdateRsvpInput } from "@tripful/shared/schemas";
+
+type RsvpStatus = "going" | "maybe" | "not_going" | "no_response";
+
+const labels: Record<RsvpStatus, string> = {
+  going: "Going",
+  maybe: "Maybe",
+  not_going: "Not Going",
+  no_response: "No Response",
+};
+
+const options: { value: UpdateRsvpInput["status"]; label: string; dot: string }[] = [
+  { value: "going", label: "Going", dot: "bg-success" },
+  { value: "maybe", label: "Maybe", dot: "bg-warning" },
+  { value: "not_going", label: "Not Going", dot: "bg-destructive" },
+];
+
+function StatusIcon({ status, className }: { status: RsvpStatus; className?: string }) {
+  switch (status) {
+    case "going":
+      return <CircleCheck className={`${className} text-success`} />;
+    case "maybe":
+      return <CircleHelp className={`${className} text-warning`} />;
+    case "not_going":
+      return <CircleX className={`${className} text-destructive`} />;
+    case "no_response":
+      return <CircleHelp className={`${className} text-muted-foreground`} />;
+  }
+}
+
+interface RsvpBadgeDropdownProps {
+  tripId: string;
+  status: RsvpStatus;
+}
+
+export function RsvpBadgeDropdown({
+  tripId,
+  status,
+}: RsvpBadgeDropdownProps) {
+  const { mutate: updateRsvp } = useUpdateRsvp(tripId);
+
+  const handleSelect = (newStatus: UpdateRsvpInput["status"]) => {
+    if (newStatus === status) return;
+    updateRsvp(
+      { status: newStatus },
+      {
+        onSuccess: () => {
+          const label = options.find((o) => o.value === newStatus)?.label ?? newStatus;
+          toast.success(`RSVP updated to "${label}"`);
+        },
+        onError: (error) => {
+          const message = getUpdateRsvpErrorMessage(error);
+          toast.error(message ?? "Failed to update RSVP");
+        },
+      },
+    );
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+        >
+          <StatusIcon status={status} className="w-5 h-5" />
+          <span className="text-sm">{labels[status]}</span>
+          <ChevronDown className="w-3.5 h-3.5 opacity-50" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        {options.map((option) => (
+          <DropdownMenuItem
+            key={option.value}
+            onClick={() => handleSelect(option.value)}
+          >
+            <span className={`size-2 rounded-full ${option.dot}`} />
+            {option.label}
+            {status === option.value && (
+              <Check className="ml-auto size-4 text-foreground" />
+            )}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/web/src/components/trip/rsvp-badge-dropdown.tsx
+++ b/apps/web/src/components/trip/rsvp-badge-dropdown.tsx
@@ -39,6 +39,10 @@ function StatusIcon({ status, className }: { status: RsvpStatus; className?: str
       return <CircleX className={`${className} text-destructive`} />;
     case "no_response":
       return <CircleHelp className={`${className} text-muted-foreground`} />;
+    default: {
+      const _exhaustive: never = status;
+      return _exhaustive;
+    }
   }
 }
 

--- a/apps/web/src/components/trip/travel-reminder-banner.tsx
+++ b/apps/web/src/components/trip/travel-reminder-banner.tsx
@@ -61,7 +61,7 @@ export function TravelReminderBanner({
 
   return (
     <div data-testid="travel-reminder-banner" className="mb-6">
-      <div className="relative rounded-2xl border border-primary/20 bg-primary/[0.03] p-4 sm:p-5">
+      <div className="relative rounded-md border border-primary/20 bg-primary/[0.03] p-4 sm:p-5">
         <div className="flex flex-col sm:flex-row items-start gap-3 sm:gap-4">
           <div className="rounded-full bg-primary/10 p-2.5 shrink-0">
             <Plane className="w-5 h-5 text-primary" aria-hidden="true" />
@@ -79,7 +79,7 @@ export function TravelReminderBanner({
                 onClick={onAddTravel}
                 variant="gradient"
                 size="sm"
-                className="rounded-xl w-full sm:w-auto min-h-[44px]"
+                className="rounded-md w-full sm:w-auto min-h-[44px]"
               >
                 Add Travel Details
               </Button>
@@ -87,7 +87,7 @@ export function TravelReminderBanner({
                 onClick={handleDismiss}
                 variant="ghost"
                 size="sm"
-                className="rounded-xl text-muted-foreground min-h-[44px]"
+                className="rounded-md text-muted-foreground min-h-[44px]"
               >
                 Dismiss
               </Button>

--- a/apps/web/src/components/trip/trip-card.tsx
+++ b/apps/web/src/components/trip/trip-card.tsx
@@ -51,10 +51,10 @@ export const TripCard = memo(function TripCard({
   const preset = trip.themeId
     ? (THEME_PRESETS.find((p) => p.id === trip.themeId) ?? null)
     : null;
-  // Mat background: theme background or a warm neutral
+  // Mat background: white border (theme cards use theme background)
   const matBackground = preset
     ? buildBackground(preset.background)
-    : "#eee5d6";
+    : "#ffffff";
 
   const fontFamily = trip.themeFont
     ? THEME_FONTS[trip.themeFont as keyof typeof THEME_FONTS]
@@ -73,7 +73,7 @@ export const TripCard = memo(function TripCard({
         )}
         style={{ animationDelay: `${index * 80}ms` }}
       >
-        {/* Mat: theme background border */}
+        {/* Mat: white border */}
         <div className="postcard-mat" style={{ background: matBackground }}>
           {/* Inner: cover image with overlay */}
           <div className="postcard-image">
@@ -112,7 +112,7 @@ export const TripCard = memo(function TripCard({
               {/* Trip info overlay — bottom */}
               <div className="absolute bottom-0 left-0 right-0 p-4">
                 <h3
-                  className="text-lg font-semibold text-white mb-1 truncate"
+                  className="text-lg font-semibold text-white mb-1 truncate font-[family-name:var(--font-playfair)]"
                   style={fontFamily ? { fontFamily } : undefined}
                 >
                   {trip.name}
@@ -129,6 +129,7 @@ export const TripCard = memo(function TripCard({
                 </div>
               </div>
             </div>
+
           </div>
       </Link>
     </TripThemeProvider>

--- a/apps/web/src/components/trip/trip-card.tsx
+++ b/apps/web/src/components/trip/trip-card.tsx
@@ -3,10 +3,10 @@
 import { memo } from "react";
 import Link from "next/link";
 import Image from "next/image";
-import { Calendar, MapPin, ClipboardList, ImagePlus } from "lucide-react";
+import { Calendar, MapPin, ImagePlus } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { RsvpBadge } from "@/components/ui/rsvp-badge";
-import { formatDateRange, getInitials } from "@/lib/format";
+import { formatDateRange } from "@/lib/format";
 import { getUploadUrl } from "@/lib/api";
 import { TripThemeProvider } from "@/components/trip/trip-theme-provider";
 import { buildBackground } from "@/lib/theme-styles";
@@ -51,141 +51,85 @@ export const TripCard = memo(function TripCard({
   const preset = trip.themeId
     ? (THEME_PRESETS.find((p) => p.id === trip.themeId) ?? null)
     : null;
+  // Mat background: theme background or a warm neutral
+  const matBackground = preset
+    ? buildBackground(preset.background)
+    : "#eee5d6";
 
-  // Show up to 3 organizers
-  const displayedOrganizers = (trip.organizerInfo ?? []).slice(0, 3);
-  const firstOrganizer = trip.organizerInfo?.[0];
-  const organizerLabel = firstOrganizer
-    ? `${firstOrganizer.displayName}${(trip.organizerInfo?.length ?? 0) > 1 ? ` +${(trip.organizerInfo?.length ?? 0) - 1}` : ""}`
-    : "";
+  const fontFamily = trip.themeFont
+    ? THEME_FONTS[trip.themeFont as keyof typeof THEME_FONTS]
+    : undefined;
 
   return (
     <TripThemeProvider themeId={trip.themeId} themeFont={trip.themeFont}>
       <Link
-      href={`/trips/${trip.id}`}
-      {...(supportsHover ? { onMouseEnter: prefetchTrip } : {})}
-      onTouchStart={prefetchTrip}
-      onFocus={prefetchTrip}
-      className={cn(
-        "block bg-card rounded-2xl overflow-hidden border border-border shadow-sm hover:shadow-lg motion-safe:active:scale-[0.98] transition-all cursor-pointer motion-safe:animate-[staggerIn_500ms_ease-out_both] motion-safe:hover:-translate-y-1 card-noise",
-        className,
-      )}
-      style={{ animationDelay: `${index * 80}ms` }}
-    >
-      {/* Cover image or placeholder */}
-      {trip.coverImageUrl ? (
-        <div className="relative h-48 overflow-hidden">
-          <Image
-            src={getUploadUrl(trip.coverImageUrl)!}
-            alt={trip.name}
-            fill
-            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-            className="object-cover"
-          />
-          <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent" />
-
-          {/* Badges overlay */}
-          <div className="absolute top-3 left-3 flex gap-2">
-            {trip.isOrganizer && (
-              <Badge className="bg-black/50 backdrop-blur-md text-white border-white/20 shadow-sm">
-                Organizing
-              </Badge>
-            )}
-            <RsvpBadge status={trip.rsvpStatus} variant="overlay" />
-          </div>
-        </div>
-      ) : preset ? (
-        <div className="relative h-48 overflow-hidden">
-          <div className="absolute inset-0" style={{ background: buildBackground(preset.background) }} />
-          <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-transparent" />
-          {/* Badges overlay */}
-          <div className="absolute top-3 left-3 flex gap-2">
-            {trip.isOrganizer && (
-              <Badge className="bg-black/50 backdrop-blur-md text-white border-white/20 shadow-sm">
-                Organizing
-              </Badge>
-            )}
-            <RsvpBadge status={trip.rsvpStatus} variant="overlay" />
-          </div>
-        </div>
-      ) : (
-        <div className="relative h-48 overflow-hidden bg-gradient-to-br from-primary/20 via-accent/15 to-secondary/20">
-          <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-transparent" />
-          <div className="absolute inset-0 flex items-center justify-center">
-            <ImagePlus className="w-8 h-8 text-white/30" />
-          </div>
-
-          {/* Badges overlay */}
-          <div className="absolute top-3 left-3 flex gap-2">
-            {trip.isOrganizer && (
-              <Badge className="bg-black/50 backdrop-blur-md text-white border-white/20 shadow-sm">
-                Organizing
-              </Badge>
-            )}
-            <RsvpBadge status={trip.rsvpStatus} variant="overlay" />
-          </div>
-        </div>
-      )}
-
-      {/* Content */}
-      <div className="p-4 space-y-3">
-        <div>
-          <h3
-            className="text-lg font-semibold text-foreground mb-1 truncate font-[family-name:var(--font-playfair)]"
-            style={trip.themeFont ? { fontFamily: THEME_FONTS[trip.themeFont as keyof typeof THEME_FONTS] } : undefined}
-          >
-            {trip.name}
-          </h3>
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <MapPin className="w-4 h-4 shrink-0" />
-            <span className="truncate">{trip.destination}</span>
-          </div>
-        </div>
-
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <Calendar className="w-4 h-4 shrink-0" />
-          <span>{dateRange}</span>
-        </div>
-
-        {/* Footer */}
-        <div className="flex items-center justify-between pt-3 border-t border-border">
-          <div className="flex items-center gap-2 min-w-0">
-            <div className="flex -space-x-2 shrink-0">
-              {displayedOrganizers.map((org) =>
-                org.profilePhotoUrl ? (
-                  <Image
-                    key={org.id}
-                    src={getUploadUrl(org.profilePhotoUrl)!}
-                    alt={org.displayName}
-                    width={24}
-                    height={24}
-                    className="w-6 h-6 rounded-full ring-2 ring-white object-cover"
-                  />
-                ) : (
-                  <div
-                    key={org.id}
-                    className="w-6 h-6 rounded-full ring-2 ring-white bg-muted flex items-center justify-center text-[10px] font-medium text-foreground"
-                  >
-                    {getInitials(org.displayName)}
-                  </div>
-                ),
+        href={`/trips/${trip.id}`}
+        {...(supportsHover ? { onMouseEnter: prefetchTrip } : {})}
+        onTouchStart={prefetchTrip}
+        onFocus={prefetchTrip}
+        className={cn(
+          "postcard motion-safe:animate-[staggerIn_500ms_ease-out_both]",
+          className,
+        )}
+        style={{ animationDelay: `${index * 80}ms` }}
+      >
+        {/* Mat: theme background border */}
+        <div className="postcard-mat" style={{ background: matBackground }}>
+          {/* Inner: cover image with overlay */}
+          <div className="postcard-image">
+              {trip.coverImageUrl ? (
+                <Image
+                  src={getUploadUrl(trip.coverImageUrl)!}
+                  alt={trip.name}
+                  fill
+                  sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+                  className="object-cover"
+                />
+              ) : preset ? (
+                <div
+                  className="absolute inset-0"
+                  style={{ background: buildBackground(preset.background) }}
+                />
+              ) : (
+                <div className="absolute inset-0 bg-gradient-to-br from-primary/20 via-accent/15 to-secondary/20 flex items-center justify-center">
+                  <ImagePlus className="w-8 h-8 text-foreground/20" />
+                </div>
               )}
-            </div>
-            <span className="text-xs text-muted-foreground truncate">
-              {organizerLabel}
-            </span>
-          </div>
 
-          <div className="flex items-center gap-1 text-xs text-muted-foreground shrink-0">
-            <ClipboardList className="w-4 h-4" />
-            <span>
-              {trip.eventCount === 0
-                ? "No events yet"
-                : `${trip.eventCount} event${trip.eventCount === 1 ? "" : "s"}`}
-            </span>
+              {/* Scrim gradient for text readability */}
+              <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent" />
+
+              {/* Badges overlay — top-left */}
+              <div className="absolute top-3 left-3 flex gap-2">
+                {trip.isOrganizer && (
+                  <Badge className="bg-black/50 backdrop-blur-md text-white border-white/20 shadow-sm">
+                    Organizing
+                  </Badge>
+                )}
+                <RsvpBadge status={trip.rsvpStatus} variant="overlay" />
+              </div>
+
+              {/* Trip info overlay — bottom */}
+              <div className="absolute bottom-0 left-0 right-0 p-4">
+                <h3
+                  className="text-lg font-semibold text-white mb-1 truncate"
+                  style={fontFamily ? { fontFamily } : undefined}
+                >
+                  {trip.name}
+                </h3>
+                <div className="flex items-center gap-3 text-white/80 text-sm">
+                  <span className="flex items-center gap-1 truncate">
+                    <MapPin className="w-3.5 h-3.5 shrink-0" />
+                    {trip.destination}
+                  </span>
+                  <span className="flex items-center gap-1 shrink-0">
+                    <Calendar className="w-3.5 h-3.5 shrink-0" />
+                    {dateRange}
+                  </span>
+                </div>
+              </div>
+            </div>
           </div>
-        </div>
-      </div>
       </Link>
     </TripThemeProvider>
   );

--- a/apps/web/src/components/trip/trip-preview.tsx
+++ b/apps/web/src/components/trip/trip-preview.tsx
@@ -144,7 +144,7 @@ export function TripPreview({
         )}
 
         {/* Invitation CTA card — the main action */}
-        <div className="rounded-2xl border border-primary/20 bg-primary/[0.03] p-5 sm:p-6">
+        <div className="rounded-md border border-primary/20 bg-primary/[0.03] p-5 sm:p-6">
           <div className="text-center mb-5">
             <p className="text-lg sm:text-xl font-semibold text-foreground mb-1">
               You've been invited!
@@ -163,7 +163,7 @@ export function TripPreview({
               onClick={() => handleRsvp("going")}
               disabled={isPending}
               size="lg"
-              className={`flex-1 h-12 rounded-xl text-base font-semibold ${
+              className={`flex-1 h-12 rounded-md text-base font-semibold ${
                 trip.userRsvpStatus === "going"
                   ? "bg-success hover:bg-success/90 text-white shadow-md shadow-success/25"
                   : "bg-success/10 text-success hover:bg-success/20 border border-success/30"
@@ -181,7 +181,7 @@ export function TripPreview({
               onClick={() => handleRsvp("maybe")}
               disabled={isPending}
               size="lg"
-              className={`flex-1 h-12 rounded-xl text-base font-semibold ${
+              className={`flex-1 h-12 rounded-md text-base font-semibold ${
                 trip.userRsvpStatus === "maybe"
                   ? "bg-warning hover:bg-warning/90 text-white shadow-md shadow-warning/25"
                   : "bg-warning/10 text-warning hover:bg-warning/20 border border-warning/30"
@@ -199,7 +199,7 @@ export function TripPreview({
               onClick={() => handleRsvp("not_going")}
               disabled={isPending}
               size="lg"
-              className={`flex-1 h-12 rounded-xl text-base font-semibold ${
+              className={`flex-1 h-12 rounded-md text-base font-semibold ${
                 trip.userRsvpStatus === "not_going"
                   ? "bg-destructive/15 text-destructive shadow-md shadow-destructive/10 border border-destructive/30"
                   : "bg-muted/50 text-muted-foreground hover:bg-muted border border-border"

--- a/apps/web/src/components/ui/airmail-stripe.tsx
+++ b/apps/web/src/components/ui/airmail-stripe.tsx
@@ -1,0 +1,22 @@
+import { cn } from "@/lib/utils";
+
+interface AirmailStripeProps {
+  variant?: "thin" | "medium";
+  className?: string;
+}
+
+export function AirmailStripe({
+  variant = "thin",
+  className,
+}: AirmailStripeProps) {
+  return (
+    <div
+      className={cn(
+        "airmail-stripe w-full",
+        variant === "thin" ? "h-1.5" : "h-3",
+        className,
+      )}
+      aria-hidden="true"
+    />
+  );
+}

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -7,7 +7,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center justify-center rounded-full border border-transparent px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden font-accent",
+  "inline-flex items-center justify-center rounded-sm border border-transparent px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden font-accent",
   {
     variants: {
       variant: {

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -7,7 +7,7 @@ import { Slot } from "radix-ui";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-xl text-sm font-medium cursor-pointer transition-all motion-safe:active:scale-[0.97] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium cursor-pointer transition-all motion-safe:active:scale-[0.97] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 aria-invalid:border-destructive",
   {
     variants: {
       variant: {

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-md border py-6 shadow-sm",
         className,
       )}
       {...props}

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -10,7 +10,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground border-input h-11 w-full min-w-0 rounded-xl border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow,border-color] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground border-input h-11 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow,border-color] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 aria-invalid:border-destructive",
         className,

--- a/apps/web/src/components/ui/postcard-back.tsx
+++ b/apps/web/src/components/ui/postcard-back.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import { AirmailStripe } from "./airmail-stripe";
+import { PostmarkStamp } from "./postmark-stamp";
+
+interface PostcardBackProps {
+  children: ReactNode;
+  aside?: ReactNode | undefined;
+  stampDate?: string | undefined;
+  stampCity?: string | undefined;
+  className?: string | undefined;
+}
+
+export function PostcardBack({
+  children,
+  aside,
+  stampDate,
+  stampCity,
+  className,
+}: PostcardBackProps) {
+  return (
+    <div
+      className={cn(
+        "relative bg-card rounded-md shadow-sm overflow-hidden linen-texture",
+        className,
+      )}
+    >
+      {/* Top airmail stripe */}
+      <AirmailStripe variant="medium" />
+
+      <div className="relative p-6 sm:p-8">
+        {/* Stamp + postmark in top-right corner */}
+        <div className="absolute top-4 right-4 sm:top-6 sm:right-6 flex items-start gap-0">
+          {/* Stamp placeholder */}
+          <div className="w-12 h-14 sm:w-14 sm:h-16 border-2 border-dashed border-border rounded-sm bg-card/50" />
+          {/* Postmark overlapping stamp */}
+          <div className="-ml-6 mt-2">
+            <PostmarkStamp
+              date={stampDate}
+              city={stampCity}
+              size="md"
+            />
+          </div>
+        </div>
+
+        {/* Two-column layout on md+ */}
+        <div className="md:grid md:grid-cols-[1fr_220px] md:gap-8">
+          {/* Left: main content with writing lines */}
+          <div className="writing-lines min-h-[200px] pr-4 md:border-r md:border-border">
+            {children}
+          </div>
+
+          {/* Right: metadata aside */}
+          {aside && (
+            <div className="mt-6 md:mt-0 pt-6 md:pt-10">
+              {aside}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Bottom airmail stripe */}
+      <AirmailStripe variant="medium" />
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/postmark-stamp.tsx
+++ b/apps/web/src/components/ui/postmark-stamp.tsx
@@ -1,0 +1,114 @@
+import { cn } from "@/lib/utils";
+
+interface PostmarkStampProps {
+  date?: string | undefined;
+  city?: string | undefined;
+  className?: string | undefined;
+  size?: "sm" | "md" | "lg" | undefined;
+}
+
+export function PostmarkStamp({
+  date,
+  city,
+  className,
+  size = "md",
+}: PostmarkStampProps) {
+  const sizeMap = {
+    sm: { outer: 48, stroke: 1.5, fontSize: 5, lineGap: 6 },
+    md: { outer: 72, stroke: 2, fontSize: 7, lineGap: 8 },
+    lg: { outer: 96, stroke: 2, fontSize: 9, lineGap: 10 },
+  };
+  const s = sizeMap[size];
+  const cx = s.outer / 2;
+  const cy = s.outer / 2;
+  const r = cx - 4;
+
+  return (
+    <svg
+      width={s.outer}
+      height={s.outer}
+      viewBox={`0 0 ${s.outer} ${s.outer}`}
+      className={cn("text-foreground opacity-35", className)}
+      style={{ transform: "rotate(-15deg)" }}
+      aria-hidden="true"
+    >
+      {/* Outer circle */}
+      <circle
+        cx={cx}
+        cy={cy}
+        r={r}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={s.stroke}
+      />
+      {/* Inner circle */}
+      <circle
+        cx={cx}
+        cy={cy}
+        r={r - 3}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={s.stroke * 0.6}
+      />
+
+      {/* Cancellation lines extending past circle */}
+      {[-s.lineGap, 0, s.lineGap].map((offset) => (
+        <line
+          key={offset}
+          x1={0}
+          y1={cy + offset}
+          x2={s.outer}
+          y2={cy + offset}
+          stroke="currentColor"
+          strokeWidth={s.stroke * 0.8}
+        />
+      ))}
+
+      {/* City text — top arc */}
+      {city && (
+        <>
+          <defs>
+            <path
+              id={`city-arc-${size}`}
+              d={`M ${cx - r + 8} ${cy} A ${r - 8} ${r - 8} 0 0 1 ${cx + r - 8} ${cy}`}
+            />
+          </defs>
+          <text
+            fill="currentColor"
+            fontSize={s.fontSize}
+            fontFamily="var(--font-typewriter), monospace"
+            textAnchor="middle"
+            letterSpacing="0.12em"
+          >
+            <textPath href={`#city-arc-${size}`} startOffset="50%">
+              {city.toUpperCase()}
+            </textPath>
+          </text>
+        </>
+      )}
+
+      {/* Date text — bottom arc */}
+      {date && (
+        <>
+          <defs>
+            <path
+              id={`date-arc-${size}`}
+              d={`M ${cx - r + 8} ${cy} A ${r - 8} ${r - 8} 0 0 0 ${cx + r - 8} ${cy}`}
+            />
+          </defs>
+          <text
+            fill="currentColor"
+            fontSize={s.fontSize}
+            fontFamily="var(--font-typewriter), monospace"
+            textAnchor="middle"
+            letterSpacing="0.1em"
+          >
+            <textPath href={`#date-arc-${size}`} startOffset="50%">
+              {date.toUpperCase()}
+            </textPath>
+          </text>
+        </>
+      )}
+    </svg>
+  );
+}

--- a/apps/web/src/components/ui/skeleton.tsx
+++ b/apps/web/src/components/ui/skeleton.tsx
@@ -6,7 +6,7 @@ function Skeleton({ className, ...props }: ComponentProps<"div">) {
     <div
       data-slot="skeleton"
       className={cn(
-        "bg-muted rounded-lg relative overflow-hidden",
+        "bg-muted rounded-md relative overflow-hidden",
         "after:absolute after:inset-0 after:animate-[shimmer_2s_infinite] after:bg-gradient-to-r after:from-transparent after:via-white/40 after:to-transparent after:-translate-x-full",
         className,
       )}

--- a/apps/web/src/hooks/use-invitations.ts
+++ b/apps/web/src/hooks/use-invitations.ts
@@ -25,8 +25,8 @@ import {
   mySettingsQueryOptions,
 } from "./invitation-queries";
 
-// Import trip keys for cache invalidation on RSVP and member removal
-import { tripKeys } from "./trip-queries";
+// Import trip keys and types for cache invalidation and optimistic updates on RSVP
+import { tripKeys, type TripDetailWithMeta } from "./trip-queries";
 
 // Import event keys for cache invalidation on member removal (creatorAttending depends on member existence)
 import { eventKeys } from "./event-queries";
@@ -294,7 +294,12 @@ export function getUpdateMemberRoleErrorMessage(
 export function useUpdateRsvp(tripId: string) {
   const queryClient = useQueryClient();
 
-  return useMutation<MemberWithProfile, APIError, UpdateRsvpInput>({
+  return useMutation<
+    MemberWithProfile,
+    APIError,
+    UpdateRsvpInput,
+    { previousTrip: TripDetailWithMeta | undefined }
+  >({
     mutationKey: rsvpKeys.update(),
     mutationFn: async (data) => {
       const response = await apiRequest<UpdateRsvpResponse>(
@@ -305,6 +310,30 @@ export function useUpdateRsvp(tripId: string) {
         },
       );
       return response.member;
+    },
+    onMutate: async (data) => {
+      await queryClient.cancelQueries({ queryKey: tripKeys.detail(tripId) });
+
+      const previousTrip = queryClient.getQueryData<TripDetailWithMeta>(
+        tripKeys.detail(tripId),
+      );
+
+      if (previousTrip) {
+        queryClient.setQueryData<TripDetailWithMeta>(
+          tripKeys.detail(tripId),
+          { ...previousTrip, userRsvpStatus: data.status },
+        );
+      }
+
+      return { previousTrip };
+    },
+    onError: (_error, _data, context) => {
+      if (context?.previousTrip) {
+        queryClient.setQueryData(
+          tripKeys.detail(tripId),
+          context.previousTrip,
+        );
+      }
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: tripKeys.detail(tripId) });

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -21,7 +21,8 @@ export function getUploadUrl(
 ): string | undefined {
   if (!path) return undefined;
   if (path.startsWith("http") || path.startsWith("blob:")) return path;
-  return `${API_BASE}${path}`;
+  // Use relative path so Next.js Image can optimize via the /uploads rewrite
+  return path.startsWith("/") ? path : `${API_BASE}${path}`;
 }
 
 /**

--- a/apps/web/src/lib/fonts.ts
+++ b/apps/web/src/lib/fonts.ts
@@ -1,11 +1,35 @@
 import {
+  Bungee_Shade,
   Caveat,
+  Italiana,
   Nunito,
   Oswald,
   Playfair_Display,
   Plus_Jakarta_Sans,
   Space_Grotesk,
+  Special_Elite,
 } from "next/font/google";
+
+export const bungeeShade = Bungee_Shade({
+  subsets: ["latin"],
+  variable: "--font-display",
+  display: "swap",
+  weight: ["400"],
+});
+
+export const italiana = Italiana({
+  subsets: ["latin"],
+  variable: "--font-script",
+  display: "swap",
+  weight: ["400"],
+});
+
+export const specialElite = Special_Elite({
+  subsets: ["latin"],
+  variable: "--font-typewriter",
+  display: "swap",
+  weight: ["400"],
+});
 
 export const playfairDisplay = Playfair_Display({
   subsets: ["latin"],

--- a/apps/web/tests/e2e/helpers/pages/profile.page.ts
+++ b/apps/web/tests/e2e/helpers/pages/profile.page.ts
@@ -33,6 +33,9 @@ export class ProfilePage {
   /** Navigate to trips page and open the profile dialog from the header dropdown */
   async goto() {
     await this.page.goto("/trips");
+    // Wait for auth context to load user data before opening the dropdown,
+    // otherwise the profile menu item won't render (it's gated on user !== null).
+    await this.page.waitForLoadState("networkidle");
     await this.openDialog();
   }
 
@@ -49,7 +52,14 @@ export class ProfilePage {
       await this.page.getByRole("button", { name: "Open menu" }).click();
       await this.page.getByTestId("mobile-menu-profile-button").click();
     } else {
-      await this.page.getByRole("button", { name: "User menu" }).click();
+      const userMenuBtn = this.page.getByRole("button", {
+        name: "User menu",
+      });
+      await userMenuBtn.waitFor({ state: "visible", timeout: ELEMENT_TIMEOUT });
+      await userMenuBtn.click();
+      await this.page
+        .getByTestId("profile-menu-item")
+        .waitFor({ state: "visible", timeout: ELEMENT_TIMEOUT });
       await this.page.getByTestId("profile-menu-item").click();
     }
     await this.heading.waitFor({ state: "visible", timeout: ELEMENT_TIMEOUT });

--- a/apps/web/tests/e2e/helpers/pages/trips.page.ts
+++ b/apps/web/tests/e2e/helpers/pages/trips.page.ts
@@ -24,7 +24,7 @@ export class TripsPage {
     this.userMenuButton = page.getByRole("button", { name: "User menu" });
     this.mobileMenuButton = page.getByRole("button", { name: "Open menu" });
     this.emptyStateHeading = page.getByRole("heading", {
-      name: "No trips yet",
+      name: "Your adventures await",
     });
     this.emptyStateCreateButton = page.getByRole("button", {
       name: "Create your first trip",

--- a/apps/web/tests/e2e/invitation-journey.spec.ts
+++ b/apps/web/tests/e2e/invitation-journey.spec.ts
@@ -302,6 +302,48 @@ test.describe("Invitation Journey", () => {
         await snap(page, "16-member-not-attending-indicator");
       });
 
+      await test.step("organizer changes own RSVP via dropdown", async () => {
+        // The organizer is already on the trip detail page from the previous step.
+        // Click the RSVP dropdown (organizer is "Going" by default)
+        const rsvpButton = page.getByRole("button", { name: "Going" });
+        await rsvpButton.waitFor({ state: "visible", timeout: ELEMENT_TIMEOUT });
+        await rsvpButton.click();
+
+        // Select "Maybe" from the dropdown
+        await page.getByRole("menuitem", { name: "Maybe" }).click();
+
+        // Wait for dropdown to close
+        await expect(page.getByRole("menu")).not.toBeVisible();
+
+        // Verify toast confirms the change
+        await expect(page.getByText('RSVP updated to "Maybe"')).toBeVisible({
+          timeout: TOAST_TIMEOUT,
+        });
+        await dismissToast(page);
+
+        // Trigger button should now show "Maybe"
+        const maybeButton = page.getByRole("button", { name: "Maybe" });
+        await maybeButton.waitFor({ state: "visible", timeout: ELEMENT_TIMEOUT });
+
+        // Change back to "Going" via dropdown
+        await maybeButton.click();
+        await page.getByRole("menuitem", { name: "Going" }).first().click();
+
+        // Wait for dropdown to close
+        await expect(page.getByRole("menu")).not.toBeVisible();
+
+        await expect(page.getByText('RSVP updated to "Going"')).toBeVisible({
+          timeout: TOAST_TIMEOUT,
+        });
+        await dismissToast(page);
+
+        await expect(
+          page.getByRole("button", { name: "Going" }),
+        ).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+
+        await snap(page, "16b-organizer-rsvp-dropdown");
+      });
+
       await test.step("member RSVPs Going again, indicator removed", async () => {
         // Use API shortcut to change RSVP back to going
         const inviteeCookie = await createUserViaAPI(


### PR DESCRIPTION
## Summary
- Add `RsvpBadgeDropdown` component that lets users change RSVP status directly from the trip detail page
- Move RSVP indicator from hero overlay into the stats row, matching icon+text style of members/events items
- Add e2e test step covering the dropdown flow (Going → Maybe → Going)

## Test plan
- [x] E2E test added to "RSVP status change and member indicator" flow
- [ ] Navigate to a trip where you're a member — tap the RSVP status in the stats row
- [ ] Dropdown shows Going/Maybe/Not Going with check on current status
- [ ] Selecting a new status shows success toast and updates the button

🤖 Generated with [Claude Code](https://claude.com/claude-code)