### PR TITLE
Landing page & dashboard brand polish

### DIFF
--- a/apps/web/src/app/(app)/trips/[id]/trip-detail-content.tsx
+++ b/apps/web/src/app/(app)/trips/[id]/trip-detail-content.tsx
@@ -223,7 +223,7 @@ export function TripDetailContent({ tripId }: { tripId: string }) {
           <p className="text-muted-foreground mb-6">
             This trip doesn't exist or you don't have access to it.
           </p>
-          <Button variant="gradient" asChild className="h-12 px-8 rounded-md">
+          <Button variant="gradient" size="lg" asChild>
             <Link href="/trips">Return to trips</Link>
           </Button>
         </div>
@@ -385,39 +385,45 @@ export function TripDetailContent({ tripId }: { tripId: string }) {
               <div className="flex items-center gap-3">
                 {isOrganizer && (
                   <>
-                    <button
+                    <Button
                       onClick={() => setIsInviteOpen(true)}
                       onMouseEnter={
                         supportsHover ? preloadInviteMembersDialog : undefined
                       }
                       onTouchStart={preloadInviteMembersDialog}
                       onFocus={preloadInviteMembersDialog}
-                      className="text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                      variant="ghost"
+                      size="icon"
+                      className="text-muted-foreground hover:text-foreground hover:bg-transparent"
                       aria-label="Invite members"
                     >
                       <UserPlus className="w-5 h-5" />
-                    </button>
-                    <button
+                    </Button>
+                    <Button
                       onClick={() => setIsEditOpen(true)}
                       onMouseEnter={
                         supportsHover ? preloadEditTripDialog : undefined
                       }
                       onTouchStart={preloadEditTripDialog}
                       onFocus={preloadEditTripDialog}
-                      className="text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                      variant="ghost"
+                      size="icon"
+                      className="text-muted-foreground hover:text-foreground hover:bg-transparent"
                       aria-label="Edit trip"
                     >
                       <Pencil className="w-5 h-5" />
-                    </button>
+                    </Button>
                   </>
                 )}
-                <button
+                <Button
                   onClick={() => setIsSettingsOpen(true)}
-                  className="text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                  variant="ghost"
+                  size="icon"
+                  className="text-muted-foreground hover:text-foreground hover:bg-transparent"
                   aria-label="Settings"
                 >
                   <Settings className="w-5 h-5" />
-                </button>
+                </Button>
               </div>
             </div>
 

--- a/apps/web/src/app/(app)/trips/[id]/trip-detail-content.tsx
+++ b/apps/web/src/app/(app)/trips/[id]/trip-detail-content.tsx
@@ -392,12 +392,11 @@ export function TripDetailContent({ tripId }: { tripId: string }) {
                       }
                       onTouchStart={preloadInviteMembersDialog}
                       onFocus={preloadInviteMembersDialog}
-                      variant="ghost"
+                      variant="outline"
                       size="icon"
-                      className="text-muted-foreground hover:text-foreground hover:bg-transparent"
                       aria-label="Invite members"
                     >
-                      <UserPlus className="w-5 h-5" />
+                      <UserPlus />
                     </Button>
                     <Button
                       onClick={() => setIsEditOpen(true)}
@@ -406,23 +405,21 @@ export function TripDetailContent({ tripId }: { tripId: string }) {
                       }
                       onTouchStart={preloadEditTripDialog}
                       onFocus={preloadEditTripDialog}
-                      variant="ghost"
+                      variant="outline"
                       size="icon"
-                      className="text-muted-foreground hover:text-foreground hover:bg-transparent"
                       aria-label="Edit trip"
                     >
-                      <Pencil className="w-5 h-5" />
+                      <Pencil />
                     </Button>
                   </>
                 )}
                 <Button
                   onClick={() => setIsSettingsOpen(true)}
-                  variant="ghost"
+                  variant="outline"
                   size="icon"
-                  className="text-muted-foreground hover:text-foreground hover:bg-transparent"
                   aria-label="Settings"
                 >
-                  <Settings className="w-5 h-5" />
+                  <Settings />
                 </Button>
               </div>
             </div>

