### PR TITLE
Fix image 400s by skipping Next.js image optimizer

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -19,7 +19,7 @@ const nextConfig: NextConfig = {
     ];
   },
   images: {
-    remotePatterns: [],
+    unoptimized: true,
   },
 };
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -7,8 +7,8 @@ export const API_URL =
 
 /**
  * Normalize an upload path for use in <Image> and <img> tags.
- * Returns the path as-is (e.g. /uploads/uuid.jpg) so that Next.js
- * rewrites proxy the request to the API in every environment.
+ * Returns the path as-is so Next.js rewrites proxy the request
+ * to the API in every environment.
  *
  * Returns undefined for null/undefined input. Passes through absolute
  * URLs (http/https) and blob URLs unchanged.


### PR DESCRIPTION
## Summary
- Set `images.unoptimized: true` in next.config — bypasses the `/_next/image` proxy that was returning 400s in both dev and prod
- `<Image>` still provides lazy loading, `fill`, `sizes`, `priority` — just no format conversion/resizing
- Uploads served directly through the existing `/uploads/*` rewrite to the API

## Context
The `/_next/image` optimizer rejected upload URLs due to:
- **Dev**: port mismatch in `remotePatterns` (localhost:8000 vs default port)
- **Prod**: standalone mode can't resolve rewrites for internal optimizer fetches

## Test plan
- [ ] Upload image locally, verify it displays
- [ ] Deploy to prod, verify images display
- [ ] Confirm lazy loading still works on trip cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)