### PR TITLE
Fix image URLs and revert Zod 4 string validators

### DIFF
--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -18,7 +18,8 @@ const envSchema = z.object({
 
   // Database
   DATABASE_URL: z
-    .url({ error: "DATABASE_URL must be a valid PostgreSQL URL" })
+    .string()
+    .url("DATABASE_URL must be a valid PostgreSQL URL")
     .refine(
       (url) => url.startsWith("postgresql://"),
       "DATABASE_URL must start with postgresql://",
@@ -31,7 +32,8 @@ const envSchema = z.object({
 
   // Frontend
   FRONTEND_URL: z
-    .url({ error: "FRONTEND_URL must be a valid URL" })
+    .string()
+    .url("FRONTEND_URL must be a valid URL")
     .default("http://localhost:3000"),
 
   // Proxy

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -19,16 +19,7 @@ const nextConfig: NextConfig = {
     ];
   },
   images: {
-    remotePatterns: [
-      {
-        protocol: "http",
-        hostname: "localhost",
-      },
-      {
-        protocol: "https",
-        hostname: "api.tripful.me",
-      },
-    ],
+    remotePatterns: [],
   },
 };
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -7,22 +7,18 @@ export const API_URL =
 
 /**
  * Normalize an upload path for use in <Image> and <img> tags.
- * Relative paths (e.g. /uploads/uuid.jpg) are prefixed with the API
- * base URL so the browser fetches directly from the API server, which
- * redirects to a signed S3 URL in production.
+ * Returns the path as-is (e.g. /uploads/uuid.jpg) so that Next.js
+ * rewrites proxy the request to the API in every environment.
  *
  * Returns undefined for null/undefined input. Passes through absolute
  * URLs (http/https) and blob URLs unchanged.
  */
-const API_BASE = API_URL.replace(/\/api$/, "");
-
 export function getUploadUrl(
   path: string | null | undefined,
 ): string | undefined {
   if (!path) return undefined;
   if (path.startsWith("http") || path.startsWith("blob:")) return path;
-  // Use relative path so Next.js Image can optimize via the /uploads rewrite
-  return path.startsWith("/") ? path : `${API_BASE}${path}`;
+  return path;
 }
 
 /**

--- a/shared/schemas/accommodation.ts
+++ b/shared/schemas/accommodation.ts
@@ -28,9 +28,7 @@ const baseAccommodationSchema = z.object({
   checkOut: z.string().datetime({ offset: true }).or(z.string().datetime()),
   links: z
     .array(
-      z.url({
-        error: "Link must be a valid URL",
-      }),
+      z.string().url("Link must be a valid URL"),
     )
     .max(10, {
       error: "Links must not exceed 10 items",

--- a/shared/schemas/event.ts
+++ b/shared/schemas/event.ts
@@ -35,9 +35,7 @@ const baseEventSchema = z.object({
   isOptional: z.boolean().default(false),
   links: z
     .array(
-      z.url({
-        error: "Link must be a valid URL",
-      }),
+      z.string().url("Link must be a valid URL"),
     )
     .max(10, {
       error: "Links must not exceed 10 items",

--- a/shared/schemas/index.ts
+++ b/shared/schemas/index.ts
@@ -8,16 +8,12 @@ export { phoneNumberSchema, PHONE_REGEX } from "./phone";
 /**
  * Validates email addresses using Zod's built-in email validator
  */
-export const emailSchema = z.email({
-  error: "Invalid email address",
-});
+export const emailSchema = z.string().email("Invalid email address");
 
 /**
  * Validates UUID strings (v4 format)
  */
-export const uuidSchema = z.uuid({
-  error: "Invalid UUID format",
-});
+export const uuidSchema = z.string().uuid("Invalid UUID format");
 
 // Re-export authentication schemas
 export {

--- a/shared/schemas/invitation.ts
+++ b/shared/schemas/invitation.ts
@@ -19,7 +19,7 @@ export const createInvitationsSchema = z
       .optional()
       .default([]),
     userIds: z
-      .array(z.uuid({ error: "Each user ID must be a valid UUID" }))
+      .array(z.string().uuid("Each user ID must be a valid UUID"))
       .max(25, {
         error: "Cannot invite more than 25 members at once",
       })

--- a/shared/schemas/member-travel.ts
+++ b/shared/schemas/member-travel.ts
@@ -29,7 +29,7 @@ const baseMemberTravelSchema = z.object({
  * - memberId: UUID of target member for delegation (optional, organizer-only)
  */
 export const createMemberTravelSchema = baseMemberTravelSchema.extend({
-  memberId: z.uuid({ error: "Invalid member ID format" }).optional(),
+  memberId: z.string().uuid("Invalid member ID format").optional(),
 });
 
 /**

--- a/shared/schemas/message.ts
+++ b/shared/schemas/message.ts
@@ -14,7 +14,7 @@ export const createMessageSchema = z.object({
     .min(1, "Message cannot be empty")
     .max(2000, "Message too long")
     .transform(stripControlChars),
-  parentId: z.uuid().optional(),
+  parentId: z.string().uuid().optional(),
 });
 
 /**
@@ -57,17 +57,17 @@ const reactionSummarySchema = z.object({
 
 /** Message author as returned by the API */
 const messageAuthorSchema = z.object({
-  id: z.uuid(),
+  id: z.string().uuid(),
   displayName: z.string(),
   profilePhotoUrl: z.string().nullable(),
 });
 
 /** Message entity as returned by the API */
 const messageEntitySchema = z.object({
-  id: z.uuid(),
-  tripId: z.uuid(),
-  authorId: z.uuid(),
-  parentId: z.uuid().nullable(),
+  id: z.string().uuid(),
+  tripId: z.string().uuid(),
+  authorId: z.string().uuid(),
+  parentId: z.string().uuid().nullable(),
   content: z.string(),
   isPinned: z.boolean(),
   editedAt: z.date().nullable(),

--- a/shared/schemas/mutuals.ts
+++ b/shared/schemas/mutuals.ts
@@ -10,7 +10,7 @@ import { z } from "zod";
  * - limit: page size (default 20, max 50)
  */
 export const getMutualsQuerySchema = z.object({
-  tripId: z.uuid().optional(),
+  tripId: z.string().uuid().optional(),
   search: z.string().max(100).optional(),
   cursor: z.string().max(500).optional(),
   limit: z.coerce.number().int().positive().max(50).optional().default(20),

--- a/shared/schemas/notification.ts
+++ b/shared/schemas/notification.ts
@@ -16,9 +16,9 @@ export const notificationPreferencesSchema = z.object({
 
 /** Notification entity as returned by the API */
 const notificationEntitySchema = z.object({
-  id: z.uuid(),
-  userId: z.uuid(),
-  tripId: z.uuid().nullable(),
+  id: z.string().uuid(),
+  userId: z.string().uuid(),
+  tripId: z.string().uuid().nullable(),
   type: z.enum([
     "daily_itinerary",
     "trip_message",


### PR DESCRIPTION
## Summary
- **Image fix**: `getUploadUrl()` now returns relative paths (`/uploads/uuid.jpg`) instead of prepending the API host, so Next.js rewrites proxy images correctly in both dev and prod
- **Cleared `remotePatterns`**: No longer needed since images are same-origin via the rewrite
- **Zod compat**: Reverted standalone validators (`z.url`, `z.email`, `z.uuid`) to chained form (`z.string().url()`) across shared schemas and API env config

## Test plan
- [ ] Upload an image locally, verify it displays
- [ ] Deploy to prod, verify images display without changing env vars
- [ ] Verify Zod validation still works for emails, UUIDs, and URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)