### PR TITLE
Split E2E to 4 shards + inline GHA summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,8 +185,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [1, 2]
-        shardTotal: [2]
+        shardIndex: [1, 2, 3, 4]
+        shardTotal: [4]
     env:
       NODE_ENV: test
       DATABASE_URL: postgresql://tripful:tripful123@localhost:5432/tripful
@@ -267,7 +267,8 @@ jobs:
           merge-multiple: true
 
       - name: Merge Reports
-        run: pnpm --filter @tripful/web exec npx playwright merge-reports --reporter html ./all-blob-reports
+        run: |
+          pnpm --filter @tripful/web exec npx playwright merge-reports --reporter=html,markdown ./all-blob-reports >> $GITHUB_STEP_SUMMARY
 
       - name: Upload HTML Report
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary
- Split E2E test shards from 2 → 4 to reduce wall-clock time
- Add `markdown` reporter to merge-reports step, piping output to `$GITHUB_STEP_SUMMARY` for inline test results on the Actions page
- HTML report artifact remains unchanged

## Test plan
- [ ] Verify 4 E2E shard jobs appear in the Actions tab
- [ ] Verify `merge-e2e-reports` job summary shows a markdown table with test results
- [ ] Verify HTML report artifact is still uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)