### PR TITLE
Fix theme images 400: copy public/ into standalone build

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -2,9 +2,4 @@
 cmds = ["corepack enable"]
 
 [phases.build]
-cmds = [
-  "pnpm install --frozen-lockfile",
-  "pnpm build",
-  "cp -r apps/web/public apps/web/.next/standalone/apps/web/public",
-  "cp -r apps/web/.next/static apps/web/.next/standalone/apps/web/.next/static",
-]
+cmds = ["pnpm install --frozen-lockfile", "pnpm build"]

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev:web": "turbo run dev --filter=@tripful/web",
     "dev:api": "turbo run dev --filter=@tripful/api",
     "build": "turbo run build",
-    "build:web": "turbo run build --filter=@tripful/web && cp -r apps/web/.next/static apps/web/.next/standalone/apps/web/.next/static",
+    "build:web": "turbo run build --filter=@tripful/web && cp -r apps/web/public apps/web/.next/standalone/apps/web/public && cp -r apps/web/.next/static apps/web/.next/standalone/apps/web/.next/static",
     "build:api": "turbo run build --filter=@tripful/api",
     "lint": "turbo run lint",
     "lint:fix": "turbo run lint -- --fix",


### PR DESCRIPTION
## Summary
- Add `public/` directory copy to `build:web` script so the standalone server can serve theme cover images and other static assets
- Revert unnecessary `nixpacks.toml` changes from #68 (Railway uses `build:web`, not nixpacks build commands)

## Root cause
The `build:web` script copied `.next/static` into the standalone output but not `public/`. The standalone server returned 404 for `/themes/*.webp`, causing `/_next/image` to return 400.

## Test plan
- [ ] Deploy and verify theme cover images load (no 400s in console)
- [ ] Verify `/themes/impressionist-beach-cover.webp` returns 200 directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)