### PR TITLE
UI polish: fix mutuals rendering, create trip button, customize placement

### DIFF
--- a/apps/web/src/app/(app)/mutuals/mutuals-content.tsx
+++ b/apps/web/src/app/(app)/mutuals/mutuals-content.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-  useState,
-  useEffect,
-  useRef,
-  type KeyboardEvent,
-  type RefObject,
-} from "react";
+import { useState, useEffect, useRef, type KeyboardEvent } from "react";
 import { Search, Users, AlertCircle, Loader2 } from "lucide-react";
 import type { Mutual } from "@tripful/shared/types";
 import { useMutuals } from "@/hooks/use-mutuals";
@@ -197,7 +191,7 @@ export function MutualsContent() {
         {/* Mutuals Grid */}
         {!isPending && !isError && mutuals.length > 0 && (
           <div
-            ref={gridRevealRef as RefObject<HTMLDivElement>}
+            ref={gridRevealRef}
             className={`grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 ${gridRevealed ? "motion-safe:animate-[revealUp_400ms_ease-out_both]" : "motion-safe:opacity-0"}`}
             aria-live="polite"
           >

--- a/apps/web/src/app/(app)/trips/[id]/trip-detail-content.tsx
+++ b/apps/web/src/app/(app)/trips/[id]/trip-detail-content.tsx
@@ -145,7 +145,7 @@ export function TripDetailContent({ tripId }: { tripId: string }) {
   const { data: weather, isLoading: weatherLoading } =
     useWeatherForecast(tripId);
   const temperatureUnit: TemperatureUnit =
-    user?.temperatureUnit === "fahrenheit" ? "fahrenheit" : "celsius";
+    user?.temperatureUnit === "celsius" ? "celsius" : "fahrenheit";
 
   const handleUpdateRole = (
     member: MemberWithProfile,

--- a/apps/web/src/app/(app)/trips/[id]/trip-detail-content.tsx
+++ b/apps/web/src/app/(app)/trips/[id]/trip-detail-content.tsx
@@ -267,28 +267,10 @@ export function TripDetailContent({ tripId }: { tripId: string }) {
           <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent" />
         )}
 
-        {/* Customize button — top-right overlay on hero */}
-        {isOrganizer && (
-          <button
-            onClick={() => setIsCustomizeOpen(true)}
-            onMouseEnter={supportsHover ? preloadCustomizeThemeSheet : undefined}
-            onTouchStart={preloadCustomizeThemeSheet}
-            onFocus={preloadCustomizeThemeSheet}
-            className={`absolute top-3 right-3 sm:top-4 sm:right-4 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium backdrop-blur-sm transition-colors cursor-pointer ${
-              heroTextLight
-                ? "bg-white/20 text-white hover:bg-white/30"
-                : "bg-black/10 text-foreground hover:bg-black/20"
-            }`}
-            aria-label="Customize theme"
-          >
-            <Paintbrush className="w-3.5 h-3.5" />
-            <span className="hidden sm:inline">Customize</span>
-          </button>
-        )}
-
         {/* Bottom: title + metadata */}
         <div className="absolute bottom-0 left-0 right-0 pb-5 sm:pb-6">
-          <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 flex items-end">
+            <div className="flex-1 min-w-0">
             <h1
               className={`text-2xl sm:text-4xl font-bold ${heroTextLight ? "text-white" : "text-foreground"} font-playfair line-clamp-2 drop-shadow-sm`}
               style={trip.themeFont ? { fontFamily: THEME_FONTS[trip.themeFont as keyof typeof THEME_FONTS] } : undefined}
@@ -311,6 +293,26 @@ export function TripDetailContent({ tripId }: { tripId: string }) {
                 <span>{dateRange}</span>
               </span>
             </div>
+            </div>
+
+            {/* Customize button */}
+            {isOrganizer && (
+              <button
+                onClick={() => setIsCustomizeOpen(true)}
+                onMouseEnter={supportsHover ? preloadCustomizeThemeSheet : undefined}
+                onTouchStart={preloadCustomizeThemeSheet}
+                onFocus={preloadCustomizeThemeSheet}
+                className={`shrink-0 ml-4 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium backdrop-blur-sm transition-colors cursor-pointer ${
+                  heroTextLight
+                    ? "bg-white/20 text-white hover:bg-white/30"
+                    : "bg-black/10 text-foreground hover:bg-black/20"
+                }`}
+                aria-label="Customize theme"
+              >
+                <Paintbrush className="w-3.5 h-3.5" />
+                <span className="hidden sm:inline">Customize</span>
+              </button>
+            )}
           </div>
         </div>
       </div>

--- a/apps/web/src/app/(app)/trips/[id]/trip-detail-content.tsx
+++ b/apps/web/src/app/(app)/trips/[id]/trip-detail-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type RefObject } from "react";
+import { useState } from "react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import Image from "next/image";
@@ -455,7 +455,7 @@ export function TripDetailContent({ tripId }: { tripId: string }) {
       {/* Itinerary — outside padded container so sticky header works */}
       <div
         id="itinerary"
-        ref={itineraryRef as RefObject<HTMLDivElement>}
+        ref={itineraryRef}
         className="scroll-mt-14"
       >
         <ItineraryView

--- a/apps/web/src/app/(app)/trips/trips-content.tsx
+++ b/apps/web/src/app/(app)/trips/trips-content.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useMemo, useEffect, useRef } from "react";
-import { createPortal } from "react-dom";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import { Plus, Search, AlertCircle, Loader2 } from "lucide-react";
 import { useTrips, type TripSummary } from "@/hooks/use-trips";
@@ -10,7 +9,6 @@ import { CreateTripDialog } from "@/components/trip/create-trip-dialog";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useMounted } from "@/hooks/use-mounted";
 import { useScrollReveal } from "@/hooks/use-scroll-reveal";
 import { PostmarkStamp } from "@/components/ui/postmark-stamp";
 import { EmptyState } from "@/components/ui/empty-state";
@@ -31,7 +29,6 @@ export function TripsContent() {
   const searchParams = useSearchParams();
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState(searchParams.get("q") ?? "");
-  const mounted = useMounted();
   const { ref: upcomingSectionRef, isRevealed: upcomingRevealed } =
     useScrollReveal();
   const { ref: pastSectionRef, isRevealed: pastRevealed } = useScrollReveal();
@@ -127,15 +124,25 @@ export function TripsContent() {
     <div className="min-h-screen bg-background pb-24 motion-safe:animate-[revealUp_400ms_ease-out_both] gradient-mesh linen-texture">
       <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Header */}
-        <header className="mb-8">
-          <h1 className="text-2xl sm:text-4xl font-bold text-foreground mb-2 font-playfair">
-            My Trips
-          </h1>
-          {!isPending && !isError && (
-            <p className="text-muted-foreground">
-              {tripCount} trip{tripCount !== 1 ? "s" : ""}
-            </p>
-          )}
+        <header className="flex items-start justify-between mb-8">
+          <div>
+            <h1 className="text-2xl sm:text-4xl font-bold text-foreground mb-2 font-playfair">
+              My Trips
+            </h1>
+            {!isPending && !isError && (
+              <p className="text-muted-foreground">
+                {tripCount} trip{tripCount !== 1 ? "s" : ""}
+              </p>
+            )}
+          </div>
+          <Button
+            onClick={() => setCreateDialogOpen(true)}
+            variant="outline"
+            className="h-10 px-4 rounded-md"
+          >
+            <Plus className="w-4 h-4" strokeWidth={2.5} />
+            New Trip
+          </Button>
         </header>
 
         {/* Search Bar */}
@@ -259,21 +266,6 @@ export function TripsContent() {
           </div>
         )}
       </div>
-
-      {/* Floating Action Button (FAB) — portaled to body to escape ancestor transforms that break position:fixed */}
-      {mounted &&
-        createPortal(
-          <Button
-            onClick={() => setCreateDialogOpen(true)}
-            variant="gradient"
-            size="icon"
-            className="fixed bottom-safe-6 right-6 sm:bottom-safe-8 sm:right-8 w-14 h-14 rounded-full z-50"
-            aria-label="Create new trip"
-          >
-            <Plus className="w-6 h-6" strokeWidth={2.5} />
-          </Button>,
-          document.body,
-        )}
 
       {/* Create Trip Dialog */}
       <CreateTripDialog

--- a/apps/web/src/app/(app)/trips/trips-content.tsx
+++ b/apps/web/src/app/(app)/trips/trips-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useEffect, useRef, type RefObject } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import { Plus, Search, AlertCircle, Loader2 } from "lucide-react";
@@ -224,9 +224,7 @@ export function TripsContent() {
             {/* Upcoming Trips */}
             {upcomingTrips.length > 0 && (
               <section
-                ref={
-                  upcomingSectionRef as RefObject<HTMLElement>
-                }
+                ref={upcomingSectionRef}
                 className={`mb-12 ${upcomingRevealed ? "motion-safe:animate-[revealUp_400ms_ease-out_both]" : "motion-safe:opacity-0"}`}
               >
                 <h2 className="text-xl sm:text-2xl font-semibold text-foreground mb-4 font-playfair">
@@ -244,9 +242,7 @@ export function TripsContent() {
             {/* Past Trips */}
             {pastTrips.length > 0 && (
               <section
-                ref={
-                  pastSectionRef as RefObject<HTMLElement>
-                }
+                ref={pastSectionRef}
                 className={pastRevealed ? "motion-safe:animate-[revealUp_400ms_ease-out_both]" : "motion-safe:opacity-0"}
               >
                 <h2 className="text-xl sm:text-2xl font-semibold text-foreground mb-4 font-playfair">

--- a/apps/web/src/components/itinerary/accommodation-line-item.tsx
+++ b/apps/web/src/components/itinerary/accommodation-line-item.tsx
@@ -17,7 +17,7 @@ export const AccommodationLineItem = memo(function AccommodationLineItem({
     <div
       role="button"
       tabIndex={0}
-      className="flex items-center gap-2 py-2.5 px-3 border-b border-border/40 hover:bg-muted/50 cursor-pointer transition-colors"
+      className="flex items-center gap-2 py-2 px-3 border-b border-border/40 hover:bg-muted/50 cursor-pointer transition-colors"
       onClick={() => onClick(accommodation)}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
@@ -26,13 +26,13 @@ export const AccommodationLineItem = memo(function AccommodationLineItem({
         }
       }}
     >
-      <Building2 className="w-3.5 h-3.5 text-accommodation shrink-0" />
-      <span className="font-semibold text-sm truncate min-w-0">
+      <Building2 className="w-3 h-3 text-accommodation shrink-0" />
+      <span className="font-medium text-xs truncate min-w-0">
         {accommodation.name}
       </span>
       {accommodation.address && (
         <>
-          <span className="text-xs text-muted-foreground truncate min-w-0 hidden sm:inline">
+          <span className="text-[11px] text-muted-foreground truncate min-w-0 hidden sm:inline">
             {accommodation.address}
           </span>
           <a
@@ -47,7 +47,7 @@ export const AccommodationLineItem = memo(function AccommodationLineItem({
           </a>
         </>
       )}
-      <ChevronRight className="w-3.5 h-3.5 text-muted-foreground/60 ml-auto shrink-0" />
+      <ChevronRight className="w-3 h-3 text-muted-foreground/60 ml-auto shrink-0" />
     </div>
   );
 });

--- a/apps/web/src/components/itinerary/day-by-day-view.tsx
+++ b/apps/web/src/components/itinerary/day-by-day-view.tsx
@@ -399,7 +399,7 @@ export function DayByDayView({
                 </span>
                 <WeatherDayBadge
                   forecast={forecastMap.get(day.date)}
-                  temperatureUnit={temperatureUnit || "celsius"}
+                  temperatureUnit={temperatureUnit || "fahrenheit"}
                 />
               </div>
             </div>

--- a/apps/web/src/components/itinerary/itinerary-view.tsx
+++ b/apps/web/src/components/itinerary/itinerary-view.tsx
@@ -319,7 +319,7 @@ export function ItineraryView({ tripId, onAddTravel, forecasts, temperatureUnit 
             userNameMap={userNameMap}
             isLocked={isLocked}
             forecasts={forecasts ?? []}
-            temperatureUnit={temperatureUnit ?? "celsius"}
+            temperatureUnit={temperatureUnit ?? "fahrenheit"}
           />
         ) : (
           <GroupByTypeView

--- a/apps/web/src/components/itinerary/member-travel-detail-sheet.tsx
+++ b/apps/web/src/components/itinerary/member-travel-detail-sheet.tsx
@@ -182,17 +182,15 @@ export function MemberTravelDetailSheet({
 
           {/* Location */}
           {memberTravel.location && (
-            <div className="mt-4 flex items-start gap-2">
-              <MapPin className="w-4 h-4 text-muted-foreground mt-0.5 shrink-0" />
-              <a
-                href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(memberTravel.location)}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-sm text-primary underline underline-offset-2 hover:text-primary/80 transition-colors"
-              >
-                {memberTravel.location}
-              </a>
-            </div>
+            <a
+              href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(memberTravel.location)}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-4 inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors"
+            >
+              <MapPin className="w-3.5 h-3.5 shrink-0" />
+              <span>{memberTravel.location}</span>
+            </a>
           )}
 
           {/* Details */}

--- a/apps/web/src/components/itinerary/member-travel-line-item.tsx
+++ b/apps/web/src/components/itinerary/member-travel-line-item.tsx
@@ -3,7 +3,6 @@
 import React, { memo, useCallback } from "react";
 import {
   ChevronRight,
-  ExternalLink,
   PlaneLanding,
   PlaneTakeoff,
 } from "lucide-react";
@@ -48,29 +47,12 @@ export const MemberTravelLineItem = memo(function MemberTravelLineItem({
       tabIndex={0}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
-      className="flex items-center gap-2 py-2.5 px-3 border-b border-border/40 hover:bg-muted/50 cursor-pointer transition-colors"
+      className="flex items-center gap-2 py-2 px-3 border-b border-border/40 hover:bg-muted/50 cursor-pointer transition-colors"
     >
-      <PlaneIcon className="w-3.5 h-3.5 text-member-travel shrink-0" />
-      <span className="font-semibold text-sm truncate">{memberName}</span>
-      <span className="text-xs text-muted-foreground">· {time}</span>
-      {memberTravel.location && (
-        <>
-          <span className="text-xs text-muted-foreground truncate min-w-0">
-            {memberTravel.location}
-          </span>
-          <a
-            href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(memberTravel.location)}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-muted-foreground hover:text-primary transition-colors shrink-0"
-            onClick={(e) => e.stopPropagation()}
-            aria-label={`${memberTravel.location} on Google Maps`}
-          >
-            <ExternalLink className="w-3 h-3" />
-          </a>
-        </>
-      )}
-      <ChevronRight className="w-3.5 h-3.5 text-muted-foreground/60 ml-auto shrink-0" />
+      <PlaneIcon className="w-3 h-3 text-member-travel shrink-0" />
+      <span className="font-medium text-xs truncate">{memberName}</span>
+      <span className="text-[11px] text-muted-foreground">· {time}</span>
+      <ChevronRight className="w-3 h-3 text-muted-foreground/60 ml-auto shrink-0" />
     </div>
   );
 });

--- a/apps/web/src/components/itinerary/member-travel-line-item.tsx
+++ b/apps/web/src/components/itinerary/member-travel-line-item.tsx
@@ -3,6 +3,7 @@
 import React, { memo, useCallback } from "react";
 import {
   ChevronRight,
+  ExternalLink,
   PlaneLanding,
   PlaneTakeoff,
 } from "lucide-react";
@@ -52,6 +53,23 @@ export const MemberTravelLineItem = memo(function MemberTravelLineItem({
       <PlaneIcon className="w-3 h-3 text-member-travel shrink-0" />
       <span className="font-medium text-xs truncate">{memberName}</span>
       <span className="text-[11px] text-muted-foreground">· {time}</span>
+      {memberTravel.location && (
+        <>
+          <span className="text-[11px] text-muted-foreground truncate min-w-0">
+            {memberTravel.location}
+          </span>
+          <a
+            href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(memberTravel.location)}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-muted-foreground hover:text-primary transition-colors shrink-0"
+            onClick={(e) => e.stopPropagation()}
+            aria-label={`${memberTravel.location} on Google Maps`}
+          >
+            <ExternalLink className="w-3 h-3" />
+          </a>
+        </>
+      )}
       <ChevronRight className="w-3 h-3 text-muted-foreground/60 ml-auto shrink-0" />
     </div>
   );

--- a/apps/web/src/components/profile/profile-dialog.tsx
+++ b/apps/web/src/components/profile/profile-dialog.tsx
@@ -87,7 +87,7 @@ export function ProfileDialog({ open, onOpenChange }: ProfileDialogProps) {
       form.reset({
         displayName: user.displayName,
         timezone: user.timezone,
-        temperatureUnit: (user.temperatureUnit as "celsius" | "fahrenheit") || "celsius",
+        temperatureUnit: (user.temperatureUnit as "celsius" | "fahrenheit") || "fahrenheit",
         handles: {
           venmo: user.handles?.venmo ?? "",
           instagram: user.handles?.instagram ?? "",
@@ -382,7 +382,7 @@ export function ProfileDialog({ open, onOpenChange }: ProfileDialogProps) {
                         </FormLabel>
                         <Select
                           onValueChange={field.onChange}
-                          value={field.value || "celsius"}
+                          value={field.value || "fahrenheit"}
                           disabled={updateProfile.isPending}
                         >
                           <FormControl>

--- a/apps/web/src/components/trip/invite-members-dialog.tsx
+++ b/apps/web/src/components/trip/invite-members-dialog.tsx
@@ -35,6 +35,7 @@ import { Badge } from "@/components/ui/badge";
 import { PhoneInput } from "@/components/ui/phone-input";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Separator } from "@/components/ui/separator";
 import { toast } from "sonner";
 import { Loader2, X, UserPlus, Phone, Search, Users } from "lucide-react";
@@ -57,7 +58,8 @@ export function InviteMembersDialog({
   const [mutualSearch, setMutualSearch] = useState("");
 
   const { mutate: inviteMembers, isPending } = useInviteMembers(tripId);
-  const { data: suggestions } = useMutualSuggestions(tripId);
+  const { data: suggestions, isPending: isSuggestionsLoading } =
+    useMutualSuggestions(tripId);
 
   const form = useForm({
     resolver: zodResolver(createInvitationsSchema),
@@ -184,7 +186,7 @@ export function InviteMembersDialog({
             Invite members
           </SheetTitle>
           <SheetDescription>
-            {hasMutuals
+            {hasMutuals || isSuggestionsLoading
               ? "Select mutuals or add phone numbers to invite to this trip"
               : "Add phone numbers of people you want to invite to this trip"}
           </SheetDescription>
@@ -196,8 +198,34 @@ export function InviteMembersDialog({
               onSubmit={form.handleSubmit(handleSubmit)}
               className="space-y-6 pb-6"
             >
-              {/* Mutuals Section - only show when suggestions exist */}
-              {hasMutuals && (
+              {/* Mutuals Section - loading skeleton */}
+              {isSuggestionsLoading && (
+                <div className="space-y-3">
+                  <Skeleton className="h-5 w-40" />
+                  <Skeleton className="h-10 w-full rounded-md" />
+                  <div className="space-y-1 rounded-md border border-border p-2">
+                    {[1, 2, 3].map((i) => (
+                      <div key={i} className="flex items-center gap-3 p-2">
+                        <Skeleton className="h-4 w-4 rounded" />
+                        <Skeleton className="size-8 rounded-full" />
+                        <div className="space-y-1.5">
+                          <Skeleton className="h-4 w-24" />
+                          <Skeleton className="h-3 w-16" />
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                  <div className="relative py-2">
+                    <Separator />
+                    <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-background px-3 text-xs text-muted-foreground">
+                      Or invite by phone number
+                    </span>
+                  </div>
+                </div>
+              )}
+
+              {/* Mutuals Section - show when suggestions loaded */}
+              {hasMutuals && !isSuggestionsLoading && (
                 <div className="space-y-3" data-testid="mutuals-section">
                   <label className="text-base font-semibold text-foreground">
                     Suggest from mutuals

--- a/apps/web/src/hooks/__tests__/use-scroll-reveal.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-scroll-reveal.test.tsx
@@ -49,7 +49,7 @@ function TestComponent(props: {
   props.onResult?.({ isRevealed });
 
   return (
-    <div ref={ref as React.RefObject<HTMLDivElement>} data-revealed={String(isRevealed)}>
+    <div ref={ref} data-revealed={String(isRevealed)}>
       content
     </div>
   );

--- a/apps/web/src/hooks/use-scroll-reveal.ts
+++ b/apps/web/src/hooks/use-scroll-reveal.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 interface UseScrollRevealOptions {
   /** Intersection threshold (0-1). Default: 0.1 */
@@ -15,15 +15,20 @@ interface UseScrollRevealOptions {
  * Uses IntersectionObserver with a one-shot pattern: once the element
  * is intersecting, `isRevealed` becomes true and the observer disconnects.
  *
+ * Uses a callback ref so it works correctly with conditionally rendered elements.
+ *
  * @param options - Optional threshold and rootMargin for the observer
- * @returns Object with a ref to attach to the target element and the revealed state
+ * @returns Object with a ref callback to attach to the target element and the revealed state
  */
 export function useScrollReveal(options?: UseScrollRevealOptions) {
-  const ref = useRef<HTMLElement>(null);
+  const [element, setElement] = useState<HTMLElement | null>(null);
   const [isRevealed, setIsRevealed] = useState(false);
 
+  const ref = useCallback((node: HTMLElement | null) => {
+    setElement(node);
+  }, []);
+
   useEffect(() => {
-    const element = ref.current;
     if (!element || isRevealed) return;
 
     const observer = new IntersectionObserver(
@@ -44,7 +49,7 @@ export function useScrollReveal(options?: UseScrollRevealOptions) {
     return () => {
       observer.disconnect();
     };
-  }, [isRevealed, options?.threshold, options?.rootMargin]);
+  }, [element, isRevealed, options?.threshold, options?.rootMargin]);
 
   return { ref, isRevealed };
 }

--- a/apps/web/tests/e2e/helpers/pages/trips.page.ts
+++ b/apps/web/tests/e2e/helpers/pages/trips.page.ts
@@ -19,7 +19,7 @@ export class TripsPage {
     this.page = page;
     this.heading = page.getByRole("heading", { name: "My Trips" });
     this.createTripButton = page.getByRole("button", {
-      name: "Create new trip",
+      name: "New Trip",
     });
     this.userMenuButton = page.getByRole("button", { name: "User menu" });
     this.mobileMenuButton = page.getByRole("button", { name: "Open menu" });

--- a/apps/web/tests/e2e/trip-journey.spec.ts
+++ b/apps/web/tests/e2e/trip-journey.spec.ts
@@ -866,13 +866,14 @@ test.describe("Trip Journey", () => {
       });
 
       await test.step("verify delegated travel appears with correct member name", async () => {
-        // The travel card shows "Name · Time · Location" format
+        // The travel card shows "Name · Time" in compact format
         // Verify the delegated member's name appears on the travel card
         await expect(page.getByText("Delegated Member").first()).toBeVisible({
           timeout: ELEMENT_TIMEOUT,
         });
 
-        // Location should also be visible (compact view truncates > 20 chars)
+        // Click the travel card to open the detail sheet and verify location there
+        await page.getByText("Delegated Member").first().click();
         const locationLink = page.getByRole("link", {
           name: /Seattle-Tacoma/,
         });


### PR DESCRIPTION
## Summary

- **Fix mutuals grid intermittently not rendering**: `useScrollReveal` used `useRef` which doesn't re-trigger when conditionally rendered elements mount. Switched to callback ref.
- **Polish itinerary UI**: Smaller travel/accommodation cards, consistent location style, default to °F
- **Move create trip button**: Replace FAB with inline outline button in page header
- **Move customize button**: Repositioned from top-right to bottom-right of cover photo, aligned with title row
- **Add loading skeleton** to invite dialog mutual suggestions

## Test plan

- [ ] My Mutuals page — cards always render
- [ ] Trips page — "New Trip" button visible in header
- [ ] Trips page — upcoming/past sections animate on scroll
- [ ] Trip detail — customize button at bottom-right of cover photo
- [ ] Trip detail — itinerary scroll reveal works
- [ ] Invite members dialog — skeleton while mutual suggestions load

🤖 Generated with [Claude Code](https://claude.com/claude-code)