### PR TITLE
Add accommodations to calendar feed and UI polish

### DIFF
--- a/apps/api/src/services/calendar.service.ts
+++ b/apps/api/src/services/calendar.service.ts
@@ -9,15 +9,18 @@ import {
   members,
   trips,
   events,
+  accommodations,
   type User,
   type Trip,
   type Event,
+  type Accommodation,
 } from "@/db/schema/index.js";
 import type { AppDatabase } from "@/types/index.js";
 
 interface TripWithEvents {
   trip: Trip;
   events: Event[];
+  accommodations: Accommodation[];
 }
 
 export interface ICalendarService {
@@ -94,6 +97,17 @@ export class CalendarService implements ICalendarService {
         and(inArray(events.tripId, activeTripIds), isNull(events.deletedAt)),
       );
 
+    // Batch-fetch all non-deleted accommodations for those trips
+    const accommodationRows = await this.db
+      .select()
+      .from(accommodations)
+      .where(
+        and(
+          inArray(accommodations.tripId, activeTripIds),
+          isNull(accommodations.deletedAt),
+        ),
+      );
+
     // Group events by tripId
     const eventsByTrip = new Map<string, Event[]>();
     for (const event of eventRows) {
@@ -102,9 +116,18 @@ export class CalendarService implements ICalendarService {
       eventsByTrip.set(event.tripId, list);
     }
 
+    // Group accommodations by tripId
+    const accommodationsByTrip = new Map<string, Accommodation[]>();
+    for (const acc of accommodationRows) {
+      const list = accommodationsByTrip.get(acc.tripId) ?? [];
+      list.push(acc);
+      accommodationsByTrip.set(acc.tripId, list);
+    }
+
     return tripRows.map((trip) => ({
       trip,
       events: eventsByTrip.get(trip.id) ?? [],
+      accommodations: accommodationsByTrip.get(trip.id) ?? [],
     }));
   }
 
@@ -122,7 +145,11 @@ export class CalendarService implements ICalendarService {
       ],
     });
 
-    for (const { trip, events: tripEvents } of tripsWithEvents) {
+    for (const {
+      trip,
+      events: tripEvents,
+      accommodations: tripAccommodations,
+    } of tripsWithEvents) {
       const timezone = trip.preferredTimezone || "UTC";
 
       // Trip overview event (all-day, multi-day) — skip if no startDate
@@ -222,6 +249,40 @@ export class CalendarService implements ICalendarService {
             x: [{ key: "X-TRIPFUL-TRIP", value: trip.name }],
           });
         }
+      }
+
+      // Accommodation events
+      for (const acc of tripAccommodations) {
+        const descriptionParts: string[] = [];
+
+        if (acc.description) {
+          descriptionParts.push(acc.description);
+        }
+
+        if (acc.links && acc.links.length > 0) {
+          descriptionParts.push(
+            "Links:\n" + acc.links.map((l) => `- ${l}`).join("\n"),
+          );
+        }
+
+        descriptionParts.push(
+          `View trip: https://tripful.app/trips/${trip.id}`,
+        );
+
+        const description = descriptionParts.join("\n\n");
+
+        calendar.createEvent({
+          id: `accommodation-${acc.id}@tripful.app`,
+          summary: `🏨 ${acc.name}`,
+          description,
+          location: acc.address || null,
+          start: toTimezoneDate(acc.checkIn, timezone),
+          end: toTimezoneDate(acc.checkOut, timezone),
+          timezone,
+          transparency: ICalEventTransparency.TRANSPARENT,
+          categories: [{ name: "accommodation" }],
+          x: [{ key: "X-TRIPFUL-TRIP", value: trip.name }],
+        });
       }
     }
 

--- a/apps/api/src/services/calendar.service.ts
+++ b/apps/api/src/services/calendar.service.ts
@@ -17,7 +17,7 @@ import {
 } from "@/db/schema/index.js";
 import type { AppDatabase } from "@/types/index.js";
 
