### PR TITLE
Fix image loading — hit API directly instead of via rewrite

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,22 +1,11 @@
 import type { NextConfig } from "next";
 
-const apiUrl =
-  process.env.API_URL?.replace(/\/api$/, "") || "http://localhost:8000";
-
 const nextConfig: NextConfig = {
   output: "standalone",
   transpilePackages: ["@tripful/shared"],
   reactStrictMode: true,
   experimental: {
     optimizePackageImports: ["lucide-react", "date-fns"],
-  },
-  async rewrites() {
-    return [
-      {
-        source: "/uploads/:path*",
-        destination: `${apiUrl}/uploads/:path*`,
-      },
-    ];
   },
   images: {
     unoptimized: true,

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -7,18 +7,20 @@ export const API_URL =
 
 /**
  * Normalize an upload path for use in <Image> and <img> tags.
- * Returns the path as-is so Next.js rewrites proxy the request
- * to the API in every environment.
+ * Prefixes relative paths with the API base URL so the browser
+ * hits the API directly (which redirects to S3 in production).
  *
  * Returns undefined for null/undefined input. Passes through absolute
  * URLs (http/https) and blob URLs unchanged.
  */
+const API_BASE = API_URL.replace(/\/api$/, "");
+
 export function getUploadUrl(
   path: string | null | undefined,
 ): string | undefined {
   if (!path) return undefined;
   if (path.startsWith("http") || path.startsWith("blob:")) return path;
-  return path;
+  return `${API_BASE}${path}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Remove `/uploads/*` rewrite — it can't handle the API's 302 redirect to S3 signed URLs (causes 500 in prod)
- `getUploadUrl()` now builds absolute URLs from `NEXT_PUBLIC_API_URL` so the browser hits the API directly and follows the redirect itself
- Keep `images.unoptimized: true` to avoid `/_next/image` proxy issues

## Why the rewrite didn't work
In production, `GET /uploads/uuid.jpg` → API returns 302 to S3 signed URL → Next.js rewrite proxy chokes on the redirect → 500

## Test plan
- [ ] Upload image locally, verify it displays
- [ ] Deploy to prod, verify images load (browser follows 302 to S3)
- [ ] Check no CORS errors in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)