--- a/apps/web/src/app/(app)/trips/trips-content.test.tsx
+++ b/apps/web/src/app/(app)/trips/trips-content.test.tsx
@@ -287,7 +287,7 @@ describe("TripsContent", () => {
       expect(screen.getByText("Your adventures await")).toBeDefined();
       expect(
         screen.getByText(
-          "Start planning your next adventure by creating your first trip.",
+          "Invite friends, plan together, and keep everything in one place.",
         ),
       ).toBeDefined();
       expect(screen.getByText("Create your first trip")).toBeDefined();
@@ -394,7 +394,7 @@ describe("TripsContent", () => {
 
       renderWithClient(<TripsContent />);
 
-      const searchInput = screen.getByPlaceholderText("Search trips...");
+      const searchInput = screen.getByPlaceholderText("Search by name or destination...");
       await user.type(searchInput, "Summer");
 
       await waitFor(() => {
@@ -416,7 +416,7 @@ describe("TripsContent", () => {
 
       renderWithClient(<TripsContent />);
 
-      const searchInput = screen.getByPlaceholderText("Search trips...");
+      const searchInput = screen.getByPlaceholderText("Search by name or destination...");
       await user.type(searchInput, "Aspen");
 
       await waitFor(() => {
@@ -437,7 +437,7 @@ describe("TripsContent", () => {
 
       renderWithClient(<TripsContent />);
 
-      const searchInput = screen.getByPlaceholderText("Search trips...");
+      const searchInput = screen.getByPlaceholderText("Search by name or destination...");
       await user.type(searchInput, "hawaii");
 
       await waitFor(() => {
@@ -457,7 +457,7 @@ describe("TripsContent", () => {
 
       renderWithClient(<TripsContent />);
 
-      const searchInput = screen.getByPlaceholderText("Search trips...");
+      const searchInput = screen.getByPlaceholderText("Search by name or destination...");
       await user.type(searchInput, "xyz123");
 
       await waitFor(() => {
@@ -480,7 +480,7 @@ describe("TripsContent", () => {
 
       renderWithClient(<TripsContent />);
 
-      const searchInput = screen.getByPlaceholderText("Search trips...");
+      const searchInput = screen.getByPlaceholderText("Search by name or destination...");
       await user.type(searchInput, "Summer");
 
       await waitFor(() => {
@@ -510,7 +510,7 @@ describe("TripsContent", () => {
       renderWithClient(<TripsContent />);
 
       const searchInput =
-        screen.getByPlaceholderText<HTMLInputElement>("Search trips...");
+        screen.getByPlaceholderText<HTMLInputElement>("Search by name or destination...");
       expect(searchInput.value).toBe("Summer");
 
       // Should filter to show only matching trips
@@ -533,7 +533,7 @@ describe("TripsContent", () => {
 
       renderWithClient(<TripsContent />);
 
-      const searchInput = screen.getByPlaceholderText("Search trips...");
+      const searchInput = screen.getByPlaceholderText("Search by name or destination...");
       await user.type(searchInput, "Hawaii");
 
       // Advance past the 300ms debounce
@@ -565,7 +565,7 @@ describe("TripsContent", () => {
 
       renderWithClient(<TripsContent />);
 
-      const searchInput = screen.getByPlaceholderText("Search trips...");
+      const searchInput = screen.getByPlaceholderText("Search by name or destination...");
       await user.clear(searchInput);
 
       // Advance past the 300ms debounce

--- a/apps/web/src/app/(app)/trips/trips-content.tsx
+++ b/apps/web/src/app/(app)/trips/trips-content.tsx
@@ -162,7 +162,7 @@ export function TripsContent() {
               onClick={toggleSearch}
               variant="ghost"
               size="icon"
-              className="h-10 w-10 rounded-md text-muted-foreground hover:text-foreground"
+              className="h-10 w-10 rounded-md text-muted-foreground hover:text-foreground hover:bg-transparent"
               aria-label={searchOpen ? "Close search" : "Search trips"}
             >
               <Search className="w-4 h-4" />
@@ -191,7 +191,7 @@ export function TripsContent() {
                 placeholder="Search by name or destination..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                className="h-12 pl-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
+                className="h-12 pl-12 text-base border-border/50 bg-background/50 focus-visible:border-ring focus-visible:ring-ring rounded-md"
               />
             </div>
           </div>

--- a/apps/web/src/app/(app)/trips/trips-content.tsx
+++ b/apps/web/src/app/(app)/trips/trips-content.tsx
@@ -244,9 +244,6 @@ export function TripsContent() {
               >
                 <h2 className="text-xl sm:text-2xl font-semibold text-foreground mb-4 font-playfair">
                   Current trips
-                  <span className="block text-xs font-normal text-muted-foreground mt-1">
-                    In progress
-                  </span>
                 </h2>
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
                   {currentTrips.map((trip, index) => (
@@ -264,9 +261,6 @@ export function TripsContent() {
               >
                 <h2 className="text-xl sm:text-2xl font-semibold text-foreground mb-4 font-playfair">
                   Upcoming trips
-                  <span className="block text-xs font-normal text-muted-foreground mt-1">
-                    Departures
-                  </span>
                 </h2>
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
                   {upcomingTrips.map((trip, index) => (
@@ -288,9 +282,6 @@ export function TripsContent() {
               >
                 <h2 className="text-xl sm:text-2xl font-semibold text-foreground mb-4 font-playfair">
                   Past trips
-                  <span className="block text-xs font-normal text-muted-foreground mt-1">
-                    Memories
-                  </span>
                 </h2>
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
                   {pastTrips.map((trip, index) => (

--- a/apps/web/src/app/(app)/trips/trips-content.tsx
+++ b/apps/web/src/app/(app)/trips/trips-content.tsx
@@ -158,7 +158,7 @@ export function TripsContent() {
           <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-muted-foreground" />
           <Input
             type="text"
-            placeholder="Search trips..."
+            placeholder="Search by name or destination..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             className="h-12 pl-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
@@ -204,13 +204,13 @@ export function TripsContent() {
             </div>
             <div className="relative max-w-md mx-auto">
               <p className="text-2xl text-accent mb-2 font-script">
-                No postcards yet...
+                No trips yet...
               </p>
               <h2 className="text-xl font-semibold text-foreground mb-2 font-playfair">
                 Your adventures await
               </h2>
               <p className="text-muted-foreground mb-6">
-                Start planning your next adventure by creating your first trip.
+                Invite friends, plan together, and keep everything in one place.
               </p>
               <Button
                 onClick={() => setCreateDialogOpen(true)}
@@ -244,7 +244,7 @@ export function TripsContent() {
               >
                 <h2 className="text-xl sm:text-2xl font-semibold text-foreground mb-4 font-playfair">
                   Current trips
-                  <span className="block text-xs font-normal text-muted-foreground font-accent tracking-wider uppercase mt-1">
+                  <span className="block text-xs font-normal text-muted-foreground mt-1">
                     In progress
                   </span>
                 </h2>
@@ -264,7 +264,7 @@ export function TripsContent() {
               >
                 <h2 className="text-xl sm:text-2xl font-semibold text-foreground mb-4 font-playfair">
                   Upcoming trips
-                  <span className="block text-xs font-normal text-muted-foreground font-accent tracking-wider uppercase mt-1">
+                  <span className="block text-xs font-normal text-muted-foreground mt-1">
                     Departures
                   </span>
                 </h2>
@@ -288,7 +288,7 @@ export function TripsContent() {
               >
                 <h2 className="text-xl sm:text-2xl font-semibold text-foreground mb-4 font-playfair">
                   Past trips
-                  <span className="block text-xs font-normal text-muted-foreground font-accent tracking-wider uppercase mt-1">
+                  <span className="block text-xs font-normal text-muted-foreground mt-1">
                     Memories
                   </span>
                 </h2>

--- a/apps/web/src/app/(app)/trips/trips-content.tsx
+++ b/apps/web/src/app/(app)/trips/trips-content.tsx
@@ -191,7 +191,7 @@ export function TripsContent() {
                 placeholder="Search by name or destination..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                className="h-12 pl-12 text-base border-border/50 bg-background/50 focus-visible:border-ring focus-visible:ring-ring rounded-md"
+                className="h-12 pl-12 text-base rounded-md"
               />
             </div>
           </div>

--- a/apps/web/src/app/(app)/trips/trips-content.tsx
+++ b/apps/web/src/app/(app)/trips/trips-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useEffect, useRef } from "react";
+import { useState, useMemo, useEffect, useRef, useCallback } from "react";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import { Plus, Search, AlertCircle, Loader2 } from "lucide-react";
 import { useTrips, type TripSummary } from "@/hooks/use-trips";
@@ -31,7 +31,10 @@ export function TripsContent() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
-  const [searchQuery, setSearchQuery] = useState(searchParams.get("q") ?? "");
+  const initialQuery = searchParams.get("q") ?? "";
+  const [searchQuery, setSearchQuery] = useState(initialQuery);
+  const [searchOpen, setSearchOpen] = useState(initialQuery.length > 0);
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const { ref: currentSectionRef, isRevealed: currentRevealed } =
     useScrollReveal();
   const { ref: upcomingSectionRef, isRevealed: upcomingRevealed } =
@@ -123,6 +126,17 @@ export function TripsContent() {
     return { currentTrips: current, upcomingTrips: upcoming, pastTrips: past };
   }, [filteredTrips]);
 
+  const toggleSearch = useCallback(() => {
+    setSearchOpen((prev) => {
+      if (prev) {
+        setSearchQuery("");
+      } else {
+        requestAnimationFrame(() => searchInputRef.current?.focus());
+      }
+      return !prev;
+    });
+  }, []);
+
   const tripCount = data?.pages[0]?.meta?.total ?? trips.length;
   const hasSearchQuery = searchQuery.trim().length > 0;
   const noResults = filteredTrips.length === 0 && hasSearchQuery;
@@ -143,26 +157,44 @@ export function TripsContent() {
               </p>
             )}
           </div>
-          <Button
-            onClick={() => setCreateDialogOpen(true)}
-            variant="outline"
-            className="h-10 px-4 rounded-md"
-          >
-            <Plus className="w-4 h-4" strokeWidth={2.5} />
-            New Trip
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              onClick={toggleSearch}
+              variant="ghost"
+              size="icon"
+              className="h-10 w-10 rounded-md text-muted-foreground hover:text-foreground"
+              aria-label={searchOpen ? "Close search" : "Search trips"}
+            >
+              <Search className="w-4 h-4" />
+            </Button>
+            <Button
+              onClick={() => setCreateDialogOpen(true)}
+              variant="outline"
+              className="h-10 px-4 rounded-md"
+            >
+              <Plus className="w-4 h-4" strokeWidth={2.5} />
+              New Trip
+            </Button>
+          </div>
         </header>
 
         {/* Search Bar */}
-        <div className="relative mb-8">
-          <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-muted-foreground" />
-          <Input
-            type="text"
-            placeholder="Search by name or destination..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="h-12 pl-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
-          />
+        <div
+          className={`grid transition-all duration-200 ease-out ${searchOpen ? "grid-rows-[1fr] opacity-100 mb-8" : "grid-rows-[0fr] opacity-0 mb-0"}`}
+        >
+          <div className="overflow-hidden">
+            <div className="relative">
+              <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-muted-foreground" />
+              <Input
+                ref={searchInputRef}
+                type="text"
+                placeholder="Search by name or destination..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="h-12 pl-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
+              />
+            </div>
+          </div>
         </div>
 
         {/* Loading State */}

--- a/apps/web/src/app/(app)/trips/trips-content.tsx
+++ b/apps/web/src/app/(app)/trips/trips-content.tsx
@@ -164,7 +164,7 @@ export function TripsContent() {
               size="icon"
               aria-label={searchOpen ? "Close search" : "Search trips"}
             >
-              <Search className="w-4 h-4" />
+              <Search />
             </Button>
             <Button
               onClick={() => setCreateDialogOpen(true)}

--- a/apps/web/src/app/(app)/trips/trips-content.tsx
+++ b/apps/web/src/app/(app)/trips/trips-content.tsx
@@ -160,9 +160,9 @@ export function TripsContent() {
           <div className="flex items-center gap-2">
             <Button
               onClick={toggleSearch}
-              variant="ghost"
+              variant="outline"
               size="icon"
-              className="h-10 w-10 rounded-md text-muted-foreground hover:text-foreground hover:bg-transparent"
+              className="h-10 w-10 rounded-md"
               aria-label={searchOpen ? "Close search" : "Search trips"}
             >
               <Search className="w-4 h-4" />

--- a/apps/web/src/app/(app)/trips/trips-content.tsx
+++ b/apps/web/src/app/(app)/trips/trips-content.tsx
@@ -162,7 +162,6 @@ export function TripsContent() {
               onClick={toggleSearch}
               variant="outline"
               size="icon"
-              className="h-10 w-10 rounded-md"
               aria-label={searchOpen ? "Close search" : "Search trips"}
             >
               <Search className="w-4 h-4" />
@@ -170,7 +169,6 @@ export function TripsContent() {
             <Button
               onClick={() => setCreateDialogOpen(true)}
               variant="outline"
-              className="h-10 px-4 rounded-md"
             >
               <Plus className="w-4 h-4" strokeWidth={2.5} />
               New Trip
@@ -220,7 +218,7 @@ export function TripsContent() {
               onClick={() => refetch()}
               disabled={isFetching}
               variant="gradient"
-              className="h-12 px-8 rounded-md disabled:opacity-50 disabled:cursor-not-allowed"
+              size="lg"
             >
               {isFetching && <Loader2 className="w-4 h-4 animate-spin mr-2" />}
               {isFetching ? "Loading..." : "Try again"}
@@ -247,7 +245,7 @@ export function TripsContent() {
               <Button
                 onClick={() => setCreateDialogOpen(true)}
                 variant="gradient"
-                className="h-12 px-8"
+                size="lg"
               >
                 <Plus className="w-5 h-5 mr-2" strokeWidth={2.5} />
                 Create your first trip

--- a/apps/web/src/app/(auth)/layout.tsx
+++ b/apps/web/src/app/(auth)/layout.tsx
@@ -1,27 +1,20 @@
 import type { ReactNode } from "react";
-import { PostmarkStamp } from "@/components/ui/postmark-stamp";
+import Link from "next/link";
 
 export default function AuthLayout({ children }: { children: ReactNode }) {
   return (
     <div className="relative min-h-screen w-full overflow-hidden bg-background linen-texture">
-      {/* Decorative postmark stamps */}
-      <div className="absolute inset-0" aria-hidden="true">
-        <div className="absolute top-12 right-12 hidden sm:block">
-          <PostmarkStamp date="EST. 2026" city="JOURNIFUL" size="lg" />
-        </div>
-        <div className="absolute bottom-16 left-16 hidden sm:block">
-          <PostmarkStamp date="PAR AVION" city="AIR MAIL" size="md" />
-        </div>
-      </div>
-
       <main
         id="main-content"
         className="relative z-10 flex min-h-screen flex-col items-center justify-center p-4"
       >
         {/* Journiful wordmark */}
-        <p className="mb-8 text-4xl font-bold tracking-tight text-foreground font-playfair">
+        <Link
+          href="/"
+          className="mb-8 font-display text-3xl font-bold tracking-tight text-foreground"
+        >
           Journiful
-        </p>
+        </Link>
 
         {children}
       </main>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -211,6 +211,17 @@
   }
 }
 
+/* Scroll-triggered reveal for landing page sections */
+@media (prefers-reduced-motion: no-preference) {
+  @supports (animation-timeline: view()) {
+    .scroll-reveal {
+      animation: revealUp 500ms ease-out both;
+      animation-timeline: view();
+      animation-range: entry 0% entry 30%;
+    }
+  }
+}
+
 @keyframes collapsible-down {
   from {
     height: 0;

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
   ),
   title: { default: "Journiful - Group Trip Planner", template: "%s | Journiful" },
   description:
-    "Plan group trips together. Coordinate itineraries, accommodations, and events with your travel companions in one place.",
+    "Journiful — memories & itineraries. Plan group trips together. Coordinate itineraries, accommodations, and events with your travel companions in one place.",
   keywords: [
     "group trip planner",
     "trip planning app",
@@ -35,13 +35,13 @@ export const metadata: Metadata = {
     siteName: "Journiful",
     title: "Journiful - Group Trip Planner",
     description:
-      "Plan group trips together. Coordinate itineraries, accommodations, and events with your travel companions in one place.",
+      "Journiful — memories & itineraries. Plan group trips together. Coordinate itineraries, accommodations, and events with your travel companions in one place.",
   },
   twitter: {
     card: "summary_large_image",
     title: "Journiful - Group Trip Planner",
     description:
-      "Plan group trips together. Coordinate itineraries, accommodations, and events with your travel companions in one place.",
+      "Journiful — memories & itineraries. Plan group trips together. Coordinate itineraries, accommodations, and events with your travel companions in one place.",
   },
   robots: { index: true, follow: true },
   appleWebApp: {

--- a/apps/web/src/app/opengraph-image.tsx
+++ b/apps/web/src/app/opengraph-image.tsx
@@ -57,6 +57,19 @@ export default async function OGImage() {
       {/* Tagline */}
       <div
         style={{
+          fontSize: 32,
+          fontFamily: "DM Sans",
+          color: "#a09080",
+          display: "flex",
+          marginBottom: 12,
+        }}
+      >
+        Memories & Itineraries
+      </div>
+
+      {/* Subtitle */}
+      <div
+        style={{
           fontSize: 28,
           fontFamily: "DM Sans",
           color: "#8c8173",

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -92,12 +92,9 @@ export default async function Home() {
           <h1 className="mb-4 max-w-2xl text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl font-playfair">
             Plan Group Trips Together
           </h1>
-          <p className="mb-3 max-w-lg text-center text-lg text-muted-foreground sm:text-xl">
+          <p className="mb-10 max-w-lg text-center text-lg text-muted-foreground sm:text-xl">
             The trip planning app that brings your travel group together.
             Coordinate everything in one place.
-          </p>
-          <p className="mb-10 text-xl text-accent font-script">
-            Wish you were here...
           </p>
           <Button
             variant="gradient"

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -73,14 +73,21 @@ export default async function Home() {
     <>
       <main className="flex min-h-screen flex-col bg-background linen-texture">
         {/* Header */}
-        <header className="flex items-center justify-between px-6 py-5 sm:px-10">
-          <span className="font-display text-xl font-bold tracking-tight">Journiful</span>
-          <Link
-            href="/login"
-            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-          >
-            Sign in
-          </Link>
+        <header className="sticky top-0 z-40 w-full bg-background border-b border-border linen-texture">
+          <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
+            <Link
+              href="/"
+              className="font-display text-xl font-bold tracking-tight"
+            >
+              Journiful
+            </Link>
+            <Link
+              href="/login"
+              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Sign in
+            </Link>
+          </div>
         </header>
 
         {/* Hero Section */}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -81,12 +81,9 @@ export default async function Home() {
             >
               Journiful
             </Link>
-            <Link
-              href="/login"
-              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-            >
-              Sign in
-            </Link>
+            <Button variant="outline" size="sm" asChild>
+              <Link href="/login">Sign in</Link>
+            </Button>
           </div>
         </header>
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -76,7 +76,7 @@ export default async function Home() {
           <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
             <Link
               href="/"
-              className="font-display text-xl font-bold tracking-tight"
+              className="font-display text-2xl font-bold tracking-tight"
             >
               Journiful
             </Link>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -33,7 +33,7 @@ const features = [
     icon: PartyPopper,
     title: "Event Planning",
     description:
-      "Create events with RSVP tracking so everyone knows what's happening and when.",
+      "Create events and schedule activities so everyone knows what's happening and when.",
   },
   {
     icon: Plane,

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -4,7 +4,6 @@ import { redirect } from "next/navigation";
 import Link from "next/link";
 import { Calendar, Building2, PartyPopper, Plane } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { PostmarkStamp } from "@/components/ui/postmark-stamp";
 import { JsonLd } from "@/components/json-ld";
 
 export const metadata: Metadata = {
@@ -89,10 +88,6 @@ export default async function Home() {
 
         {/* Hero Section */}
         <section className="relative flex flex-col items-center justify-center px-4 pt-12 pb-20 text-center sm:pt-20 sm:pb-28">
-          {/* Postmark decoration */}
-          <div className="absolute top-8 right-8 sm:top-12 sm:right-16 hidden sm:block">
-            <PostmarkStamp date="EST. 2026" city="JOURNIFUL" size="lg" />
-          </div>
           <h1 className="mb-4 max-w-2xl text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl font-playfair">
             Plan Group Trips Together
           </h1>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -78,10 +78,10 @@ export default async function Home() {
           <div className="absolute top-8 right-8 sm:top-12 sm:right-16 hidden sm:block">
             <PostmarkStamp date="EST. 2026" city="JOURNIFUL" size="lg" />
           </div>
-          <p className="font-script text-5xl sm:text-6xl lg:text-7xl text-foreground mb-2">
+          <p className="text-xs sm:text-sm tracking-widest uppercase text-muted-foreground mb-1">
             Journiful
           </p>
-          <p className="text-sm sm:text-base tracking-widest uppercase text-muted-foreground mb-8">
+          <p className="text-[10px] sm:text-xs tracking-widest uppercase text-muted-foreground/70 mb-8">
             Memories & Itineraries
           </p>
           <h1 className="mb-4 max-w-2xl text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl font-display">

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -72,18 +72,23 @@ export default async function Home() {
   return (
     <>
       <main className="flex min-h-screen flex-col bg-background linen-texture">
+        {/* Header */}
+        <header className="flex items-center justify-between px-6 py-5 sm:px-10">
+          <span className="font-script text-2xl text-foreground">Journiful</span>
+          <Link
+            href="/login"
+            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Sign in
+          </Link>
+        </header>
+
         {/* Hero Section */}
-        <section className="relative flex flex-col items-center justify-center px-4 pt-24 pb-20 text-center sm:pt-32 sm:pb-28">
+        <section className="relative flex flex-col items-center justify-center px-4 pt-12 pb-20 text-center sm:pt-20 sm:pb-28">
           {/* Postmark decoration */}
           <div className="absolute top-8 right-8 sm:top-12 sm:right-16 hidden sm:block">
             <PostmarkStamp date="EST. 2026" city="JOURNIFUL" size="lg" />
           </div>
-          <p className="text-xs sm:text-sm tracking-widest uppercase text-muted-foreground mb-1">
-            Journiful
-          </p>
-          <p className="text-[10px] sm:text-xs tracking-widest uppercase text-muted-foreground/70 mb-8">
-            Memories & Itineraries
-          </p>
           <h1 className="mb-4 max-w-2xl text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl font-display">
             Plan Group Trips Together
           </h1>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -88,17 +88,17 @@ export default async function Home() {
 
         {/* Hero Section */}
         <section className="relative flex flex-col items-center justify-center px-4 pt-12 pb-20 text-center sm:pt-20 sm:pb-28">
-          <h1 className="mb-4 max-w-2xl text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl font-playfair">
+          <h1 className="mb-4 max-w-2xl text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl font-playfair motion-safe:animate-[revealUp_600ms_ease-out_both]">
             Plan Group Trips Together
           </h1>
-          <p className="mb-10 max-w-lg text-center text-lg text-muted-foreground sm:text-xl">
+          <p className="mb-10 max-w-lg text-center text-lg text-muted-foreground sm:text-xl motion-safe:animate-[revealUp_600ms_ease-out_200ms_both]">
             The trip planning app that brings your travel group together.
             Coordinate everything in one place.
           </p>
           <Button
             variant="gradient"
             size="lg"
-            className="px-10 font-accent"
+            className="px-10 font-accent motion-safe:animate-[revealUp_600ms_ease-out_400ms_both]"
             asChild
           >
             <Link href="/login">Get started</Link>
@@ -108,14 +108,14 @@ export default async function Home() {
         {/* Features Section */}
         <section className="px-4 py-20 sm:py-28">
           <div className="mx-auto max-w-5xl">
-            <h2 className="mb-12 text-center text-3xl font-bold tracking-tight text-foreground sm:text-4xl font-playfair">
+            <h2 className="mb-12 text-center text-3xl font-bold tracking-tight text-foreground sm:text-4xl font-playfair scroll-reveal">
               Everything your group needs to plan the perfect trip
             </h2>
             <div className="grid gap-8 sm:grid-cols-2">
               {features.map((feature) => (
                 <div
                   key={feature.title}
-                  className="rounded-md border border-border bg-card p-6 linen-texture"
+                  className="rounded-md border border-border bg-card p-6 linen-texture scroll-reveal"
                 >
                   <feature.icon className="mb-3 h-6 w-6 text-accent" />
                   <h3 className="mb-2 text-lg font-semibold text-foreground font-accent">
@@ -133,12 +133,12 @@ export default async function Home() {
         {/* How It Works Section */}
         <section className="px-4 py-20 sm:py-28">
           <div className="mx-auto max-w-3xl">
-            <h2 className="mb-12 text-center text-3xl font-bold tracking-tight text-foreground sm:text-4xl font-playfair">
+            <h2 className="mb-12 text-center text-3xl font-bold tracking-tight text-foreground sm:text-4xl font-playfair scroll-reveal">
               How Journiful works
             </h2>
             <div className="grid gap-8 sm:grid-cols-3">
               {steps.map((step) => (
-                <div key={step.number} className="text-center">
+                <div key={step.number} className="text-center scroll-reveal">
                   <div className="mx-auto mb-4 flex h-10 w-10 items-center justify-center rounded-sm border-2 border-dashed border-accent text-sm font-bold text-accent font-accent">
                     {step.number}
                   </div>
@@ -155,7 +155,7 @@ export default async function Home() {
         </section>
 
         {/* Bottom CTA Section */}
-        <section className="flex flex-col items-center px-4 pt-12 pb-24 text-center sm:pb-32">
+        <section className="flex flex-col items-center px-4 pt-12 pb-24 text-center sm:pb-32 scroll-reveal">
           <h2 className="mb-6 text-2xl font-bold tracking-tight text-foreground sm:text-3xl font-playfair">
             Ready to plan your next adventure?
           </h2>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -81,7 +81,7 @@ export default async function Home() {
           <p className="font-script text-5xl sm:text-6xl lg:text-7xl text-foreground mb-2">
             Journiful
           </p>
-          <p className="font-script text-lg sm:text-xl text-muted-foreground mb-8">
+          <p className="text-sm sm:text-base tracking-widest uppercase text-muted-foreground mb-8">
             Memories & Itineraries
           </p>
           <h1 className="mb-4 max-w-2xl text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl font-display">

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -74,7 +74,7 @@ export default async function Home() {
       <main className="flex min-h-screen flex-col bg-background linen-texture">
         {/* Header */}
         <header className="flex items-center justify-between px-6 py-5 sm:px-10">
-          <span className="font-script text-2xl text-foreground">Journiful</span>
+          <span className="font-display text-xl font-bold tracking-tight">Journiful</span>
           <Link
             href="/login"
             className="text-sm text-muted-foreground hover:text-foreground transition-colors"

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -164,9 +164,6 @@ export default async function Home() {
 
         {/* Bottom CTA Section */}
         <section className="flex flex-col items-center px-4 pt-12 pb-24 text-center sm:pb-32">
-          <p className="mb-2 text-lg text-accent font-script">
-            Wish you were here?
-          </p>
           <h2 className="mb-6 text-2xl font-bold tracking-tight text-foreground sm:text-3xl font-playfair">
             Ready to plan your next adventure?
           </h2>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -89,7 +89,7 @@ export default async function Home() {
           <div className="absolute top-8 right-8 sm:top-12 sm:right-16 hidden sm:block">
             <PostmarkStamp date="EST. 2026" city="JOURNIFUL" size="lg" />
           </div>
-          <h1 className="mb-4 max-w-2xl text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl font-display">
+          <h1 className="mb-4 max-w-2xl text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl font-playfair">
             Plan Group Trips Together
           </h1>
           <p className="mb-3 max-w-lg text-center text-lg text-muted-foreground sm:text-xl">

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -10,7 +10,7 @@ import { JsonLd } from "@/components/json-ld";
 export const metadata: Metadata = {
   title: "Journiful - Group Trip Planner | Plan Travel Together",
   description:
-    "The group trip planner that makes collaborative travel planning easy. Coordinate itineraries, accommodations, events, and member logistics all in one place.",
+    "Journiful — memories & itineraries. The group trip planner that makes collaborative travel planning easy. Coordinate itineraries, accommodations, events, and member logistics all in one place.",
   alternates: { canonical: "/" },
 };
 
@@ -78,6 +78,12 @@ export default async function Home() {
           <div className="absolute top-8 right-8 sm:top-12 sm:right-16 hidden sm:block">
             <PostmarkStamp date="EST. 2026" city="JOURNIFUL" size="lg" />
           </div>
+          <p className="font-script text-5xl sm:text-6xl lg:text-7xl text-foreground mb-2">
+            Journiful
+          </p>
+          <p className="font-script text-lg sm:text-xl text-muted-foreground mb-8">
+            Memories & Itineraries
+          </p>
           <h1 className="mb-4 max-w-2xl text-4xl font-bold tracking-tight text-foreground sm:text-5xl lg:text-6xl font-display">
             Plan Group Trips Together
           </h1>

--- a/apps/web/src/components/app-header.tsx
+++ b/apps/web/src/components/app-header.tsx
@@ -84,7 +84,7 @@ export function AppHeader() {
                   <UserAvatar user={user} />
                 </Button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-48">
+              <DropdownMenuContent align="end" className="w-[calc(100vw-2rem)] sm:w-[380px]">
                 {user && (
                   <>
                     <DropdownMenuItem

--- a/apps/web/src/components/app-header.tsx
+++ b/apps/web/src/components/app-header.tsx
@@ -3,14 +3,13 @@
 import { useState } from "react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
-import { LogOut, Menu, Users } from "lucide-react";
+import { LogOut, Users } from "lucide-react";
 import { useAuth } from "@/app/providers/auth-provider";
 import { getInitials } from "@/lib/format";
 import { getUploadUrl } from "@/lib/api";
 import { supportsHover } from "@/lib/supports-hover";
 import { Button } from "@/components/ui/button";
 import { NotificationBell } from "@/components/notifications";
-import { MobileNav } from "@/components/mobile-nav";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   DropdownMenu,
@@ -54,32 +53,17 @@ function UserAvatar({
 export function AppHeader() {
   const { user, logout } = useAuth();
   const [profileDialogOpen, setProfileDialogOpen] = useState(false);
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   return (
     <>
       <header className="sticky top-0 z-40 w-full bg-background border-b border-border linen-texture">
         <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center gap-2">
-            {/* Mobile hamburger button */}
-            <Button
-              variant="ghost"
-              size="icon"
-              className="md:hidden"
-              aria-label="Open menu"
-              onClick={() => setMobileMenuOpen(true)}
-              data-testid="mobile-menu-button"
-            >
-              <Menu className="size-5" />
-            </Button>
-
-            <Link
-              href="/trips"
-              className="font-display text-xl font-bold tracking-tight"
-            >
-              Journiful
-            </Link>
-          </div>
+          <Link
+            href="/trips"
+            className="font-display text-xl font-bold tracking-tight"
+          >
+            Journiful
+          </Link>
 
           <div className="flex items-center gap-2">
             <NotificationBell />
@@ -90,7 +74,7 @@ export function AppHeader() {
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="hidden md:flex rounded-full"
+                  className="rounded-full"
                   aria-label="User menu"
                   onMouseEnter={
                     supportsHover ? preloadProfileDialog : undefined
@@ -137,15 +121,6 @@ export function AppHeader() {
           </div>
         </div>
       </header>
-
-      {/* Mobile navigation sheet */}
-      <MobileNav
-        open={mobileMenuOpen}
-        onOpenChange={setMobileMenuOpen}
-        user={user}
-        onLogout={logout}
-        onProfileOpen={() => setProfileDialogOpen(true)}
-      />
 
       <ProfileDialog
         open={profileDialogOpen}

--- a/apps/web/src/components/app-header.tsx
+++ b/apps/web/src/components/app-header.tsx
@@ -73,7 +73,7 @@ export function AppHeader() {
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="rounded-full"
+                  className="rounded-full hover:bg-transparent text-muted-foreground hover:text-foreground"
                   aria-label="User menu"
                   onMouseEnter={
                     supportsHover ? preloadProfileDialog : undefined

--- a/apps/web/src/components/app-header.tsx
+++ b/apps/web/src/components/app-header.tsx
@@ -11,15 +11,13 @@ import { supportsHover } from "@/lib/supports-hover";
 import { Button } from "@/components/ui/button";
 import { NotificationBell } from "@/components/notifications";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Separator } from "@/components/ui/separator";
 import {
-  Sheet,
-  SheetBody,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle,
-} from "@/components/ui/sheet";
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 const ProfileDialog = dynamic(() =>
   import("@/components/profile/profile-dialog").then((mod) => ({
@@ -55,7 +53,6 @@ function UserAvatar({
 export function AppHeader() {
   const { user, logout } = useAuth();
   const [profileDialogOpen, setProfileDialogOpen] = useState(false);
-  const [menuOpen, setMenuOpen] = useState(false);
 
   return (
     <>
@@ -71,91 +68,58 @@ export function AppHeader() {
           <div className="flex items-center gap-2">
             <NotificationBell />
 
-            <Button
-              variant="ghost"
-              size="icon"
-              className="rounded-full"
-              aria-label="User menu"
-              onClick={() => setMenuOpen(true)}
-              onMouseEnter={
-                supportsHover ? preloadProfileDialog : undefined
-              }
-              onTouchStart={preloadProfileDialog}
-              onFocus={preloadProfileDialog}
-            >
-              <UserAvatar user={user} />
-            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="rounded-full"
+                  aria-label="User menu"
+                  onMouseEnter={
+                    supportsHover ? preloadProfileDialog : undefined
+                  }
+                  onTouchStart={preloadProfileDialog}
+                  onFocus={preloadProfileDialog}
+                >
+                  <UserAvatar user={user} />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-48">
+                {user && (
+                  <>
+                    <DropdownMenuItem
+                      onSelect={() => setProfileDialogOpen(true)}
+                      onMouseEnter={
+                        supportsHover ? preloadProfileDialog : undefined
+                      }
+                      onTouchStart={preloadProfileDialog}
+                      onFocus={preloadProfileDialog}
+                      className="flex flex-col items-start gap-0"
+                      data-testid="profile-menu-item"
+                    >
+                      <p className="text-sm font-medium">{user.displayName}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {user.phoneNumber}
+                      </p>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem asChild data-testid="mutuals-menu-item">
+                      <Link href="/mutuals">
+                        <Users />
+                        My Mutuals
+                      </Link>
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                  </>
+                )}
+                <DropdownMenuItem onClick={logout}>
+                  <LogOut />
+                  Log out
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         </div>
       </header>
-
-      <Sheet open={menuOpen} onOpenChange={setMenuOpen}>
-        <SheetContent side="right" showCloseButton={true}>
-          <SheetHeader>
-            <SheetTitle className="sr-only">User menu</SheetTitle>
-            <SheetDescription className="sr-only">
-              Account and navigation options
-            </SheetDescription>
-          </SheetHeader>
-
-          <SheetBody>
-            {user && (
-              <div className="flex items-center gap-3 mb-4">
-                <UserAvatar user={user} size="default" />
-                <div className="min-w-0">
-                  <p className="text-sm font-medium truncate">
-                    {user.displayName}
-                  </p>
-                  <p className="text-xs text-muted-foreground truncate">
-                    {user.phoneNumber}
-                  </p>
-                </div>
-              </div>
-            )}
-
-            <Separator />
-
-            <nav className="flex flex-col gap-1 py-4">
-              <button
-                onClick={() => {
-                  setMenuOpen(false);
-                  setProfileDialogOpen(true);
-                }}
-                className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-foreground hover:bg-accent transition-colors cursor-pointer"
-                data-testid="profile-menu-item"
-              >
-                <UserAvatar user={user} size="sm" />
-                Profile
-              </button>
-              <Link
-                href="/mutuals"
-                onClick={() => setMenuOpen(false)}
-                className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-foreground hover:bg-accent transition-colors"
-                data-testid="mutuals-menu-item"
-              >
-                <Users className="size-5" />
-                My Mutuals
-              </Link>
-            </nav>
-
-            <Separator />
-
-            <div className="flex flex-col gap-1 py-4">
-              <button
-                onClick={() => {
-                  setMenuOpen(false);
-                  logout();
-                }}
-                className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-foreground hover:bg-accent transition-colors cursor-pointer"
-                data-testid="mobile-menu-logout-button"
-              >
-                <LogOut className="size-5" />
-                Log out
-              </button>
-            </div>
-          </SheetBody>
-        </SheetContent>
-      </Sheet>
 
       <ProfileDialog
         open={profileDialogOpen}

--- a/apps/web/src/components/app-header.tsx
+++ b/apps/web/src/components/app-header.tsx
@@ -11,13 +11,15 @@ import { supportsHover } from "@/lib/supports-hover";
 import { Button } from "@/components/ui/button";
 import { NotificationBell } from "@/components/notifications";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Separator } from "@/components/ui/separator";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+  Sheet,
+  SheetBody,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
 
 const ProfileDialog = dynamic(() =>
   import("@/components/profile/profile-dialog").then((mod) => ({
@@ -53,6 +55,7 @@ function UserAvatar({
 export function AppHeader() {
   const { user, logout } = useAuth();
   const [profileDialogOpen, setProfileDialogOpen] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
 
   return (
     <>
@@ -68,59 +71,91 @@ export function AppHeader() {
           <div className="flex items-center gap-2">
             <NotificationBell />
 
-            {/* Desktop dropdown menu */}
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="rounded-full"
-                  aria-label="User menu"
-                  onMouseEnter={
-                    supportsHover ? preloadProfileDialog : undefined
-                  }
-                  onTouchStart={preloadProfileDialog}
-                  onFocus={preloadProfileDialog}
-                >
-                  <UserAvatar user={user} />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-48">
-                {user && (
-                  <>
-                    <DropdownMenuItem
-                      onSelect={() => setProfileDialogOpen(true)}
-                      onMouseEnter={
-                        supportsHover ? preloadProfileDialog : undefined
-                      }
-                      onTouchStart={preloadProfileDialog}
-                      onFocus={preloadProfileDialog}
-                      className="flex flex-col items-start gap-0 font-accent"
-                      data-testid="profile-menu-item"
-                    >
-                      <p className="text-sm font-medium">{user.displayName}</p>
-                      <p className="text-xs text-muted-foreground">
-                        {user.phoneNumber}
-                      </p>
-                    </DropdownMenuItem>
-                    <DropdownMenuItem asChild data-testid="mutuals-menu-item">
-                      <Link href="/mutuals" className="font-accent">
-                        <Users />
-                        My Mutuals
-                      </Link>
-                    </DropdownMenuItem>
-                    <DropdownMenuSeparator />
-                  </>
-                )}
-                <DropdownMenuItem onClick={logout} className="font-accent">
-                  <LogOut />
-                  Log out
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="rounded-full"
+              aria-label="User menu"
+              onClick={() => setMenuOpen(true)}
+              onMouseEnter={
+                supportsHover ? preloadProfileDialog : undefined
+              }
+              onTouchStart={preloadProfileDialog}
+              onFocus={preloadProfileDialog}
+            >
+              <UserAvatar user={user} />
+            </Button>
           </div>
         </div>
       </header>
+
+      <Sheet open={menuOpen} onOpenChange={setMenuOpen}>
+        <SheetContent side="right" showCloseButton={true}>
+          <SheetHeader>
+            <SheetTitle className="sr-only">User menu</SheetTitle>
+            <SheetDescription className="sr-only">
+              Account and navigation options
+            </SheetDescription>
+          </SheetHeader>
+
+          <SheetBody>
+            {user && (
+              <div className="flex items-center gap-3 mb-4">
+                <UserAvatar user={user} size="default" />
+                <div className="min-w-0">
+                  <p className="text-sm font-medium truncate">
+                    {user.displayName}
+                  </p>
+                  <p className="text-xs text-muted-foreground truncate">
+                    {user.phoneNumber}
+                  </p>
+                </div>
+              </div>
+            )}
+
+            <Separator />
+
+            <nav className="flex flex-col gap-1 py-4">
+              <button
+                onClick={() => {
+                  setMenuOpen(false);
+                  setProfileDialogOpen(true);
+                }}
+                className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-foreground hover:bg-accent transition-colors cursor-pointer"
+                data-testid="profile-menu-item"
+              >
+                <UserAvatar user={user} size="sm" />
+                Profile
+              </button>
+              <Link
+                href="/mutuals"
+                onClick={() => setMenuOpen(false)}
+                className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-foreground hover:bg-accent transition-colors"
+                data-testid="mutuals-menu-item"
+              >
+                <Users className="size-5" />
+                My Mutuals
+              </Link>
+            </nav>
+
+            <Separator />
+
+            <div className="flex flex-col gap-1 py-4">
+              <button
+                onClick={() => {
+                  setMenuOpen(false);
+                  logout();
+                }}
+                className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-foreground hover:bg-accent transition-colors cursor-pointer"
+                data-testid="mobile-menu-logout-button"
+              >
+                <LogOut className="size-5" />
+                Log out
+              </button>
+            </div>
+          </SheetBody>
+        </SheetContent>
+      </Sheet>
 
       <ProfileDialog
         open={profileDialogOpen}

--- a/apps/web/src/components/notifications/notification-bell.tsx
+++ b/apps/web/src/components/notifications/notification-bell.tsx
@@ -65,7 +65,7 @@ export function NotificationBell() {
           <Button
             variant="ghost"
             size="icon"
-            className="relative rounded-full"
+            className="relative rounded-full hover:bg-transparent text-muted-foreground hover:text-foreground"
             aria-label={ariaLabel}
           >
             <Bell />

--- a/apps/web/src/components/notifications/notification-bell.tsx
+++ b/apps/web/src/components/notifications/notification-bell.tsx
@@ -65,7 +65,7 @@ export function NotificationBell() {
           <Button
             variant="ghost"
             size="icon"
-            className="relative rounded-lg"
+            className="relative rounded-full"
             aria-label={ariaLabel}
           >
             <Bell />

--- a/apps/web/src/components/trip/create-trip-dialog.tsx
+++ b/apps/web/src/components/trip/create-trip-dialog.tsx
@@ -414,7 +414,7 @@ export function CreateTripDialog({
                       type="button"
                       onClick={handleContinue}
                       variant="gradient"
-                      className="h-12 px-8 rounded-md"
+                      size="lg"
                     >
                       Continue
                     </Button>
@@ -499,7 +499,8 @@ export function CreateTripDialog({
                       variant="outline"
                       onClick={handleBack}
                       disabled={isPending}
-                      className="flex-1 h-12 rounded-md border-input"
+                      size="lg"
+                      className="flex-1"
                     >
                       Back
                     </Button>
@@ -507,7 +508,8 @@ export function CreateTripDialog({
                       type="submit"
                       disabled={isPending}
                       variant="gradient"
-                      className="flex-1 h-12 rounded-md disabled:opacity-50 disabled:cursor-not-allowed"
+                      size="lg"
+                      className="flex-1"
                     >
                       {isPending && (
                         <Loader2 className="w-4 h-4 animate-spin mr-2" />

--- a/apps/web/src/components/trip/edit-trip-dialog.tsx
+++ b/apps/web/src/components/trip/edit-trip-dialog.tsx
@@ -417,7 +417,7 @@ export function EditTripDialog({
                   type="submit"
                   disabled={isPending || isDeleting}
                   variant="gradient"
-                  className="h-12 px-8 rounded-md disabled:opacity-50 disabled:cursor-not-allowed"
+                  size="lg"
                 >
                   {isPending && (
                     <Loader2 className="w-4 h-4 animate-spin mr-2" />

--- a/apps/web/src/components/trip/invite-members-dialog.tsx
+++ b/apps/web/src/components/trip/invite-members-dialog.tsx
@@ -386,7 +386,7 @@ export function InviteMembersDialog({
                           onClick={handleAddPhone}
                           disabled={isPending}
                           variant="outline"
-                          className="h-12 px-4 rounded-md"
+                          size="lg"
                         >
                           <UserPlus className="w-5 h-5" />
                           Add
@@ -421,7 +421,8 @@ export function InviteMembersDialog({
                   variant="outline"
                   onClick={() => onOpenChange(false)}
                   disabled={isPending}
-                  className="flex-1 h-12 rounded-md border-input"
+                  size="lg"
+                  className="flex-1"
                 >
                   Cancel
                 </Button>
@@ -432,7 +433,8 @@ export function InviteMembersDialog({
                     (phoneNumbers.length === 0 && userIds.length === 0)
                   }
                   variant="gradient"
-                  className="flex-1 h-12 rounded-md disabled:opacity-50 disabled:cursor-not-allowed"
+                  size="lg"
+                  className="flex-1"
                 >
                   {isPending && (
                     <Loader2 className="w-4 h-4 animate-spin mr-2" />

--- a/apps/web/src/components/trip/members-list.tsx
+++ b/apps/web/src/components/trip/members-list.tsx
@@ -195,7 +195,7 @@ function MemberRow({
               className="text-muted-foreground"
               aria-label={`Actions for ${member.displayName}`}
             >
-              <EllipsisVertical className="w-4 h-4" />
+              <EllipsisVertical />
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
@@ -290,7 +290,7 @@ function PendingInvitationRow({
         disabled={isRevoking}
         aria-label={`Revoke invitation to ${invitation.inviteePhone}`}
       >
-        <X className="w-4 h-4" />
+        <X />
       </Button>
     </div>
   );

--- a/apps/web/src/components/trip/members-list.tsx
+++ b/apps/web/src/components/trip/members-list.tsx
@@ -368,7 +368,6 @@ export function MembersList({
               onClick={onInvite}
               variant="outline"
               size="sm"
-              className="h-10 px-4 rounded-md border-input hover:bg-secondary"
             >
               <UserPlus className="w-4 h-4 mr-2" />
               Invite members
@@ -511,7 +510,6 @@ export function MembersList({
             onClick={onInvite}
             variant="outline"
             size="sm"
-            className="h-10 px-4 rounded-md border-input hover:bg-secondary"
           >
             <UserPlus className="w-4 h-4 mr-2" />
             Invite

--- a/apps/web/src/components/trip/mobile/animated-hero.tsx
+++ b/apps/web/src/components/trip/mobile/animated-hero.tsx
@@ -14,6 +14,8 @@ const HERO_COMPACT = 80;
 interface AnimatedHeroProps {
   trip: TripDetailWithMeta;
   collapseProgress: number;
+  /** When true, skip CSS transitions (used for scroll-driven collapse). */
+  disableTransition?: boolean;
   isOrganizer: boolean;
   onCustomize: () => void;
 }
@@ -21,6 +23,7 @@ interface AnimatedHeroProps {
 export function AnimatedHero({
   trip,
   collapseProgress,
+  disableTransition,
   isOrganizer,
   onCustomize,
 }: AnimatedHeroProps) {
@@ -43,12 +46,12 @@ export function AnimatedHero({
 
   return (
     <div
-      className="relative w-full overflow-hidden shrink-0 transition-[height] duration-300 ease-out"
+      className={`relative w-full overflow-hidden shrink-0${disableTransition ? "" : " transition-[height] duration-300 ease-out"}`}
       style={{ height: `${heroHeight}px` }}
     >
       {/* Full-height inner that slides upward as container shrinks */}
       <div
-        className="relative w-full transition-transform duration-300 ease-out"
+        className={`relative w-full${disableTransition ? "" : " transition-transform duration-300 ease-out"}`}
         style={{
           height: `${HERO_FULL}px`,
           transform: `translateY(${translateY}px)`,

--- a/apps/web/src/components/trip/mobile/icon-strip.tsx
+++ b/apps/web/src/components/trip/mobile/icon-strip.tsx
@@ -26,15 +26,15 @@ export function IconStrip({ activeIndex, onIconClick }: IconStripProps) {
             onClick={() => onIconClick(index)}
             aria-label={label}
             aria-current={isActive ? "true" : undefined}
-            className={`flex items-center justify-center w-10 h-10 transition-all ${
+            className={`flex items-center justify-center w-10 h-10 transition-colors ${
               isActive
-                ? "text-primary scale-110"
+                ? "text-primary"
                 : "text-foreground/50"
             }`}
           >
             <Icon
               className="w-5 h-5"
-              strokeWidth={isActive ? 2.5 : 2}
+              strokeWidth={isActive ? 2 : 1.5}
             />
           </button>
         );

--- a/apps/web/src/components/trip/mobile/mobile-trip-layout.tsx
+++ b/apps/web/src/components/trip/mobile/mobile-trip-layout.tsx
@@ -102,9 +102,14 @@ export function MobileTripLayout({
 
   const swiperRef = useRef<MobileTripSwiperRef>(null);
 
-  // Hero collapse: 0 on Info panel, 1 on all other panels
-  // CSS transition handles the smooth animation
-  const collapseT = activeIndex === 0 ? 0 : 1;
+  // Hero collapse: scroll-driven on Info panel, fully collapsed on other panels
+  const [infoScrollCollapse, setInfoScrollCollapse] = useState(0);
+
+  const handleInfoScroll = useCallback((scrollTop: number) => {
+    setInfoScrollCollapse(Math.min(1, scrollTop / 120));
+  }, []);
+
+  const collapseT = activeIndex === 0 ? infoScrollCollapse : 1;
 
   // Scroll itinerary to today's date when switching to itinerary panel
   useEffect(() => {
@@ -139,6 +144,7 @@ export function MobileTripLayout({
         <AnimatedHero
           trip={trip}
           collapseProgress={collapseT}
+          disableTransition={activeIndex === 0}
           isOrganizer={isOrganizer}
           onCustomize={() => setIsCustomizeOpen(true)}
         />
@@ -163,6 +169,7 @@ export function MobileTripLayout({
               onOpenSettings={() => setIsSettingsOpen(true)}
               onOpenMembers={() => setIsMembersOpen(true)}
               onNavigateToItinerary={handleNavigateToItinerary}
+              onScroll={handleInfoScroll}
             />
             <ItineraryPanel
               tripId={tripId}

--- a/apps/web/src/components/trip/mobile/panels/info-panel.tsx
+++ b/apps/web/src/components/trip/mobile/panels/info-panel.tsx
@@ -40,6 +40,7 @@ interface InfoPanelProps {
   onOpenSettings: () => void;
   onOpenMembers: () => void;
   onNavigateToItinerary: () => void;
+  onScroll?: (scrollTop: number) => void;
 }
 
 export function InfoPanel({
@@ -55,13 +56,17 @@ export function InfoPanel({
   onOpenSettings,
   onOpenMembers,
   onNavigateToItinerary,
+  onScroll,
 }: InfoPanelProps) {
   const preset = trip.themeId
     ? (THEME_PRESETS.find((p) => p.id === trip.themeId) ?? null)
     : null;
 
   return (
-    <div className="px-4 pt-8 pb-2">
+    <div
+      className="px-4 pt-8 pb-2 h-full overflow-y-auto"
+      onScroll={onScroll ? (e) => onScroll(e.currentTarget.scrollTop) : undefined}
+    >
       <div className="mb-8">
         {/* RSVP + action icons */}
         <div className="flex items-center mb-6">

--- a/apps/web/tests/e2e/helpers/auth.ts
+++ b/apps/web/tests/e2e/helpers/auth.ts
@@ -136,19 +136,10 @@ export async function authenticateViaAPIWithPhone(
   await page.waitForURL("**/trips", { timeout: NAVIGATION_TIMEOUT });
   // Ensure page is fully interactive — wait for client-rendered navigation
   // which confirms React hydration and auth context are complete.
-  // On mobile viewports (< 768px / md breakpoint), the desktop "User menu"
-  // button is hidden and the hamburger menu button is shown instead.
-  const viewportSize = page.viewportSize();
-  const isMobile = viewportSize ? viewportSize.width < 768 : false;
-  if (isMobile) {
-    await page
-      .getByRole("button", { name: "Open menu" })
-      .waitFor({ timeout: ELEMENT_TIMEOUT });
-  } else {
-    await page
-      .getByRole("button", { name: "User menu" })
-      .waitFor({ timeout: ELEMENT_TIMEOUT });
-  }
+  // The "User menu" avatar button is visible on all viewport sizes.
+  await page
+    .getByRole("button", { name: "User menu" })
+    .waitFor({ timeout: ELEMENT_TIMEOUT });
 }
 
 /**

--- a/apps/web/tests/e2e/helpers/pages/profile.page.ts
+++ b/apps/web/tests/e2e/helpers/pages/profile.page.ts
@@ -39,28 +39,18 @@ export class ProfilePage {
     await this.openDialog();
   }
 
-  /** Returns true if the mobile hamburger menu is visible (small viewport). */
-  private async isMobileViewport(): Promise<boolean> {
-    return this.page.getByRole("button", { name: "Open menu" }).isVisible();
-  }
-
-  /** Open the profile dialog from the header dropdown or mobile nav (adapts to viewport) */
+  /** Open the profile dialog from the header dropdown */
   async openDialog() {
     await this.page.waitForLoadState("networkidle");
-    if (await this.isMobileViewport()) {
-      await this.page.getByRole("button", { name: "Open menu" }).click();
-      await this.page.getByTestId("mobile-menu-profile-button").click();
-    } else {
-      const userMenuBtn = this.page.getByRole("button", {
-        name: "User menu",
-      });
-      await userMenuBtn.waitFor({ state: "visible", timeout: ELEMENT_TIMEOUT });
-      await userMenuBtn.click();
-      await this.page
-        .getByTestId("profile-menu-item")
-        .waitFor({ state: "visible", timeout: ELEMENT_TIMEOUT });
-      await this.page.getByTestId("profile-menu-item").click();
-    }
+    const userMenuBtn = this.page.getByRole("button", {
+      name: "User menu",
+    });
+    await userMenuBtn.waitFor({ state: "visible", timeout: ELEMENT_TIMEOUT });
+    await userMenuBtn.click();
+    await this.page
+      .getByTestId("profile-menu-item")
+      .waitFor({ state: "visible", timeout: ELEMENT_TIMEOUT });
+    await this.page.getByTestId("profile-menu-item").click();
     await this.heading.waitFor({ state: "visible", timeout: ELEMENT_TIMEOUT });
   }
 }

--- a/apps/web/tests/e2e/helpers/pages/trips.page.ts
+++ b/apps/web/tests/e2e/helpers/pages/trips.page.ts
@@ -6,14 +6,11 @@ export class TripsPage {
   readonly heading: Locator;
   readonly createTripButton: Locator;
   readonly userMenuButton: Locator;
-  readonly mobileMenuButton: Locator;
   readonly emptyStateHeading: Locator;
   readonly emptyStateCreateButton: Locator;
   readonly upcomingTripsHeading: Locator;
   readonly logoutItem: Locator;
-  readonly mobileLogoutButton: Locator;
   readonly profileItem: Locator;
-  readonly mobileProfileButton: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -22,7 +19,6 @@ export class TripsPage {
       name: "New Trip",
     });
     this.userMenuButton = page.getByRole("button", { name: "User menu" });
-    this.mobileMenuButton = page.getByRole("button", { name: "Open menu" });
     this.emptyStateHeading = page.getByRole("heading", {
       name: "Your adventures await",
     });
@@ -33,54 +29,28 @@ export class TripsPage {
       name: "Upcoming trips",
     });
     this.logoutItem = page.getByRole("menuitem", { name: "Log out" });
-    this.mobileLogoutButton = page.getByTestId("mobile-menu-logout-button");
     this.profileItem = page.getByTestId("profile-menu-item");
-    this.mobileProfileButton = page.getByTestId("mobile-menu-profile-button");
   }
 
   async goto() {
     await this.page.goto("/trips");
   }
 
-  /** Returns true if the mobile hamburger menu is visible (small viewport). */
-  private async isMobileViewport(): Promise<boolean> {
-    return this.mobileMenuButton.isVisible();
-  }
-
   async openUserMenu() {
-    if (await this.isMobileViewport()) {
-      // Retry click — on mobile WebKit the Sheet can fail to open on first click
-      for (let attempt = 0; attempt < 3; attempt++) {
-        await this.mobileMenuButton.click();
-        const opened = await this.mobileLogoutButton
-          .waitFor({ state: "visible", timeout: RETRY_INTERVAL })
-          .then(() => true)
-          .catch(() => false);
-        if (opened) return;
-      }
-    } else {
-      // Radix DropdownMenu can sometimes fail to stay open on the first click
-      // due to pointer event timing in Playwright. Retry if menu doesn't appear.
-      for (let attempt = 0; attempt < 3; attempt++) {
-        await this.userMenuButton.click();
-        const opened = await this.logoutItem
-          .waitFor({ state: "visible", timeout: RETRY_INTERVAL })
-          .then(() => true)
-          .catch(() => false);
-        if (opened) return;
-      }
+    // Radix DropdownMenu can sometimes fail to stay open on the first click
+    // due to pointer event timing in Playwright. Retry if menu doesn't appear.
+    for (let attempt = 0; attempt < 3; attempt++) {
+      await this.userMenuButton.click();
+      const opened = await this.logoutItem
+        .waitFor({ state: "visible", timeout: RETRY_INTERVAL })
+        .then(() => true)
+        .catch(() => false);
+      if (opened) return;
     }
   }
 
   async logout() {
     await this.openUserMenu();
-    // After openUserMenu(), check which logout element is visible.
-    // Don't re-check isMobileViewport() — the hamburger button is hidden
-    // behind the Sheet overlay once the mobile menu is open.
-    if (await this.mobileLogoutButton.isVisible()) {
-      await this.mobileLogoutButton.click();
-    } else {
-      await this.logoutItem.click();
-    }
+    await this.logoutItem.click();
   }
 }

--- a/apps/web/tests/e2e/profile-journey.spec.ts
+++ b/apps/web/tests/e2e/profile-journey.spec.ts
@@ -77,13 +77,8 @@ test.describe("Profile Journey", () => {
 
       await test.step("navigate to profile from header menu", async () => {
         await trips.openUserMenu();
-        // After openUserMenu(), check the actual menu content (not the hamburger button,
-        // which may be hidden behind the Sheet overlay on mobile)
-        const profileButton = (await trips.mobileProfileButton.isVisible())
-          ? trips.mobileProfileButton
-          : trips.profileItem;
-        await expect(profileButton).toBeVisible({ timeout: ELEMENT_TIMEOUT });
-        await profileButton.click();
+        await expect(trips.profileItem).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+        await trips.profileItem.click();
         await expect(profile.heading).toBeVisible({ timeout: ELEMENT_TIMEOUT });
       });
 


### PR DESCRIPTION
## Summary

- **Landing page**: Add sticky header with Journiful wordmark + Sign In button, clean up hero (Playfair Display h1, remove stamps/tagline clutter), add scroll-triggered section reveals, fix feature card copy
- **Dashboard**: Hide search bar behind toggle, remove redundant section subtitles, update empty state and placeholder text
- **Button consistency**: Standardize sizing across trip pages and dialogs — use `size="lg"` instead of manual `h-12 px-8`, remove redundant className overrides, convert plain `<button>` elements to Button component
- **Nav consistency**: Remove hamburger menu (avatar dropdown works on all sizes), match notification bell and avatar button shapes, match popover widths
- **Mobile**: Hero collapses on scroll in Info panel, normalize icon strip visual weight
- **Auth**: Remove stamps, use Bungee Shade wordmark matching app nav
- **Font hierarchy**: Bungee Shade for brand wordmark only, Playfair Display for headings, Plus Jakarta Sans for body

## Test plan

- [ ] Landing page renders clean hero with scroll animations
- [ ] Trips dashboard search toggle works (open/close, auto-focus, URL persistence)
- [ ] Button sizes consistent across trip detail, create/edit/invite dialogs
- [ ] Mobile trip hero collapses on scroll, expands on scroll-to-top
- [ ] Nav bell and avatar dropdowns match in width and alignment
- [ ] Auth pages show Bungee Shade wordmark, no stamps
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)