### PR TITLE
Mobile home: today section, current trips, and linkification

### DIFF
--- a/apps/web/src/app/(app)/trips/trips-content.tsx
+++ b/apps/web/src/app/(app)/trips/trips-content.tsx
@@ -32,6 +32,8 @@ export function TripsContent() {
   const searchParams = useSearchParams();
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState(searchParams.get("q") ?? "");
+  const { ref: currentSectionRef, isRevealed: currentRevealed } =
+    useScrollReveal();
   const { ref: upcomingSectionRef, isRevealed: upcomingRevealed } =
     useScrollReveal();
   const { ref: pastSectionRef, isRevealed: pastRevealed } = useScrollReveal();
@@ -90,11 +92,14 @@ export function TripsContent() {
     );
   }, [trips, searchQuery]);
 
-  // Split trips into upcoming and past based on end date (or start date)
-  // Trips stay "upcoming" until one day after their end date
-  const { upcomingTrips, pastTrips } = useMemo(() => {
+  // Split trips into current, upcoming, and past
+  // Current: startDate <= today <= effectiveEnd (trips happening now)
+  // Upcoming: startDate > today (trips that haven't started yet)
+  // Past: effectiveEnd < today
+  const { currentTrips, upcomingTrips, pastTrips } = useMemo(() => {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
+    const current: TripSummary[] = [];
     const upcoming: TripSummary[] = [];
     const past: TripSummary[] = [];
     for (const trip of filteredTrips) {
@@ -102,16 +107,20 @@ export function TripsContent() {
         upcoming.push(trip);
         continue;
       }
+      const startDate = new Date(trip.startDate);
+      startDate.setHours(0, 0, 0, 0);
       const effectiveEnd = new Date(trip.endDate ?? trip.startDate);
       effectiveEnd.setDate(effectiveEnd.getDate() + 1);
       effectiveEnd.setHours(23, 59, 59, 999);
-      if (effectiveEnd >= today) {
+      if (startDate <= today && effectiveEnd >= today) {
+        current.push(trip);
+      } else if (startDate > today) {
         upcoming.push(trip);
       } else {
         past.push(trip);
       }
     }
-    return { upcomingTrips: upcoming, pastTrips: past };
+    return { currentTrips: current, upcomingTrips: upcoming, pastTrips: past };
   }, [filteredTrips]);
 
   const tripCount = data?.pages[0]?.meta?.total ?? trips.length;
@@ -227,6 +236,26 @@ export function TripsContent() {
         {/* Trips Sections */}
         {!isPending && !isError && !isEmpty && !noResults && (
           <div aria-live="polite">
+            {/* Current Trips */}
+            {currentTrips.length > 0 && (
+              <section
+                ref={currentSectionRef}
+                className={`mb-12 ${currentRevealed ? "motion-safe:animate-[revealUp_400ms_ease-out_both]" : "motion-safe:opacity-0"}`}
+              >
+                <h2 className="text-xl sm:text-2xl font-semibold text-foreground mb-4 font-playfair">
+                  Current trips
+                  <span className="block text-xs font-normal text-muted-foreground font-accent tracking-wider uppercase mt-1">
+                    In progress
+                  </span>
+                </h2>
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+                  {currentTrips.map((trip, index) => (
+                    <TripCard key={trip.id} trip={trip} index={index} />
+                  ))}
+                </div>
+              </section>
+            )}
+
             {/* Upcoming Trips */}
             {upcomingTrips.length > 0 && (
               <section

--- a/apps/web/src/components/trip/mobile/panels/info-panel.tsx
+++ b/apps/web/src/components/trip/mobile/panels/info-panel.tsx
@@ -11,6 +11,8 @@ import {
 import { RsvpBadgeDropdown } from "@/components/trip/rsvp-badge-dropdown";
 import { WeatherForecastCard } from "@/components/itinerary/weather-forecast-card";
 import { MessageCountIndicator } from "@/components/messaging";
+import { TodaySection } from "./today-section";
+import { linkifyText } from "@/utils/linkify";
 import { getUploadUrl } from "@/lib/api";
 import { getInitials } from "@/lib/format";
 import { supportsHover } from "@/lib/supports-hover";
@@ -167,12 +169,19 @@ export function InfoPanel({
           <MessageCountIndicator tripId={tripId} />
         </div>
 
+        {/* Today's schedule */}
+        <TodaySection
+          tripId={tripId}
+          timezone={trip.preferredTimezone || "UTC"}
+          onNavigateToItinerary={onNavigateToItinerary}
+        />
+
         {/* About this trip */}
         <div className="mb-2 space-y-3">
           {trip.description && (
             <div className="bg-card rounded-md border border-border p-6 linen-texture">
-              <p className="text-muted-foreground whitespace-pre-wrap">
-                {trip.description}
+              <p className="text-sm text-muted-foreground whitespace-pre-wrap">
+                {linkifyText(trip.description)}
               </p>
             </div>
           )}

--- a/apps/web/src/components/trip/mobile/panels/today-section.tsx
+++ b/apps/web/src/components/trip/mobile/panels/today-section.tsx
@@ -107,12 +107,16 @@ export function TodaySection({
     todayAccommodations.length === 0 &&
     sortedEvents.length === 0;
 
-  const todayLabel = new Intl.DateTimeFormat("en-US", {
-    timeZone: timezone,
-    weekday: "long",
-    month: "short",
-    day: "numeric",
-  }).format(new Date());
+  const todayLabel = useMemo(
+    () =>
+      new Intl.DateTimeFormat("en-US", {
+        timeZone: timezone,
+        weekday: "long",
+        month: "short",
+        day: "numeric",
+      }).format(new Date()),
+    [timezone],
+  );
 
   return (
     <div className="mb-6">

--- a/apps/web/src/components/trip/mobile/panels/today-section.tsx
+++ b/apps/web/src/components/trip/mobile/panels/today-section.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Calendar } from "lucide-react";
+import type { Accommodation, Event } from "@tripful/shared/types";
+import { useAccommodations } from "@/hooks/use-accommodations";
+import { useEvents } from "@/hooks/use-events";
+import { getDayInTimezone, utcToLocalParts } from "@/lib/utils/timezone";
+import { AccommodationLineItem } from "@/components/itinerary/accommodation-line-item";
+import { AccommodationDetailSheet } from "@/components/itinerary/accommodation-detail-sheet";
+import { EventCard } from "@/components/itinerary/event-card";
+import { EventDetailSheet } from "@/components/itinerary/event-detail-sheet";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const MAX_VISIBLE_EVENTS = 4;
+
+interface TodaySectionProps {
+  tripId: string;
+  timezone: string;
+  onNavigateToItinerary: () => void;
+}
+
+export function TodaySection({
+  tripId,
+  timezone,
+  onNavigateToItinerary,
+}: TodaySectionProps) {
+  const { data: accommodations, isPending: accLoading } =
+    useAccommodations(tripId);
+  const { data: events, isPending: eventsLoading } = useEvents(tripId);
+
+  const todayString = useMemo(
+    () => getDayInTimezone(new Date(), timezone),
+    [timezone],
+  );
+
+  // Filter accommodations to today: checkIn <= today < checkOut
+  const todayAccommodations = useMemo(() => {
+    if (!accommodations) return [];
+    return accommodations.filter((acc) => {
+      const startDay = getDayInTimezone(acc.checkIn, timezone);
+      const endDay = getDayInTimezone(acc.checkOut, timezone);
+      const current = new Date(startDay + "T00:00:00");
+      const end = new Date(endDay + "T00:00:00");
+      const today = new Date(todayString + "T00:00:00");
+      return current <= today && today < end;
+    });
+  }, [accommodations, timezone, todayString]);
+
+  // Filter events to today
+  const todayEvents = useMemo(() => {
+    if (!events) return [];
+    return events.filter((event) => {
+      const startDay = getDayInTimezone(event.startTime, timezone);
+
+      if (event.allDay) {
+        // All-day events: check if today is in range
+        if (!event.endTime) return startDay === todayString;
+        const endDay = getDayInTimezone(event.endTime, timezone);
+        return startDay <= todayString && todayString <= endDay;
+      }
+
+      // Timed events: check if today falls within start-end range
+      const endIsMidnight = event.endTime
+        ? utcToLocalParts(
+            typeof event.endTime === "string"
+              ? event.endTime
+              : event.endTime.toISOString(),
+            timezone,
+          ).time === "00:00"
+        : false;
+      const endDay =
+        event.endTime && !endIsMidnight
+          ? getDayInTimezone(event.endTime, timezone)
+          : startDay;
+
+      if (startDay === endDay) {
+        return startDay === todayString;
+      }
+      // Multi-day event
+      return startDay <= todayString && todayString <= endDay;
+    });
+  }, [events, timezone, todayString]);
+
+  // Sort: all-day first, then by startTime
+  const sortedEvents = useMemo(() => {
+    return [...todayEvents].sort((a, b) => {
+      if (a.allDay && !b.allDay) return -1;
+      if (!a.allDay && b.allDay) return 1;
+      return (
+        new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
+      );
+    });
+  }, [todayEvents]);
+
+  const visibleEvents = sortedEvents.slice(0, MAX_VISIBLE_EVENTS);
+  const hasMoreEvents = sortedEvents.length > MAX_VISIBLE_EVENTS;
+
+  // Detail sheet state
+  const [selectedAccommodation, setSelectedAccommodation] =
+    useState<Accommodation | null>(null);
+  const [selectedEvent, setSelectedEvent] = useState<Event | null>(null);
+
+  const isLoading = accLoading || eventsLoading;
+  const isEmpty =
+    !isLoading &&
+    todayAccommodations.length === 0 &&
+    sortedEvents.length === 0;
+
+  const todayLabel = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    weekday: "long",
+    month: "short",
+    day: "numeric",
+  }).format(new Date());
+
+  return (
+    <div className="mb-6">
+      <h3 className="text-sm font-semibold text-foreground mb-2">
+        Today{" "}
+        <span className="font-normal text-muted-foreground">{todayLabel}</span>
+      </h3>
+
+      {isLoading && (
+        <div className="space-y-2">
+          <Skeleton className="h-10 w-full rounded-md" />
+          <Skeleton className="h-16 w-full rounded-md" />
+        </div>
+      )}
+
+      {isEmpty && (
+        <div className="flex items-center gap-2 py-4 text-muted-foreground">
+          <Calendar className="w-4 h-4" />
+          <span className="text-sm">Nothing planned for today</span>
+        </div>
+      )}
+
+      {!isLoading && !isEmpty && (
+        <div className="space-y-2">
+          {todayAccommodations.map((acc) => (
+            <AccommodationLineItem
+              key={acc.id}
+              accommodation={acc}
+              onClick={setSelectedAccommodation}
+            />
+          ))}
+
+          {visibleEvents.map((event) => (
+            <EventCard
+              key={event.id}
+              event={event}
+              timezone={timezone}
+              onClick={setSelectedEvent}
+            />
+          ))}
+
+          {hasMoreEvents && (
+            <button
+              onClick={onNavigateToItinerary}
+              className="w-full text-center text-sm text-primary hover:text-primary/80 py-2 transition-colors cursor-pointer"
+            >
+              View all in itinerary
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Detail sheets */}
+      <AccommodationDetailSheet
+        accommodation={selectedAccommodation}
+        open={!!selectedAccommodation}
+        onOpenChange={(open) => {
+          if (!open) setSelectedAccommodation(null);
+        }}
+        timezone={timezone}
+        canEdit={false}
+        canDelete={false}
+        onEdit={() => {}}
+        onDelete={() => setSelectedAccommodation(null)}
+      />
+
+      <EventDetailSheet
+        event={selectedEvent}
+        open={!!selectedEvent}
+        onOpenChange={(open) => {
+          if (!open) setSelectedEvent(null);
+        }}
+        timezone={timezone}
+        canEdit={false}
+        canDelete={false}
+        onEdit={() => {}}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/utils/__tests__/linkify.test.tsx
+++ b/apps/web/src/utils/__tests__/linkify.test.tsx
@@ -84,6 +84,34 @@ describe("linkifyText", () => {
     );
   });
 
+  it("linkifies bare domain with common TLD", () => {
+    const result = linkifyText("Check google.com for info");
+    expect(result).toHaveLength(3);
+    expect(result[0]).toBe("Check ");
+    const anchor = result[1] as React.ReactElement;
+    expect(anchor.props.href).toBe("https://google.com");
+    expect(anchor.props.children).toBe("google.com");
+    expect(result[2]).toBe(" for info");
+  });
+
+  it("linkifies bare domain with path", () => {
+    const result = linkifyText("See docs.google.com/spreadsheets for details");
+    expect(result).toHaveLength(3);
+    const anchor = result[1] as React.ReactElement;
+    expect(anchor.props.href).toBe("https://docs.google.com/spreadsheets");
+    expect(anchor.props.children).toBe("docs.google.com/spreadsheets");
+  });
+
+  it("does not linkify words that look like domains but have unknown TLDs", () => {
+    const result = linkifyText("file.txt is not a URL");
+    expect(result).toEqual(["file.txt is not a URL"]);
+  });
+
+  it("does not linkify email-like patterns", () => {
+    const result = linkifyText("Email user@example.com for help");
+    expect(result).toEqual(["Email user@example.com for help"]);
+  });
+
   it("returns single-element array for empty string", () => {
     const result = linkifyText("");
     expect(result).toEqual([""]);

--- a/apps/web/src/utils/__tests__/linkify.test.tsx
+++ b/apps/web/src/utils/__tests__/linkify.test.tsx
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { linkifyText } from "../linkify";
+
+describe("linkifyText", () => {
+  it("returns the original text when there are no URLs", () => {
+    const result = linkifyText("Hello, world!");
+    expect(result).toEqual(["Hello, world!"]);
+  });
+
+  it("linkifies a single URL in the middle of text", () => {
+    const result = linkifyText("Visit https://example.com for info");
+    expect(result).toHaveLength(3);
+    expect(result[0]).toBe("Visit ");
+    expect(result[2]).toBe(" for info");
+
+    // Check the anchor element
+    const anchor = result[1] as React.ReactElement;
+    expect(anchor.props.href).toBe("https://example.com");
+    expect(anchor.props.target).toBe("_blank");
+    expect(anchor.props.rel).toBe("noopener noreferrer");
+    expect(anchor.props.children).toBe("https://example.com");
+  });
+
+  it("linkifies multiple URLs", () => {
+    const result = linkifyText(
+      "See https://a.com and https://b.com for details",
+    );
+    expect(result).toHaveLength(5);
+    expect(result[0]).toBe("See ");
+    expect((result[1] as React.ReactElement).props.href).toBe("https://a.com");
+    expect(result[2]).toBe(" and ");
+    expect((result[3] as React.ReactElement).props.href).toBe("https://b.com");
+    expect(result[4]).toBe(" for details");
+  });
+
+  it("handles URL at the start of text", () => {
+    const result = linkifyText("https://example.com is great");
+    expect(result).toHaveLength(2);
+    expect((result[0] as React.ReactElement).props.href).toBe(
+      "https://example.com",
+    );
+    expect(result[1]).toBe(" is great");
+  });
+
+  it("handles URL at the end of text", () => {
+    const result = linkifyText("Check out https://example.com");
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe("Check out ");
+    expect((result[1] as React.ReactElement).props.href).toBe(
+      "https://example.com",
+    );
+  });
+
+  it("strips trailing punctuation from URLs", () => {
+    const result = linkifyText("Go to https://example.com.");
+    expect(result).toHaveLength(3);
+    expect((result[1] as React.ReactElement).props.href).toBe(
+      "https://example.com",
+    );
+    expect(result[2]).toBe(".");
+  });
+
+  it("strips trailing comma from URLs", () => {
+    const result = linkifyText("See https://example.com, then go");
+    expect((result[1] as React.ReactElement).props.href).toBe(
+      "https://example.com",
+    );
+    expect(result[2]).toBe(", then go");
+  });
+
+  it("handles URLs with paths and query params", () => {
+    const result = linkifyText(
+      "Link: https://example.com/path?q=hello&lang=en#section",
+    );
+    expect((result[1] as React.ReactElement).props.href).toBe(
+      "https://example.com/path?q=hello&lang=en#section",
+    );
+  });
+
+  it("handles http URLs", () => {
+    const result = linkifyText("Go to http://example.com");
+    expect((result[1] as React.ReactElement).props.href).toBe(
+      "http://example.com",
+    );
+  });
+
+  it("returns single-element array for empty string", () => {
+    const result = linkifyText("");
+    expect(result).toEqual([""]);
+  });
+
+  it("applies correct className to links", () => {
+    const result = linkifyText("https://example.com");
+    const anchor = result[0] as React.ReactElement;
+    expect(anchor.props.className).toBe("text-primary underline");
+  });
+});

--- a/apps/web/src/utils/linkify.tsx
+++ b/apps/web/src/utils/linkify.tsx
@@ -1,12 +1,15 @@
 import type { ReactNode } from "react";
 
-const URL_REGEX = /https?:\/\/[^\s<>"']+/g;
+// Matches http(s):// URLs and bare domains with common TLDs (Gmail-style)
+const URL_REGEX =
+  /https?:\/\/[^\s<>"']+|(?<![/@\w.-])(?:\w[\w-]*\.)+(?:com|org|net|edu|gov|io|co|dev|app|me|info|biz|us|uk|ca|au|de|fr|jp|in|br|nl|se|no|fi|dk|it|es|pt|ch|at|be|nz|za|mx|ar|cl|kr|tw|sg|hk|ph|my|th|vn|id|pl|cz|hu|ro|bg|hr|sk|si|lt|lv|ee|ie|is|lu|mt|cy|gr)(?:\/[^\s<>"']*)?/gi;
 
 // Punctuation that commonly trails a URL in prose but isn't part of it
 const TRAILING_PUNCT = /[.,;:!?)]+$/;
 
 interface UrlMatch {
   url: string;
+  href: string;
   index: number;
 }
 
@@ -24,7 +27,10 @@ export function linkifyText(text: string): ReactNode[] {
       url = url.slice(0, -trailingMatch[0].length);
     }
 
-    matches.push({ url, index });
+    // Add protocol for bare domains
+    const href = /^https?:\/\//i.test(url) ? url : `https://${url}`;
+
+    matches.push({ url, href, index });
   }
 
   if (matches.length === 0) {
@@ -36,7 +42,7 @@ export function linkifyText(text: string): ReactNode[] {
 
   for (let i = 0; i < matches.length; i++) {
     const m = matches[i]!;
-    const { url, index } = m;
+    const { url, href, index } = m;
 
     // Text before this URL
     if (index > lastIndex) {
@@ -46,7 +52,7 @@ export function linkifyText(text: string): ReactNode[] {
     result.push(
       <a
         key={i}
-        href={url}
+        href={href}
         target="_blank"
         rel="noopener noreferrer"
         className="text-primary underline"

--- a/apps/web/src/utils/linkify.tsx
+++ b/apps/web/src/utils/linkify.tsx
@@ -17,6 +17,9 @@ export function linkifyText(text: string): ReactNode[] {
   const matches: UrlMatch[] = [];
   let match: RegExpExecArray | null;
 
+  // Reset lastIndex — the /g flag makes exec() stateful across calls
+  URL_REGEX.lastIndex = 0;
+
   while ((match = URL_REGEX.exec(text)) !== null) {
     let url = match[0];
     const index = match.index;

--- a/apps/web/src/utils/linkify.tsx
+++ b/apps/web/src/utils/linkify.tsx
@@ -1,0 +1,67 @@
+import type { ReactNode } from "react";
+
+const URL_REGEX = /https?:\/\/[^\s<>"']+/g;
+
+// Punctuation that commonly trails a URL in prose but isn't part of it
+const TRAILING_PUNCT = /[.,;:!?)]+$/;
+
+interface UrlMatch {
+  url: string;
+  index: number;
+}
+
+export function linkifyText(text: string): ReactNode[] {
+  const matches: UrlMatch[] = [];
+  let match: RegExpExecArray | null;
+
+  while ((match = URL_REGEX.exec(text)) !== null) {
+    let url = match[0];
+    const index = match.index;
+
+    // Strip trailing punctuation that's likely not part of the URL
+    const trailingMatch = TRAILING_PUNCT.exec(url);
+    if (trailingMatch) {
+      url = url.slice(0, -trailingMatch[0].length);
+    }
+
+    matches.push({ url, index });
+  }
+
+  if (matches.length === 0) {
+    return [text];
+  }
+
+  const result: ReactNode[] = [];
+  let lastIndex = 0;
+
+  for (let i = 0; i < matches.length; i++) {
+    const m = matches[i]!;
+    const { url, index } = m;
+
+    // Text before this URL
+    if (index > lastIndex) {
+      result.push(text.slice(lastIndex, index));
+    }
+
+    result.push(
+      <a
+        key={i}
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-primary underline"
+      >
+        {url}
+      </a>,
+    );
+
+    lastIndex = index + url.length;
+  }
+
+  // Text after last URL
+  if (lastIndex < text.length) {
+    result.push(text.slice(lastIndex));
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

- **Current trips section**: Split the trips listing into current/upcoming/past categories. Trips where `startDate <= today <= endDate+1` now appear in a dedicated "Current trips" section above upcoming trips.
- **Today section on mobile**: Added a `TodaySection` component to the mobile info panel showing today's events and accommodations with detail sheets, capped at 4 items with a "View all in itinerary" overflow link.
- **Text linkification**: Added `linkifyText()` utility that converts URLs and bare domains (Gmail-style, e.g. `google.com`) into clickable links. Applied to trip descriptions in the mobile info panel. Includes comprehensive test suite.

## Test plan

- [ ] Verify current trips appear in their own section on the trips listing page
- [ ] Verify today's events and accommodations show on mobile trip info panel
- [ ] Verify bare domains (e.g. `google.com/path`) and full URLs are linkified in trip descriptions
- [ ] Verify trailing punctuation is stripped from linkified URLs
- [ ] Run `pnpm test` — linkify unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)