### PR TITLE
Fix theme cover images returning 400 in production

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -32,6 +32,7 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.71.2",
     "react-phone-number-input": "^3.4.16",
+    "sharp": "^0.34.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "zod": "^4.3.6"

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -2,4 +2,9 @@
 cmds = ["corepack enable"]
 
 [phases.build]
-cmds = ["pnpm install --frozen-lockfile", "pnpm build"]
+cmds = [
+  "pnpm install --frozen-lockfile",
+  "pnpm build",
+  "cp -r apps/web/public apps/web/.next/standalone/apps/web/public",
+  "cp -r apps/web/.next/static apps/web/.next/standalone/apps/web/.next/static",
+]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,6 +216,9 @@ importers:
       react-phone-number-input:
         specifier: ^3.4.16
         version: 3.4.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      sharp:
+        specifier: ^0.34.1
+        version: 0.34.5
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -6264,8 +6267,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@img/colour@1.0.0':
-    optional: true
+  '@img/colour@1.0.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
@@ -10323,7 +10325,6 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Copy `public/` and `.next/static/` into the standalone output directory during the Nixpacks build so the Next.js standalone server can serve theme cover images and static assets
- Add `sharp` as an explicit dependency for reliable image optimization in production

## Test plan
- [ ] Deploy to staging and verify theme cover images load on trip cards, trip detail, and theme picker
- [ ] Verify no 400 errors in browser console for image requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)