-interface TripWithEvents {
+interface TripCalendarData {
   trip: Trip;
   events: Event[];
   accommodations: Accommodation[];
@@ -25,8 +25,8 @@ interface TripWithEvents {
 
 export interface ICalendarService {
   getUserByCalendarToken(token: string): Promise<User | null>;
-  getCalendarTripsAndEvents(userId: string): Promise<TripWithEvents[]>;
-  generateIcsFeed(tripsWithEvents: TripWithEvents[]): string;
+  getCalendarTripsAndEvents(userId: string): Promise<TripCalendarData[]>;
+  generateIcsFeed(tripsWithEvents: TripCalendarData[]): string;
   enableCalendar(userId: string): Promise<string>;
   disableCalendar(userId: string): Promise<void>;
   regenerateCalendar(userId: string): Promise<string>;
@@ -60,7 +60,7 @@ export class CalendarService implements ICalendarService {
     return user ?? null;
   }
 
-  async getCalendarTripsAndEvents(userId: string): Promise<TripWithEvents[]> {
+  async getCalendarTripsAndEvents(userId: string): Promise<TripCalendarData[]> {
     // Get all trips where user is a member, not excluded from calendar, and not "not_going"
     const memberRows = await this.db
       .select({
@@ -131,7 +131,7 @@ export class CalendarService implements ICalendarService {
     }));
   }
 
-  generateIcsFeed(tripsWithEvents: TripWithEvents[]): string {
+  generateIcsFeed(tripsWithEvents: TripCalendarData[]): string {
     const calendar = ical({
       name: "Tripful",
       method: ICalCalendarMethod.PUBLISH,
@@ -275,7 +275,7 @@ export class CalendarService implements ICalendarService {
           id: `accommodation-${acc.id}@tripful.app`,
           summary: `🏨 ${acc.name}`,
           description,
-          location: acc.address || null,
+          location: acc.address,
           start: toTimezoneDate(acc.checkIn, timezone),
           end: toTimezoneDate(acc.checkOut, timezone),
           timezone,

--- a/apps/api/tests/unit/calendar.service.test.ts
+++ b/apps/api/tests/unit/calendar.service.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { CalendarService } from "@/services/calendar.service.js";
-import type { Trip, Event } from "@/db/schema/index.js";
+import type { Trip, Event, Accommodation } from "@/db/schema/index.js";
 import type { AppDatabase } from "@/types/index.js";
 
 // generateIcsFeed is a pure function that does not use the database,
@@ -57,6 +57,27 @@ function makeEvent(overrides: Partial<Event> = {}): Event {
   };
 }
 
+function makeAccommodation(
+  overrides: Partial<Accommodation> = {},
+): Accommodation {
+  return {
+    id: "dddddddd-dddd-dddd-dddd-dddddddddddd",
+    tripId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    createdBy: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+    name: "Seaside Resort",
+    address: "123 Beach Rd, Cancun",
+    description: "Oceanfront hotel with pool",
+    checkIn: new Date("2026-07-01T15:00:00Z"),
+    checkOut: new Date("2026-07-05T11:00:00Z"),
+    links: ["https://seaside-resort.example.com"],
+    deletedAt: null,
+    deletedBy: null,
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+    updatedAt: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
 // ICS format uses line folding (RFC 5545 Section 3.1): long lines are broken
 // at 75 octets with a CRLF followed by a single whitespace character.
 // This helper unfolds the ICS string so we can do simple substring checks.
@@ -95,7 +116,7 @@ describe("CalendarService.generateIcsFeed", () => {
   describe("trip overview event", () => {
     it("should generate all-day transparent event when trip has startDate", () => {
       const trip = makeTrip();
-      const ics = service.generateIcsFeed([{ trip, events: [] }]);
+      const ics = service.generateIcsFeed([{ trip, events: [], accommodations: [] }]);
 
       expect(ics).toContain("BEGIN:VEVENT");
       expect(ics).toContain(`SUMMARY:${trip.name}`);
@@ -107,7 +128,7 @@ describe("CalendarService.generateIcsFeed", () => {
 
     it("should use exclusive end date (+1 day) per ICS spec", () => {
       const trip = makeTrip({ startDate: "2026-07-01", endDate: "2026-07-05" });
-      const ics = service.generateIcsFeed([{ trip, events: [] }]);
+      const ics = service.generateIcsFeed([{ trip, events: [], accommodations: [] }]);
 
       // endDate is July 5, exclusive end should be July 6
       expect(ics).toContain("DTEND;VALUE=DATE:20260706");
@@ -115,7 +136,7 @@ describe("CalendarService.generateIcsFeed", () => {
 
     it("should use startDate +1 day as end when endDate is null", () => {
       const trip = makeTrip({ startDate: "2026-07-01", endDate: null });
-      const ics = service.generateIcsFeed([{ trip, events: [] }]);
+      const ics = service.generateIcsFeed([{ trip, events: [], accommodations: [] }]);
 
       // Single-day trip: start July 1, exclusive end July 2
       expect(ics).toContain("DTSTART;VALUE=DATE:20260701");
@@ -124,7 +145,7 @@ describe("CalendarService.generateIcsFeed", () => {
 
     it("should skip trip overview event when startDate is null", () => {
       const trip = makeTrip({ startDate: null, endDate: null });
-      const ics = service.generateIcsFeed([{ trip, events: [] }]);
+      const ics = service.generateIcsFeed([{ trip, events: [], accommodations: [] }]);
 
       expect(ics).not.toContain(`UID:trip-${trip.id}@tripful.app`);
       expect(ics).not.toContain("BEGIN:VEVENT");
@@ -132,7 +153,7 @@ describe("CalendarService.generateIcsFeed", () => {
 
     it("should include trip description and link in description", () => {
       const trip = makeTrip({ description: "Sun and sand" });
-      const ics = unfold(service.generateIcsFeed([{ trip, events: [] }]));
+      const ics = unfold(service.generateIcsFeed([{ trip, events: [], accommodations: [] }]));
 
       expect(ics).toContain("Sun and sand");
       expect(ics).toContain(`https://tripful.app/trips/${trip.id}`);
@@ -140,14 +161,14 @@ describe("CalendarService.generateIcsFeed", () => {
 
     it("should include link even when trip description is null", () => {
       const trip = makeTrip({ description: null });
-      const ics = unfold(service.generateIcsFeed([{ trip, events: [] }]));
+      const ics = unfold(service.generateIcsFeed([{ trip, events: [], accommodations: [] }]));
 
       expect(ics).toContain(`https://tripful.app/trips/${trip.id}`);
     });
 
     it("should set destination as location", () => {
       const trip = makeTrip({ destination: "Cancun, Mexico" });
-      const ics = service.generateIcsFeed([{ trip, events: [] }]);
+      const ics = service.generateIcsFeed([{ trip, events: [], accommodations: [] }]);
 
       expect(ics).toContain("LOCATION:Cancun\\, Mexico");
     });
@@ -161,7 +182,7 @@ describe("CalendarService.generateIcsFeed", () => {
         endTime: new Date("2026-07-02T12:00:00Z"),
         allDay: false,
       });
-      const ics = service.generateIcsFeed([{ trip, events: [event] }]);
+      const ics = service.generateIcsFeed([{ trip, events: [event], accommodations: [] }]);
 
       expect(ics).toContain(`UID:event-${event.id}@tripful.app`);
       expect(ics).toContain("SUMMARY:Snorkeling Tour");
@@ -178,7 +199,7 @@ describe("CalendarService.generateIcsFeed", () => {
         endTime: null,
         allDay: false,
       });
-      const ics = service.generateIcsFeed([{ trip, events: [event] }]);
+      const ics = service.generateIcsFeed([{ trip, events: [event], accommodations: [] }]);
 
       // The ICS should have a DTEND — we verify by checking it contains VEVENT
       // and does not use all-day format
@@ -199,7 +220,7 @@ describe("CalendarService.generateIcsFeed", () => {
         endTime: new Date("2026-07-03T02:00:00Z"),
         allDay: false,
       });
-      const ics = unfold(service.generateIcsFeed([{ trip, events: [event] }]));
+      const ics = unfold(service.generateIcsFeed([{ trip, events: [event], accommodations: [] }]));
 
       // Should contain 18:00 (6pm local), NOT 23:00 (UTC)
       expect(ics).toContain("DTSTART;TZID=America/Cancun:20260702T180000");
@@ -210,7 +231,7 @@ describe("CalendarService.generateIcsFeed", () => {
     it("should include X-TRIPFUL-TRIP custom property with trip name", () => {
       const trip = makeTrip({ startDate: null, name: "Beach Vacation" });
       const event = makeEvent({ allDay: false });
-      const ics = service.generateIcsFeed([{ trip, events: [event] }]);
+      const ics = service.generateIcsFeed([{ trip, events: [event], accommodations: [] }]);
 
       expect(ics).toContain("X-TRIPFUL-TRIP:Beach Vacation");
     });
@@ -218,7 +239,7 @@ describe("CalendarService.generateIcsFeed", () => {
     it("should include event type as category", () => {
       const trip = makeTrip({ startDate: null });
       const event = makeEvent({ eventType: "meal", allDay: false });
-      const ics = service.generateIcsFeed([{ trip, events: [event] }]);
+      const ics = service.generateIcsFeed([{ trip, events: [event], accommodations: [] }]);
 
       expect(ics).toContain("CATEGORIES:meal");
     });
@@ -232,7 +253,7 @@ describe("CalendarService.generateIcsFeed", () => {
         startTime: new Date("2026-07-03T00:00:00Z"),
         endTime: new Date("2026-07-03T00:00:00Z"),
       });
-      const ics = service.generateIcsFeed([{ trip, events: [event] }]);
+      const ics = service.generateIcsFeed([{ trip, events: [event], accommodations: [] }]);
 
       expect(ics).toContain(`UID:event-${event.id}@tripful.app`);
       expect(ics).toContain("DTSTART;VALUE=DATE:");
@@ -249,7 +270,7 @@ describe("CalendarService.generateIcsFeed", () => {
         links: ["https://reef-tours.example.com", "https://maps.example.com"],
         allDay: false,
       });
-      const ics = service.generateIcsFeed([{ trip, events: [event] }]);
+      const ics = service.generateIcsFeed([{ trip, events: [event], accommodations: [] }]);
 
       expect(ics).toContain("Meetup:");
       expect(ics).toContain("Hotel Lobby");
@@ -268,7 +289,7 @@ describe("CalendarService.generateIcsFeed", () => {
         links: null,
         allDay: false,
       });
-      const ics = service.generateIcsFeed([{ trip, events: [event] }]);
+      const ics = service.generateIcsFeed([{ trip, events: [event], accommodations: [] }]);
 
       // Should still produce a valid VEVENT
       expect(ics).toContain("BEGIN:VEVENT");
@@ -287,7 +308,7 @@ describe("CalendarService.generateIcsFeed", () => {
         links: [],
         allDay: false,
       });
-      const ics = service.generateIcsFeed([{ trip, events: [event] }]);
+      const ics = service.generateIcsFeed([{ trip, events: [event], accommodations: [] }]);
 
       expect(ics).toContain("Just a description");
       expect(ics).not.toContain("Links:");
@@ -302,7 +323,7 @@ describe("CalendarService.generateIcsFeed", () => {
         links: null,
         allDay: false,
       });
-      const ics = service.generateIcsFeed([{ trip, events: [event] }]);
+      const ics = service.generateIcsFeed([{ trip, events: [event], accommodations: [] }]);
 
       expect(ics).toContain("Meetup:");
       expect(ics).not.toContain("at ");
@@ -317,7 +338,7 @@ describe("CalendarService.generateIcsFeed", () => {
         links: null,
         allDay: false,
       });
-      const ics = service.generateIcsFeed([{ trip, events: [event] }]);
+      const ics = service.generateIcsFeed([{ trip, events: [event], accommodations: [] }]);
 
       expect(ics).toContain("Meetup: at Hotel Lobby");
     });
@@ -351,8 +372,8 @@ describe("CalendarService.generateIcsFeed", () => {
       });
 
       const ics = service.generateIcsFeed([
-        { trip: trip1, events: [event1] },
-        { trip: trip2, events: [event2] },
+        { trip: trip1, events: [event1], accommodations: [] },
+        { trip: trip2, events: [event2], accommodations: [] },
       ]);
 
       // 2 trip overview events + 2 individual events = 4 VEVENTs
@@ -363,6 +384,104 @@ describe("CalendarService.generateIcsFeed", () => {
       expect(ics).toContain("SUMMARY:Trip Two");
       expect(ics).toContain("SUMMARY:Event One");
       expect(ics).toContain("SUMMARY:Event Two");
+    });
+  });
+
+  describe("accommodation events", () => {
+    it("should generate VEVENT with correct UID, summary, dates, and location", () => {
+      const trip = makeTrip({ startDate: null });
+      const acc = makeAccommodation();
+      const ics = unfold(
+        service.generateIcsFeed([
+          { trip, events: [], accommodations: [acc] },
+        ]),
+      );
+
+      expect(ics).toContain(`UID:accommodation-${acc.id}@tripful.app`);
+      expect(ics).toContain("SUMMARY:🏨 Seaside Resort");
+      expect(ics).toContain("LOCATION:123 Beach Rd\\, Cancun");
+      expect(ics).toContain("TRANSP:TRANSPARENT");
+      expect(ics).toContain("CATEGORIES:accommodation");
+      expect(ics).toContain("X-TRIPFUL-TRIP:Beach Vacation");
+      expect(ics).toContain("DTSTART");
+      expect(ics).toContain("DTEND");
+    });
+
+    it("should handle accommodation with no address, description, or links", () => {
+      const trip = makeTrip({ startDate: null });
+      const acc = makeAccommodation({
+        address: null,
+        description: null,
+        links: null,
+      });
+      const ics = unfold(
+        service.generateIcsFeed([
+          { trip, events: [], accommodations: [acc] },
+        ]),
+      );
+
+      expect(ics).toContain(`UID:accommodation-${acc.id}@tripful.app`);
+      expect(ics).toContain("SUMMARY:🏨 Seaside Resort");
+      // Should not contain LOCATION when address is null
+      expect(ics).not.toContain("LOCATION:");
+      expect(ics).not.toContain("Links:");
+      // Should still have trip link
+      expect(ics).toContain(`https://tripful.app/trips/${trip.id}`);
+    });
+
+    it("should include accommodations alongside trip and event VEVENTs", () => {
+      const trip = makeTrip(); // has startDate so trip overview is generated
+      const event = makeEvent({ allDay: false });
+      const acc = makeAccommodation();
+      const ics = service.generateIcsFeed([
+        { trip, events: [event], accommodations: [acc] },
+      ]);
+
+      // 1 trip overview + 1 event + 1 accommodation = 3 VEVENTs
+      const veventCount = (ics.match(/BEGIN:VEVENT/g) || []).length;
+      expect(veventCount).toBe(3);
+    });
+
+    it("should apply timezone conversion to checkIn/checkOut", () => {
+      // checkIn 2026-07-01T15:00:00Z with America/Cancun (UTC-5) = 10:00 AM local
+      const trip = makeTrip({
+        startDate: null,
+        preferredTimezone: "America/Cancun",
+      });
+      const acc = makeAccommodation({
+        checkIn: new Date("2026-07-01T15:00:00Z"),
+        checkOut: new Date("2026-07-05T16:00:00Z"),
+      });
+      const ics = unfold(
+        service.generateIcsFeed([
+          { trip, events: [], accommodations: [acc] },
+        ]),
+      );
+
+      expect(ics).toContain(
+        "DTSTART;TZID=America/Cancun:20260701T100000",
+      );
+      // checkOut 16:00 UTC = 11:00 AM local
+      expect(ics).toContain(
+        "DTEND;TZID=America/Cancun:20260705T110000",
+      );
+    });
+
+    it("should include description and links in description field", () => {
+      const trip = makeTrip({ startDate: null });
+      const acc = makeAccommodation({
+        description: "Oceanfront hotel with pool",
+        links: ["https://seaside-resort.example.com"],
+      });
+      const ics = unfold(
+        service.generateIcsFeed([
+          { trip, events: [], accommodations: [acc] },
+        ]),
+      );
+
+      expect(ics).toContain("Oceanfront hotel with pool");
+      expect(ics).toContain("Links:");
+      expect(ics).toContain("https://seaside-resort.example.com");
     });
   });
 });

--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -23,7 +23,7 @@ export default async function ProtectedLayout({
       <AppHeader />
       <main
         id="main-content"
-        className="bg-gradient-to-b from-background via-background to-secondary/30 min-h-screen"
+        className="bg-gradient-to-b from-background via-background to-secondary/30 min-h-[calc(100dvh-3.5rem)]"
       >
         <QueryErrorBoundaryWrapper>{children}</QueryErrorBoundaryWrapper>
       </main>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -493,6 +493,13 @@
   bottom: calc(2rem + env(safe-area-inset-bottom));
 }
 
+@utility scrollbar-none {
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
 /* Postcard card style — vintage with rounded corners */
 .postcard {
   display: block;

--- a/apps/web/src/components/itinerary/accommodation-line-item.tsx
+++ b/apps/web/src/components/itinerary/accommodation-line-item.tsx
@@ -17,7 +17,7 @@ export const AccommodationLineItem = memo(function AccommodationLineItem({
     <div
       role="button"
       tabIndex={0}
-      className="flex items-center gap-2 py-2 px-3 border-b border-border/40 hover:bg-muted/50 cursor-pointer transition-colors"
+      className="flex items-center gap-2 py-2 px-3 rounded-md border border-border/60 border-l-4 border-l-accommodation bg-accommodation-light transition-all hover:shadow-lg motion-safe:hover:-translate-y-1 motion-safe:active:scale-[0.98] cursor-pointer"
       onClick={() => onClick(accommodation)}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {

--- a/apps/web/src/components/itinerary/accommodation-line-item.tsx
+++ b/apps/web/src/components/itinerary/accommodation-line-item.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { memo } from "react";
-import { Building2, ChevronRight, ExternalLink } from "lucide-react";
+import { Building2, MapPin } from "lucide-react";
 import type { Accommodation } from "@tripful/shared/types";
 
 interface AccommodationLineItemProps {
@@ -31,23 +31,18 @@ export const AccommodationLineItem = memo(function AccommodationLineItem({
         {accommodation.name}
       </span>
       {accommodation.address && (
-        <>
-          <span className="text-[11px] text-muted-foreground truncate min-w-0 hidden sm:inline">
-            {accommodation.address}
-          </span>
-          <a
-            href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(accommodation.address)}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-muted-foreground hover:text-primary transition-colors shrink-0"
-            onClick={(e) => e.stopPropagation()}
-            aria-label={`${accommodation.name} on Google Maps`}
-          >
-            <ExternalLink className="w-3 h-3" />
-          </a>
-        </>
+        <a
+          href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(accommodation.address)}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-primary transition-colors min-w-0"
+          onClick={(e) => e.stopPropagation()}
+          aria-label={`${accommodation.name} on Google Maps`}
+        >
+          <MapPin className="w-3 h-3 shrink-0" />
+          <span className="truncate">{accommodation.address}</span>
+        </a>
       )}
-      <ChevronRight className="w-3 h-3 text-muted-foreground/60 ml-auto shrink-0" />
     </div>
   );
 });

--- a/apps/web/src/components/itinerary/day-by-day-view.tsx
+++ b/apps/web/src/components/itinerary/day-by-day-view.tsx
@@ -368,7 +368,7 @@ export function DayByDayView({
             key={day.date}
             id={isToday ? "day-today" : undefined}
             className={cn(
-              "grid grid-cols-[4.5rem_1fr] sm:grid-cols-[5rem_1fr] gap-x-3 py-4",
+              "grid grid-cols-[3.5rem_1fr] sm:grid-cols-[4.5rem_1fr] gap-x-2 sm:gap-x-3 py-4",
               isToday && "scroll-mt-28",
             )}
           >
@@ -385,7 +385,7 @@ export function DayByDayView({
                 </span>
                 <span
                   className={cn(
-                    "flex h-10 w-10 items-center justify-center rounded-full text-2xl font-bold leading-none",
+                    "flex h-8 w-8 sm:h-10 sm:w-10 items-center justify-center rounded-full text-xl sm:text-2xl font-bold leading-none",
                     isToday
                       ? "bg-primary text-primary-foreground"
                       : "text-foreground",

--- a/apps/web/src/components/itinerary/event-card.tsx
+++ b/apps/web/src/components/itinerary/event-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { memo } from "react";
-import { Calendar, Car, ExternalLink, MapPin, Utensils } from "lucide-react";
+import { Calendar, Car, MapPin, Utensils } from "lucide-react";
 import type { Event } from "@tripful/shared/types";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -119,22 +119,19 @@ export const EventCard = memo(function EventCard({
         )}
       </div>
 
-      {/* Line 3: Location with link icon */}
+      {/* Line 3: Location as map link */}
       {event.location && (
-        <div className="flex items-center gap-1 text-xs text-muted-foreground truncate">
+        <a
+          href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(event.location)}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-primary transition-colors truncate"
+          onClick={(e) => e.stopPropagation()}
+          aria-label={`${event.location} on Google Maps`}
+        >
           <MapPin className="w-3 h-3 shrink-0" />
           <span className="truncate">{event.location}</span>
-          <a
-            href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(event.location)}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="hover:text-primary transition-colors shrink-0"
-            onClick={(e) => e.stopPropagation()}
-            aria-label={`${event.location} on Google Maps`}
-          >
-            <ExternalLink className="w-3 h-3" />
-          </a>
-        </div>
+        </a>
       )}
     </div>
   );

--- a/apps/web/src/components/itinerary/member-travel-line-item.tsx
+++ b/apps/web/src/components/itinerary/member-travel-line-item.tsx
@@ -1,12 +1,7 @@
 "use client";
 
 import React, { memo, useCallback } from "react";
-import {
-  ChevronRight,
-  ExternalLink,
-  PlaneLanding,
-  PlaneTakeoff,
-} from "lucide-react";
+import { MapPin, PlaneLanding, PlaneTakeoff } from "lucide-react";
 import type { MemberTravel } from "@tripful/shared/types";
 import { formatInTimezone } from "@/lib/utils/timezone";
 
@@ -51,26 +46,21 @@ export const MemberTravelLineItem = memo(function MemberTravelLineItem({
       className="flex items-center gap-2 py-2 px-3 border-b border-border/40 hover:bg-muted/50 cursor-pointer transition-colors"
     >
       <PlaneIcon className="w-3 h-3 text-member-travel shrink-0" />
-      <span className="font-medium text-xs truncate">{memberName}</span>
-      <span className="text-[11px] text-muted-foreground">· {time}</span>
+      <span className="font-medium text-xs truncate min-w-0">{memberName}</span>
+      <span className="text-[11px] text-muted-foreground shrink-0 whitespace-nowrap">· {time}</span>
       {memberTravel.location && (
-        <>
-          <span className="text-[11px] text-muted-foreground truncate min-w-0">
-            {memberTravel.location}
-          </span>
-          <a
-            href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(memberTravel.location)}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-muted-foreground hover:text-primary transition-colors shrink-0"
-            onClick={(e) => e.stopPropagation()}
-            aria-label={`${memberTravel.location} on Google Maps`}
-          >
-            <ExternalLink className="w-3 h-3" />
-          </a>
-        </>
+        <a
+          href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(memberTravel.location)}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-primary transition-colors min-w-0"
+          onClick={(e) => e.stopPropagation()}
+          aria-label={`${memberTravel.location} on Google Maps`}
+        >
+          <MapPin className="w-3 h-3 shrink-0" />
+          <span className="truncate">{memberTravel.location}</span>
+        </a>
       )}
-      <ChevronRight className="w-3 h-3 text-muted-foreground/60 ml-auto shrink-0" />
     </div>
   );
 });

--- a/apps/web/src/components/itinerary/weather-day-badge.tsx
+++ b/apps/web/src/components/itinerary/weather-day-badge.tsx
@@ -22,12 +22,12 @@ export const WeatherDayBadge = memo(function WeatherDayBadge({
 
   return (
     <span
-      className="mt-1 inline-flex items-center gap-0.5 text-[0.65rem] text-muted-foreground"
+      className="mt-1 inline-flex flex-col items-center text-[0.65rem] text-muted-foreground"
       aria-label={`${label}, ${high}/${low}°${unit}`}
     >
       <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
       <span className="tabular-nums">
-        {high}/{low}&deg;{unit}
+        {high}/{low}&deg;
       </span>
     </span>
   );

--- a/apps/web/src/components/itinerary/weather-day-badge.tsx
+++ b/apps/web/src/components/itinerary/weather-day-badge.tsx
@@ -27,7 +27,7 @@ export const WeatherDayBadge = memo(function WeatherDayBadge({
     >
       <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
       <span className="tabular-nums">
-        {high}/{low}&deg;
+        {high}/{low}&deg;{unit}
       </span>
     </span>
   );

--- a/apps/web/src/components/itinerary/weather-forecast-card.tsx
+++ b/apps/web/src/components/itinerary/weather-forecast-card.tsx
@@ -126,7 +126,7 @@ export const WeatherForecastCard = memo(function WeatherForecastCard({
   return (
     <div className="space-y-1.5">
       <div
-        className="flex gap-1.5 overflow-x-auto pb-0.5"
+        className="flex gap-1.5 overflow-x-auto pb-0.5 scrollbar-none"
         role="region"
         aria-label="Weather forecast"
         tabIndex={0}
@@ -142,7 +142,7 @@ export const WeatherForecastCard = memo(function WeatherForecastCard({
           return (
             <div
               key={day.date}
-              className={`flex min-w-[6rem] flex-1 flex-col items-center rounded-md px-1.5 py-2 ${tileBg}`}
+              className={`flex min-w-[4.5rem] flex-1 flex-col items-center rounded-md px-1 py-2 ${tileBg}`}
               title={label}
               aria-label={`${formatDayOfWeek(day.date)}: ${label}, high ${high}, low ${low}${day.precipitationProbability > 5 ? `, ${day.precipitationProbability}% rain` : ""}`}
             >

--- a/apps/web/src/components/trip/mobile/panels/info-panel.tsx
+++ b/apps/web/src/components/trip/mobile/panels/info-panel.tsx
@@ -6,15 +6,9 @@ import {
   ClipboardList,
   UserPlus,
   Pencil,
-  ChevronDown,
   Settings,
 } from "lucide-react";
 import { RsvpBadgeDropdown } from "@/components/trip/rsvp-badge-dropdown";
-import {
-  Collapsible,
-  CollapsibleTrigger,
-  CollapsibleContent,
-} from "@/components/ui/collapsible";
 import { WeatherForecastCard } from "@/components/itinerary/weather-forecast-card";
 import { MessageCountIndicator } from "@/components/messaging";
 import { getUploadUrl } from "@/lib/api";
@@ -174,35 +168,21 @@ export function InfoPanel({
         </div>
 
         {/* About this trip */}
-        <Collapsible defaultOpen className="mb-2">
-          <CollapsibleTrigger className="flex items-center gap-2 px-0 text-sm font-semibold text-foreground hover:text-foreground/80 min-h-[44px] cursor-pointer">
-            <ChevronDown
-              className="w-4 h-4 transition-transform duration-200 [[data-state=closed]_&]:-rotate-90"
-              aria-hidden="true"
-            />
-            About this trip
-          </CollapsibleTrigger>
-          <CollapsibleContent
-            forceMount
-            className="overflow-hidden data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:h-0"
-          >
-            <div className="mt-3 space-y-3">
-              {trip.description && (
-                <div className="bg-card rounded-md border border-border p-6 linen-texture">
-                  <p className="text-muted-foreground whitespace-pre-wrap">
-                    {trip.description}
-                  </p>
-                </div>
-              )}
-              <WeatherForecastCard
-                weather={weather}
-                isLoading={weatherLoading}
-                temperatureUnit={temperatureUnit}
-                isDark={preset?.background.isDark ?? false}
-              />
+        <div className="mb-2 space-y-3">
+          {trip.description && (
+            <div className="bg-card rounded-md border border-border p-6 linen-texture">
+              <p className="text-muted-foreground whitespace-pre-wrap">
+                {trip.description}
+              </p>
             </div>
-          </CollapsibleContent>
-        </Collapsible>
+          )}
+          <WeatherForecastCard
+            weather={weather}
+            isLoading={weatherLoading}
+            temperatureUnit={temperatureUnit}
+            isDark={preset?.background.isDark ?? false}
+          />
+        </div>
       </div>
     </div>
   );

--- a/apps/web/tests/e2e/helpers/trips.ts
+++ b/apps/web/tests/e2e/helpers/trips.ts
@@ -3,7 +3,11 @@ import type { Page } from "@playwright/test";
 import { TripsPage, TripDetailPage } from "./pages";
 import { pickDate } from "./date-pickers";
 import { dismissToast } from "./toast";
-import { ELEMENT_TIMEOUT, RETRY_INTERVAL } from "./timeouts";
+import {
+  ELEMENT_TIMEOUT,
+  NAVIGATION_TIMEOUT,
+  RETRY_INTERVAL,
+} from "./timeouts";
 
 /** Create a trip via the UI and land on the trip detail page. */
 export async function createTrip(
@@ -25,7 +29,7 @@ export async function createTrip(
     await expect(tripDetail.createDialogHeading).toBeVisible({
       timeout: RETRY_INTERVAL,
     });
-  }).toPass({ timeout: ELEMENT_TIMEOUT });
+  }).toPass({ timeout: NAVIGATION_TIMEOUT });
   await tripDetail.nameInput.fill(tripName);
   await tripDetail.destinationInput.fill(destination);
   await pickDate(page, tripDetail.startDateButton, startDate);
@@ -36,5 +40,5 @@ export async function createTrip(
   await page.waitForURL("**/trips/**");
   await expect(
     page.getByRole("heading", { level: 1, name: tripName }),
-  ).toBeVisible();
+  ).toBeVisible({ timeout: NAVIGATION_TIMEOUT });
 }

--- a/apps/web/tests/e2e/helpers/trips.ts
+++ b/apps/web/tests/e2e/helpers/trips.ts
@@ -3,11 +3,7 @@ import type { Page } from "@playwright/test";
 import { TripsPage, TripDetailPage } from "./pages";
 import { pickDate } from "./date-pickers";
 import { dismissToast } from "./toast";
-import {
-  ELEMENT_TIMEOUT,
-  NAVIGATION_TIMEOUT,
-  RETRY_INTERVAL,
-} from "./timeouts";
+import { NAVIGATION_TIMEOUT, RETRY_INTERVAL } from "./timeouts";
 
 /** Create a trip via the UI and land on the trip detail page. */
 export async function createTrip(


### PR DESCRIPTION
## Summary
- Include accommodation check-in/check-out events in ICS calendar export with name, description, links, and address
- De-clutter itinerary line items: replace ExternalLink + ChevronRight with a single MapPin icon on accommodation, member travel, and event cards — whole location area is a tappable Google Maps link
- Compact date gutter on mobile (3.5rem vs 4.5rem) with smaller day circle, freeing up card real estate
- Stack weather icon above high/low temps in day gutter; hide scrollbar on weather forecast card and reduce tile min-width
- Remove collapsible wrapper from mobile info panel — tabs already separate content
- Fix blank bar at bottom of mobile view (main min-height now accounts for header)

## Test plan
- [ ] Verify ICS feed includes accommodation events with correct dates and details
- [ ] Check itinerary line items show MapPin instead of ExternalLink + ChevronRight
- [ ] Verify location links open Google Maps on tap
- [ ] Check date gutter is compact on mobile, normal on desktop
- [ ] Verify weather forecast tiles fit without ugly scrollbar
- [ ] Confirm no blank bar at bottom of mobile trip view
- [ ] Run unit tests for calendar service

🤖 Generated with [Claude Code](https://claude.com/claude-code)