### PR TITLE
Fix calendar ICS feed timezone conversion

### DIFF
--- a/apps/api/src/services/calendar.service.ts
+++ b/apps/api/src/services/calendar.service.ts
@@ -35,6 +35,16 @@ export interface ICalendarService {
   ): Promise<void>;
 }
 
+/**
+ * Convert a UTC Date to a "fake" Date whose local getters (getHours, etc.)
+ * return the wall-clock values in the target timezone. This is needed because
+ * ical-generator reads date components via local getters and stamps TZID on them.
+ */
+function toTimezoneDate(utcDate: Date, timezone: string): Date {
+  const local = utcDate.toLocaleString("en-US", { timeZone: timezone });
+  return new Date(local);
+}
+
 export class CalendarService implements ICalendarService {
   constructor(private db: AppDatabase) {}
 
@@ -196,15 +206,16 @@ export class CalendarService implements ICalendarService {
             x: [{ key: "X-TRIPFUL-TRIP", value: trip.name }],
           });
         } else {
+          const endTime =
+            event.endTime ||
+            new Date(event.startTime.getTime() + 60 * 60 * 1000);
           calendar.createEvent({
             id: `event-${event.id}@tripful.app`,
             summary: event.name,
             description,
             location,
-            start: event.startTime,
-            end:
-              event.endTime ||
-              new Date(event.startTime.getTime() + 60 * 60 * 1000),
+            start: toTimezoneDate(event.startTime, timezone),
+            end: toTimezoneDate(endTime, timezone),
             timezone,
             lastModified: event.updatedAt,
             categories: [{ name: event.eventType }],

--- a/apps/api/tests/unit/calendar.service.test.ts
+++ b/apps/api/tests/unit/calendar.service.test.ts
@@ -189,6 +189,22 @@ describe("CalendarService.generateIcsFeed", () => {
       expect(ics).not.toMatch(/DTSTART;VALUE=DATE:\d{8}\r?\n/);
     });
 
+    it("should convert UTC times to trip timezone", () => {
+      // 2026-07-02T23:00:00Z = 6:00 PM CDT (America/Cancun is UTC-5 year-round)
+      const trip = makeTrip({ startDate: null, preferredTimezone: "America/Cancun" });
+      const event = makeEvent({
+        startTime: new Date("2026-07-02T23:00:00Z"),
+        endTime: new Date("2026-07-03T02:00:00Z"),
+        allDay: false,
+      });
+      const ics = unfold(service.generateIcsFeed([{ trip, events: [event] }]));
+
+      // Should contain 18:00 (6pm local), NOT 23:00 (UTC)
+      expect(ics).toContain("DTSTART;TZID=America/Cancun:20260702T180000");
+      // End: 02:00 UTC = 9:00 PM local
+      expect(ics).toContain("DTEND;TZID=America/Cancun:20260702T210000");
+    });
+
     it("should include X-TRIPFUL-TRIP custom property with trip name", () => {
       const trip = makeTrip({ startDate: null, name: "Beach Vacation" });
       const event = makeEvent({ allDay: false });


### PR DESCRIPTION
## Summary
- Fix timed events in ICS calendar feed showing UTC times instead of local timezone
- `ical-generator` reads Date components via local getters (`getHours`, etc.) which return UTC values on Node.js servers — when stamped with `TZID`, 6pm Central was appearing as 11pm
- Add `toTimezoneDate()` helper to convert UTC dates to wall-clock representation in the trip's preferred timezone before passing to ical-generator

## Test plan
- [x] Unit test added verifying UTC→local timezone conversion (23:00 UTC → 18:00 America/Cancun)
- [ ] Subscribe to calendar feed and verify events show correct local times
- [ ] Verify all-day events are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)