### PR TITLE
Add flight number lookup and info panel improvements

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -53,3 +53,7 @@ UPLOAD_DIR=uploads
 MAX_FILE_SIZE=5242880
 # Comma-separated list of allowed MIME types for uploads (must start with 'image/')
 ALLOWED_MIME_TYPES=image/jpeg,image/png,image/webp
+
+# AeroDataBox Flight Lookup (optional -- feature hidden if not set)
+# Sign up at https://rapidapi.com/aedbx-aedbx/api/aerodatabox (free Basic plan)
+# AERODATABOX_API_KEY=your-api-key

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -37,6 +37,7 @@ import mutualsServicePlugin from "./plugins/mutuals-service.js";
 import calendarServicePlugin from "./plugins/calendar-service.js";
 import geocodingServicePlugin from "./plugins/geocoding-service.js";
 import weatherServicePlugin from "./plugins/weather-service.js";
+import flightServicePlugin from "./plugins/flight-service.js";
 import imageProcessingServicePlugin from "./plugins/image-processing-service.js";
 import photoServicePlugin from "./plugins/photo-service.js";
 import queueWorkersPlugin from "./queues/index.js";
@@ -58,6 +59,7 @@ import { mutualsRoutes } from "./routes/mutuals.routes.js";
 import { userRoutes } from "./routes/user.routes.js";
 import { calendarRoutes } from "./routes/calendar.routes.js";
 import { weatherRoutes } from "./routes/weather.routes.js";
+import { flightRoutes } from "./routes/flight.routes.js";
 import { photoRoutes } from "./routes/photo.routes.js";
 
 // Config
@@ -214,6 +216,7 @@ export async function buildApp(
   await app.register(messageServicePlugin);
   await app.register(calendarServicePlugin);
   await app.register(weatherServicePlugin);
+  await app.register(flightServicePlugin);
   await app.register(imageProcessingServicePlugin);
   await app.register(photoServicePlugin);
   await app.register(queueWorkersPlugin);
@@ -240,6 +243,7 @@ export async function buildApp(
   await app.register(userRoutes, { prefix: "/api/users" });
   await app.register(calendarRoutes, { prefix: "/api" });
   await app.register(weatherRoutes, { prefix: "/api" });
+  await app.register(flightRoutes, { prefix: "/api" });
   await app.register(photoRoutes, { prefix: "/api/trips/:id/photos" });
 
   // Not-found handler for unmatched routes

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -86,6 +86,9 @@ const envSchema = z.object({
     .transform(Number)
     .refine((n) => n > 0, "MAX_FILE_SIZE must be positive")
     .default(5242880),
+  // AeroDataBox Flight Lookup (optional)
+  AERODATABOX_API_KEY: z.string().default(""),
+
   ALLOWED_MIME_TYPES: z
     .string()
     .transform((val) => val.split(",").map((type) => type.trim()))

--- a/apps/api/src/controllers/flight.controller.ts
+++ b/apps/api/src/controllers/flight.controller.ts
@@ -1,0 +1,38 @@
+import type { FastifyRequest, FastifyReply } from "fastify";
+import type { FlightLookupRequest } from "@journiful/shared/types";
+
+export const flightController = {
+  async lookup(
+    request: FastifyRequest<{ Body: FlightLookupRequest }>,
+    reply: FastifyReply,
+  ) {
+    const { flightNumber, date } = request.body;
+
+    try {
+      const result = await request.server.flightService.lookupFlight(
+        flightNumber,
+        date,
+      );
+      return reply.send({ success: true, ...result });
+    } catch (error) {
+      if (error && typeof error === "object" && "statusCode" in error) {
+        throw error;
+      }
+
+      request.log.error(
+        { err: error, flightNumber, date },
+        "Failed to look up flight",
+      );
+
+      const message =
+        error instanceof Error ? error.message : "Flight lookup failed";
+      return reply.status(500).send({
+        success: false,
+        error: {
+          code: "FLIGHT_LOOKUP_ERROR",
+          message,
+        },
+      });
+    }
+  },
+};

--- a/apps/api/src/db/migrations/0024_wandering_vapor.sql
+++ b/apps/api/src/db/migrations/0024_wandering_vapor.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "flight_cache" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"flight_number" text NOT NULL,
+	"date" date NOT NULL,
+	"response" jsonb,
+	"fetched_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "flight_cache_flight_number_date_unique" UNIQUE("flight_number","date")
+);
+--> statement-breakpoint
+ALTER TABLE "member_travel" ADD COLUMN "flight_number" text;

--- a/apps/api/src/db/migrations/meta/0024_snapshot.json
+++ b/apps/api/src/db/migrations/meta/0024_snapshot.json
@@ -1,0 +1,2593 @@
+{
+  "id": "c4d2110b-269d-41ee-843d-fccb75a855a6",
+  "prevId": "95e15ca0-6bc0-4d6f-8af8-9dcfe01ea192",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accommodations": {
+      "name": "accommodations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "check_in": {
+          "name": "check_in",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_out": {
+          "name": "check_out",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "links": {
+          "name": "links",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accommodations_trip_id_idx": {
+          "name": "accommodations_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_created_by_idx": {
+          "name": "accommodations_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_check_in_idx": {
+          "name": "accommodations_check_in_idx",
+          "columns": [
+            {
+              "expression": "check_in",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_deleted_at_idx": {
+          "name": "accommodations_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_trip_id_deleted_at_idx": {
+          "name": "accommodations_trip_id_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_trip_id_not_deleted_idx": {
+          "name": "accommodations_trip_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accommodations\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accommodations_trip_id_trips_id_fk": {
+          "name": "accommodations_trip_id_trips_id_fk",
+          "tableFrom": "accommodations",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accommodations_created_by_users_id_fk": {
+          "name": "accommodations_created_by_users_id_fk",
+          "tableFrom": "accommodations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "accommodations_deleted_by_users_id_fk": {
+          "name": "accommodations_deleted_by_users_id_fk",
+          "tableFrom": "accommodations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_attempts": {
+      "name": "auth_attempts",
+      "schema": "",
+      "columns": {
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_failed_at": {
+          "name": "last_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blacklisted_tokens": {
+      "name": "blacklisted_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "jti": {
+          "name": "jti",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blacklisted_tokens_expires_at_idx": {
+          "name": "blacklisted_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blacklisted_tokens_user_id_users_id_fk": {
+          "name": "blacklisted_tokens_user_id_users_id_fk",
+          "tableFrom": "blacklisted_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "blacklisted_tokens_jti_unique": {
+          "name": "blacklisted_tokens_jti_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "jti"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meetup_location": {
+          "name": "meetup_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meetup_time": {
+          "name": "meetup_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_day": {
+          "name": "all_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_optional": {
+          "name": "is_optional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "links": {
+          "name": "links",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_trip_id_idx": {
+          "name": "events_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_created_by_idx": {
+          "name": "events_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_start_time_idx": {
+          "name": "events_start_time_idx",
+          "columns": [
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_deleted_at_idx": {
+          "name": "events_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_trip_id_deleted_at_idx": {
+          "name": "events_trip_id_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_trip_id_not_deleted_idx": {
+          "name": "events_trip_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_trip_id_trips_id_fk": {
+          "name": "events_trip_id_trips_id_fk",
+          "tableFrom": "events",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_created_by_users_id_fk": {
+          "name": "events_created_by_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_deleted_by_users_id_fk": {
+          "name": "events_deleted_by_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flight_cache": {
+      "name": "flight_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "flight_number": {
+          "name": "flight_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "flight_cache_flight_number_date_unique": {
+          "name": "flight_cache_flight_number_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "flight_number",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_phone": {
+          "name": "invitee_phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitations_trip_id_idx": {
+          "name": "invitations_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_invitee_phone_idx": {
+          "name": "invitations_invitee_phone_idx",
+          "columns": [
+            {
+              "expression": "invitee_phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_trip_id_trips_id_fk": {
+          "name": "invitations_trip_id_trips_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_id_users_id_fk": {
+          "name": "invitations_inviter_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitations_trip_phone_unique": {
+          "name": "invitations_trip_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trip_id",
+            "invitee_phone"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member_travel": {
+      "name": "member_travel",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "travel_type": {
+          "name": "travel_type",
+          "type": "member_travel_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flight_number": {
+          "name": "flight_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_travel_trip_id_idx": {
+          "name": "member_travel_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_member_id_idx": {
+          "name": "member_travel_member_id_idx",
+          "columns": [
+            {
+              "expression": "member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_time_idx": {
+          "name": "member_travel_time_idx",
+          "columns": [
+            {
+              "expression": "time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_deleted_at_idx": {
+          "name": "member_travel_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_member_id_deleted_at_idx": {
+          "name": "member_travel_member_id_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_trip_id_deleted_at_idx": {
+          "name": "member_travel_trip_id_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_trip_id_not_deleted_idx": {
+          "name": "member_travel_trip_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"member_travel\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_travel_trip_id_trips_id_fk": {
+          "name": "member_travel_trip_id_trips_id_fk",
+          "tableFrom": "member_travel",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_travel_member_id_members_id_fk": {
+          "name": "member_travel_member_id_members_id_fk",
+          "tableFrom": "member_travel",
+          "tableTo": "members",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_travel_deleted_by_users_id_fk": {
+          "name": "member_travel_deleted_by_users_id_fk",
+          "tableFrom": "member_travel",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "rsvp_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'no_response'"
+        },
+        "is_organizer": {
+          "name": "is_organizer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "share_phone": {
+          "name": "share_phone",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "calendar_excluded": {
+          "name": "calendar_excluded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "members_trip_id_idx": {
+          "name": "members_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "members_user_id_idx": {
+          "name": "members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "members_trip_id_is_organizer_idx": {
+          "name": "members_trip_id_is_organizer_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_organizer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "members_trip_id_trips_id_fk": {
+          "name": "members_trip_id_trips_id_fk",
+          "tableFrom": "members",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "members_user_id_users_id_fk": {
+          "name": "members_user_id_users_id_fk",
+          "tableFrom": "members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "members_trip_user_unique": {
+          "name": "members_trip_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trip_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_reactions": {
+      "name": "message_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_reactions_message_id_idx": {
+          "name": "message_reactions_message_id_idx",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_reactions_user_id_idx": {
+          "name": "message_reactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_reactions_message_id_messages_id_fk": {
+          "name": "message_reactions_message_id_messages_id_fk",
+          "tableFrom": "message_reactions",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_reactions_user_id_users_id_fk": {
+          "name": "message_reactions_user_id_users_id_fk",
+          "tableFrom": "message_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "message_reactions_message_user_emoji_unique": {
+          "name": "message_reactions_message_user_emoji_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id",
+            "user_id",
+            "emoji"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_trip_id_created_at_idx": {
+          "name": "messages_trip_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_parent_id_idx": {
+          "name": "messages_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_author_id_idx": {
+          "name": "messages_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_trip_toplevel_idx": {
+          "name": "messages_trip_toplevel_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"messages\".\"parent_id\" IS NULL AND \"messages\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_trip_id_not_deleted_idx": {
+          "name": "messages_trip_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"messages\".\"deleted_at\" IS NULL AND \"messages\".\"parent_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_trip_id_trips_id_fk": {
+          "name": "messages_trip_id_trips_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_author_id_users_id_fk": {
+          "name": "messages_author_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_parent_id_messages_id_fk": {
+          "name": "messages_parent_id_messages_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_deleted_by_users_id_fk": {
+          "name": "messages_deleted_by_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.muted_members": {
+      "name": "muted_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted_by": {
+          "name": "muted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "muted_members_trip_id_trips_id_fk": {
+          "name": "muted_members_trip_id_trips_id_fk",
+          "tableFrom": "muted_members",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "muted_members_user_id_users_id_fk": {
+          "name": "muted_members_user_id_users_id_fk",
+          "tableFrom": "muted_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "muted_members_muted_by_users_id_fk": {
+          "name": "muted_members_muted_by_users_id_fk",
+          "tableFrom": "muted_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "muted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "muted_members_trip_user_unique": {
+          "name": "muted_members_trip_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trip_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daily_itinerary": {
+          "name": "daily_itinerary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "trip_messages": {
+          "name": "trip_messages",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_user_id_users_id_fk": {
+          "name": "notification_preferences_user_id_users_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_preferences_trip_id_trips_id_fk": {
+          "name": "notification_preferences_trip_id_trips_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_preferences_user_trip_unique": {
+          "name": "notification_preferences_user_trip_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "trip_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_created_at_idx": {
+          "name": "notifications_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_id_created_at_desc_idx": {
+          "name": "notifications_user_id_created_at_desc_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notifications\".\"read_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_trip_user_created_at_idx": {
+          "name": "notifications_trip_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_trip_id_trips_id_fk": {
+          "name": "notifications_trip_id_trips_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_entries": {
+      "name": "rate_limit_entries",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rate_limit_entries_expires_at_idx": {
+          "name": "rate_limit_entries_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sent_reminders": {
+      "name": "sent_reminders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sent_reminders_type_ref_idx": {
+          "name": "sent_reminders_type_ref_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sent_reminders_user_id_users_id_fk": {
+          "name": "sent_reminders_user_id_users_id_fk",
+          "tableFrom": "sent_reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sent_reminders_type_ref_user_unique": {
+          "name": "sent_reminders_type_ref_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "type",
+            "reference_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trip_photos": {
+      "name": "trip_photos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "photo_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trip_photos_trip_id_idx": {
+          "name": "trip_photos_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trip_photos_uploaded_by_idx": {
+          "name": "trip_photos_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trip_photos_trip_id_trips_id_fk": {
+          "name": "trip_photos_trip_id_trips_id_fk",
+          "tableFrom": "trip_photos",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_photos_uploaded_by_users_id_fk": {
+          "name": "trip_photos_uploaded_by_users_id_fk",
+          "tableFrom": "trip_photos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trips": {
+      "name": "trips",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_lat": {
+          "name": "destination_lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_lon": {
+          "name": "destination_lon",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_display_name": {
+          "name": "destination_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_timezone": {
+          "name": "preferred_timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_id": {
+          "name": "theme_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_font": {
+          "name": "theme_font",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allow_members_to_add_events": {
+          "name": "allow_members_to_add_events",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_all_members": {
+          "name": "show_all_members",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancelled": {
+          "name": "cancelled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trips_created_by_idx": {
+          "name": "trips_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trips_created_by_users_id_fk": {
+          "name": "trips_created_by_users_id_fk",
+          "tableFrom": "trips",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_photo_url": {
+          "name": "profile_photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handles": {
+          "name": "handles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature_unit": {
+          "name": "temperature_unit",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'celsius'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "calendar_token": {
+          "name": "calendar_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_phone_number_idx": {
+          "name": "users_phone_number_idx",
+          "columns": [
+            {
+              "expression": "phone_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_phone_number_unique": {
+          "name": "users_phone_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone_number"
+          ]
+        },
+        "users_calendar_token_unique": {
+          "name": "users_calendar_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "calendar_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weather_cache": {
+      "name": "weather_cache",
+      "schema": "",
+      "columns": {
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "weather_cache_trip_id_trips_id_fk": {
+          "name": "weather_cache_trip_id_trips_id_fk",
+          "tableFrom": "weather_cache",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.event_type": {
+      "name": "event_type",
+      "schema": "public",
+      "values": [
+        "travel",
+        "meal",
+        "activity"
+      ]
+    },
+    "public.invitation_status": {
+      "name": "invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "declined",
+        "failed"
+      ]
+    },
+    "public.member_travel_type": {
+      "name": "member_travel_type",
+      "schema": "public",
+      "values": [
+        "arrival",
+        "departure"
+      ]
+    },
+    "public.photo_status": {
+      "name": "photo_status",
+      "schema": "public",
+      "values": [
+        "processing",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.rsvp_status": {
+      "name": "rsvp_status",
+      "schema": "public",
+      "values": [
+        "going",
+        "not_going",
+        "maybe",
+        "no_response"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1773032304908,
       "tag": "0023_icy_genesis",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1774477047713,
+      "tag": "0024_wandering_vapor",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -292,6 +292,7 @@ export const memberTravel = pgTable(
     time: timestamp("time", { withTimezone: true }).notNull(),
     location: text("location"),
     details: text("details"),
+    flightNumber: text("flight_number"),
     deletedAt: timestamp("deleted_at", { withTimezone: true }),
     deletedBy: uuid("deleted_by").references(() => users.id),
     createdAt: timestamp("created_at", { withTimezone: true })
@@ -581,6 +582,29 @@ export const weatherCache = pgTable("weather_cache", {
 
 export type WeatherCache = typeof weatherCache.$inferSelect;
 export type NewWeatherCache = typeof weatherCache.$inferInsert;
+
+// Flight Cache
+export const flightCache = pgTable(
+  "flight_cache",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    flightNumber: text("flight_number").notNull(),
+    date: date("date").notNull(),
+    response: jsonb("response"),
+    fetchedAt: timestamp("fetched_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    unique("flight_cache_flight_number_date_unique").on(
+      table.flightNumber,
+      table.date,
+    ),
+  ],
+);
+
+export type FlightCache = typeof flightCache.$inferSelect;
+export type NewFlightCache = typeof flightCache.$inferInsert;
 
 // Trip Photos
 export const photoStatusEnum = pgEnum("photo_status", [

--- a/apps/api/src/plugins/flight-service.ts
+++ b/apps/api/src/plugins/flight-service.ts
@@ -1,0 +1,16 @@
+import fp from "fastify-plugin";
+import type { FastifyInstance } from "fastify";
+import { FlightService } from "@/services/flight.service.js";
+
+export default fp(
+  async function flightServicePlugin(fastify: FastifyInstance) {
+    const apiKey = fastify.config.AERODATABOX_API_KEY || null;
+    const flightService = new FlightService(fastify.db, apiKey);
+    fastify.decorate("flightService", flightService);
+  },
+  {
+    name: "flight-service",
+    fastify: "5.x",
+    dependencies: ["database", "config"],
+  },
+);

--- a/apps/api/src/routes/flight.routes.ts
+++ b/apps/api/src/routes/flight.routes.ts
@@ -1,0 +1,18 @@
+import type { FastifyInstance } from "fastify";
+import { flightController } from "@/controllers/flight.controller.js";
+import { authenticate } from "@/middleware/auth.middleware.js";
+import { writeRateLimitConfig } from "@/middleware/rate-limit.middleware.js";
+import { flightLookupRequestSchema } from "@journiful/shared/schemas";
+
+export async function flightRoutes(fastify: FastifyInstance) {
+  fastify.post<{ Body: { flightNumber: string; date: string } }>(
+    "/flights/lookup",
+    {
+      preHandler: [fastify.rateLimit(writeRateLimitConfig), authenticate],
+      schema: {
+        body: flightLookupRequestSchema,
+      },
+    },
+    flightController.lookup,
+  );
+}

--- a/apps/api/src/services/flight.service.ts
+++ b/apps/api/src/services/flight.service.ts
@@ -112,7 +112,7 @@ export class FlightService implements IFlightService {
         error instanceof DOMException ||
         (error instanceof Error && error.name === "AbortError")
       ) {
-        throw new Error("Flight lookup timed out");
+        throw new Error("Flight lookup timed out", { cause: error });
       }
       throw error;
     }

--- a/apps/api/src/services/flight.service.ts
+++ b/apps/api/src/services/flight.service.ts
@@ -7,7 +7,7 @@ import type {
 } from "@journiful/shared/types";
 
 const CACHE_MAX_AGE_MS = 3 * 60 * 60 * 1000; // 3 hours
-const FLIGHT_NUMBER_REGEX = /^[A-Z]{2,3}\d{1,4}$/i;
+const FLIGHT_NUMBER_REGEX = /^[A-Z\d]{2,3}\d{1,4}$/i;
 
 export interface IFlightService {
   lookupFlight(

--- a/apps/api/src/services/flight.service.ts
+++ b/apps/api/src/services/flight.service.ts
@@ -1,0 +1,200 @@
+import { eq, and, gt } from "drizzle-orm";
+import { flightCache } from "@/db/schema/index.js";
+import type { AppDatabase } from "@/types/index.js";
+import type {
+  FlightLookupResponse,
+  FlightLookupResult,
+} from "@journiful/shared/types";
+
+const CACHE_MAX_AGE_MS = 3 * 60 * 60 * 1000; // 3 hours
+const FLIGHT_NUMBER_REGEX = /^[A-Z]{2,3}\d{1,4}$/i;
+
+export interface IFlightService {
+  lookupFlight(
+    flightNumber: string,
+    date: string,
+  ): Promise<FlightLookupResponse>;
+}
+
+interface AeroDataBoxAirport {
+  icao?: string;
+  iata?: string | null;
+  name?: string;
+  shortName?: string;
+  municipalityName?: string;
+  countryCode?: string;
+  timeZone?: string;
+}
+
+interface AeroDataBoxScheduledTime {
+  utc?: string;
+  local?: string;
+}
+
+interface AeroDataBoxLeg {
+  airport?: AeroDataBoxAirport;
+  scheduledTime?: AeroDataBoxScheduledTime | null;
+  terminal?: string;
+}
+
+interface AeroDataBoxFlight {
+  departure?: AeroDataBoxLeg;
+  arrival?: AeroDataBoxLeg;
+  codeshareStatus?: string;
+  number?: string;
+  status?: string;
+  isCargo?: boolean;
+}
+
+export class FlightService implements IFlightService {
+  constructor(
+    private db: AppDatabase,
+    private apiKey: string | null,
+  ) {}
+
+  async lookupFlight(
+    flightNumber: string,
+    date: string,
+  ): Promise<FlightLookupResponse> {
+    // 1. Return unavailable if no API key
+    if (!this.apiKey) {
+      return { available: false };
+    }
+
+    // 2. Validate flight number format
+    if (!FLIGHT_NUMBER_REGEX.test(flightNumber)) {
+      throw new Error(
+        "Invalid flight number format. Expected airline code + number (e.g., UA123)",
+      );
+    }
+
+    // 3. Uppercase for cache key consistency
+    const normalizedFlightNumber = flightNumber.toUpperCase();
+
+    // 4. Check cache
+    const cachedRows = await this.db
+      .select()
+      .from(flightCache)
+      .where(
+        and(
+          eq(flightCache.flightNumber, normalizedFlightNumber),
+          eq(flightCache.date, date),
+          gt(flightCache.fetchedAt, new Date(Date.now() - CACHE_MAX_AGE_MS)),
+        ),
+      );
+
+    if (cachedRows.length > 0) {
+      const cached = cachedRows[0]!;
+      // 5. Negative cache (null response)
+      if (cached.response === null) {
+        return { available: true, flight: null };
+      }
+      // 6. Cache hit with response — normalize and return
+      const flight = this.normalizeResponse(
+        cached.response as AeroDataBoxFlight[],
+      );
+      return { available: true, flight };
+    }
+
+    // 7. Cache miss — call AeroDataBox API
+    let response: Response;
+    try {
+      const url = `https://aerodatabox.p.rapidapi.com/flights/number/${encodeURIComponent(normalizedFlightNumber)}/${date}`;
+      response = await fetch(url, {
+        headers: {
+          "x-rapidapi-key": this.apiKey,
+          "x-rapidapi-host": "aerodatabox.p.rapidapi.com",
+        },
+        signal: AbortSignal.timeout(5000),
+      });
+    } catch (error: unknown) {
+      if (
+        error instanceof DOMException ||
+        (error instanceof Error && error.name === "AbortError")
+      ) {
+        throw new Error("Flight lookup timed out");
+      }
+      throw error;
+    }
+
+    // 8. Handle 204 — flight not found
+    if (response.status === 204) {
+      await this.upsertCache(normalizedFlightNumber, date, null);
+      return { available: true, flight: null };
+    }
+
+    // 15. Handle non-200/204
+    if (!response.ok) {
+      const errorBody = await response
+        .json()
+        .catch(() => ({ message: "Unknown error" }));
+      throw new Error(
+        (errorBody as { message?: string }).message || "Unknown error",
+      );
+    }
+
+    // 9. Parse JSON array
+    const flights = (await response.json()) as AeroDataBoxFlight[];
+
+    // 14. Upsert full response into cache
+    await this.upsertCache(normalizedFlightNumber, date, flights);
+
+    // 10-13. Normalize and return
+    const flight = this.normalizeResponse(flights);
+    return { available: true, flight };
+  }
+
+  private normalizeResponse(
+    flights: AeroDataBoxFlight[],
+  ): FlightLookupResult | null {
+    if (!flights || flights.length === 0) {
+      return null;
+    }
+
+    // 10. Prefer entry with codeshareStatus === "IsOperator", fall back to [0]
+    const entry =
+      flights.find((f) => f.codeshareStatus === "IsOperator") || flights[0]!;
+
+    // 11. Check scheduledTime not null
+    const depTime = entry.departure?.scheduledTime?.local;
+    const arrTime = entry.arrival?.scheduledTime?.local;
+
+    if (!depTime || !arrTime) {
+      return null;
+    }
+
+    // 12-13. Build FlightLookupResult with normalized times
+    return {
+      departureAirport: {
+        iata: entry.departure?.airport?.iata ?? null,
+        name: entry.departure?.airport?.name ?? "Unknown",
+      },
+      departureTime: depTime.replace(" ", "T"),
+      arrivalAirport: {
+        iata: entry.arrival?.airport?.iata ?? null,
+        name: entry.arrival?.airport?.name ?? "Unknown",
+      },
+      arrivalTime: arrTime.replace(" ", "T"),
+    };
+  }
+
+  private async upsertCache(
+    flightNumber: string,
+    date: string,
+    response: AeroDataBoxFlight[] | null,
+  ): Promise<void> {
+    const now = new Date();
+    await this.db
+      .insert(flightCache)
+      .values({
+        flightNumber,
+        date,
+        response,
+        fetchedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [flightCache.flightNumber, flightCache.date],
+        set: { response, fetchedAt: now },
+      });
+  }
+}

--- a/apps/api/src/types/index.ts
+++ b/apps/api/src/types/index.ts
@@ -21,6 +21,7 @@ import type { IMutualsService } from "@/services/mutuals.service.js";
 import type { ICalendarService } from "@/services/calendar.service.js";
 import type { IGeocodingService } from "@/services/geocoding.service.js";
 import type { IWeatherService } from "@/services/weather.service.js";
+import type { IFlightService } from "@/services/flight.service.js";
 import type { IPhotoService } from "@/services/photo.service.js";
 import type { IImageProcessingService } from "@/services/image-processing.service.js";
 import type { IStorageService } from "@/services/storage.service.js";
@@ -74,6 +75,7 @@ declare module "fastify" {
     calendarService: ICalendarService;
     geocodingService: IGeocodingService;
     weatherService: IWeatherService;
+    flightService: IFlightService;
     photoService: IPhotoService;
     imageProcessingService: IImageProcessingService;
     storage: IStorageService;

--- a/apps/api/tests/integration/flight.routes.test.ts
+++ b/apps/api/tests/integration/flight.routes.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, afterEach, vi } from "vitest";
+import type { FastifyInstance } from "fastify";
+import { buildApp } from "../helpers.js";
+import { db } from "@/config/database.js";
+import { users } from "@/db/schema/index.js";
+import { generateUniquePhone } from "../test-utils.js";
+
+describe("Flight Routes", () => {
+  let app: FastifyInstance;
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (app) {
+      await app.close();
+    }
+  });
+
+  describe("POST /api/flights/lookup", () => {
+    it("returns flight data for valid request", async () => {
+      app = await buildApp();
+
+      // Create test user
+      const [testUser] = await db
+        .insert(users)
+        .values({
+          phoneNumber: generateUniquePhone(),
+          displayName: "Flight Test User",
+          timezone: "UTC",
+        })
+        .returning();
+
+      const token = app.jwt.sign({
+        sub: testUser.id,
+        name: testUser.displayName,
+      });
+
+      // Mock the flight service
+      const mockResult = {
+        available: true as const,
+        flight: {
+          departureAirport: { iata: "LHR", name: "London Heathrow" },
+          departureTime: "2026-03-26T08:00+00:00",
+          arrivalAirport: { iata: "EWR", name: "Newark Liberty" },
+          arrivalTime: "2026-03-26T12:20-04:00",
+        },
+      };
+      vi.spyOn(app.flightService, "lookupFlight").mockResolvedValueOnce(
+        mockResult,
+      );
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/flights/lookup",
+        cookies: { auth_token: token },
+        payload: { flightNumber: "UA123", date: "2026-03-26" },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.success).toBe(true);
+      expect(body.available).toBe(true);
+      expect(body.flight.departureAirport.iata).toBe("LHR");
+      expect(body.flight.arrivalTime).toBe("2026-03-26T12:20-04:00");
+    });
+
+    it("returns 401 when not authenticated", async () => {
+      app = await buildApp();
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/flights/lookup",
+        payload: { flightNumber: "UA123", date: "2026-03-26" },
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it("returns 400 for invalid body", async () => {
+      app = await buildApp();
+
+      const [testUser] = await db
+        .insert(users)
+        .values({
+          phoneNumber: generateUniquePhone(),
+          displayName: "Validation Test User",
+          timezone: "UTC",
+        })
+        .returning();
+
+      const token = app.jwt.sign({
+        sub: testUser.id,
+        name: testUser.displayName,
+      });
+
+      // Missing date field
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/flights/lookup",
+        cookies: { auth_token: token },
+        payload: { flightNumber: "UA123" },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+
+    it("returns 400 for invalid flight number format", async () => {
+      app = await buildApp();
+
+      const [testUser] = await db
+        .insert(users)
+        .values({
+          phoneNumber: generateUniquePhone(),
+          displayName: "Format Test User",
+          timezone: "UTC",
+        })
+        .returning();
+
+      const token = app.jwt.sign({
+        sub: testUser.id,
+        name: testUser.displayName,
+      });
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/flights/lookup",
+        cookies: { auth_token: token },
+        payload: { flightNumber: "INVALID!", date: "2026-03-26" },
+      });
+
+      expect(response.statusCode).toBe(400);
+    });
+  });
+});

--- a/apps/api/tests/unit/flight.service.test.ts
+++ b/apps/api/tests/unit/flight.service.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { FlightService } from "@/services/flight.service.js";
+import { db } from "@/config/database.js";
+import { flightCache } from "@/db/schema/index.js";
+import { eq, and } from "drizzle-orm";
+
+const TEST_API_KEY = "test-api-key";
+const TEST_FLIGHT = "UA123";
+const TEST_DATE = "2026-03-26";
+
+function mockAeroDataBoxResponse(overrides: Record<string, unknown> = {}) {
+  return [
+    {
+      departure: {
+        airport: { iata: "LHR", name: "London Heathrow" },
+        scheduledTime: { utc: "2026-03-26 08:00Z", local: "2026-03-26 08:00+00:00" },
+      },
+      arrival: {
+        airport: { iata: "EWR", name: "Newark Liberty" },
+        scheduledTime: { utc: "2026-03-26 16:20Z", local: "2026-03-26 12:20-04:00" },
+      },
+      codeshareStatus: "IsOperator",
+      number: "UA 123",
+      ...overrides,
+    },
+  ];
+}
+
+describe("FlightService", () => {
+  let service: FlightService;
+
+  const cleanup = async () => {
+    await db
+      .delete(flightCache)
+      .where(
+        and(
+          eq(flightCache.flightNumber, TEST_FLIGHT),
+          eq(flightCache.date, TEST_DATE),
+        ),
+      );
+  };
+
+  beforeEach(async () => {
+    service = new FlightService(db, TEST_API_KEY);
+    await cleanup();
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await cleanup();
+  });
+
+  it("returns { available: false } when API key is null", async () => {
+    const noKeyService = new FlightService(db, null);
+    const result = await noKeyService.lookupFlight(TEST_FLIGHT, TEST_DATE);
+    expect(result).toEqual({ available: false });
+  });
+
+  it("throws error for invalid flight number format", async () => {
+    await expect(service.lookupFlight("INVALID!", TEST_DATE)).rejects.toThrow(
+      "Invalid flight number format",
+    );
+  });
+
+  it("returns cached result without calling fetch (cache hit)", async () => {
+    // Insert fresh cache
+    await db.insert(flightCache).values({
+      flightNumber: TEST_FLIGHT,
+      date: TEST_DATE,
+      response: mockAeroDataBoxResponse(),
+      fetchedAt: new Date(),
+    });
+
+    const mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await service.lookupFlight("ua123", TEST_DATE);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      available: true,
+      flight: {
+        departureAirport: { iata: "LHR", name: "London Heathrow" },
+        departureTime: "2026-03-26T08:00+00:00",
+        arrivalAirport: { iata: "EWR", name: "Newark Liberty" },
+        arrivalTime: "2026-03-26T12:20-04:00",
+      },
+    });
+  });
+
+  it("returns { flight: null } for negative cache hit (null response)", async () => {
+    await db.insert(flightCache).values({
+      flightNumber: TEST_FLIGHT,
+      date: TEST_DATE,
+      response: null,
+      fetchedAt: new Date(),
+    });
+
+    const mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await service.lookupFlight(TEST_FLIGHT, TEST_DATE);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result).toEqual({ available: true, flight: null });
+  });
+
+  it("calls fetch on cache miss and returns normalized result", async () => {
+    const apiResponse = mockAeroDataBoxResponse();
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(apiResponse),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await service.lookupFlight(TEST_FLIGHT, TEST_DATE);
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(result).toEqual({
+      available: true,
+      flight: {
+        departureAirport: { iata: "LHR", name: "London Heathrow" },
+        departureTime: "2026-03-26T08:00+00:00",
+        arrivalAirport: { iata: "EWR", name: "Newark Liberty" },
+        arrivalTime: "2026-03-26T12:20-04:00",
+      },
+    });
+  });
+
+  it("returns { flight: null } for 204 response and caches negative result", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 204,
+      json: () => Promise.reject(new Error("No content")),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await service.lookupFlight(TEST_FLIGHT, TEST_DATE);
+
+    expect(result).toEqual({ available: true, flight: null });
+
+    // Verify negative cache was inserted
+    const cached = await db
+      .select()
+      .from(flightCache)
+      .where(
+        and(
+          eq(flightCache.flightNumber, TEST_FLIGHT),
+          eq(flightCache.date, TEST_DATE),
+        ),
+      );
+    expect(cached).toHaveLength(1);
+    expect(cached[0]!.response).toBeNull();
+  });
+
+  it("throws error for non-200/204 response", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: () => Promise.resolve({ message: "Unauthorized" }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await expect(service.lookupFlight(TEST_FLIGHT, TEST_DATE)).rejects.toThrow(
+      "Unauthorized",
+    );
+  });
+
+  it("returns { flight: null } when scheduledTime is null", async () => {
+    const apiResponse = [
+      {
+        departure: {
+          airport: { iata: "LHR", name: "London Heathrow" },
+          scheduledTime: null,
+        },
+        arrival: {
+          airport: { iata: "EWR", name: "Newark Liberty" },
+          scheduledTime: { local: "2026-03-26 12:20-04:00" },
+        },
+        codeshareStatus: "IsOperator",
+      },
+    ];
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(apiResponse),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await service.lookupFlight(TEST_FLIGHT, TEST_DATE);
+
+    expect(result).toEqual({ available: true, flight: null });
+  });
+
+  it("prefers codeshareStatus 'IsOperator' over other entries", async () => {
+    const apiResponse = [
+      {
+        departure: {
+          airport: { iata: "CDG", name: "Paris Charles de Gaulle" },
+          scheduledTime: { local: "2026-03-26 09:00+01:00" },
+        },
+        arrival: {
+          airport: { iata: "JFK", name: "New York JFK" },
+          scheduledTime: { local: "2026-03-26 13:00-04:00" },
+        },
+        codeshareStatus: "IsCodeshared",
+      },
+      {
+        departure: {
+          airport: { iata: "LHR", name: "London Heathrow" },
+          scheduledTime: { local: "2026-03-26 08:00+00:00" },
+        },
+        arrival: {
+          airport: { iata: "EWR", name: "Newark Liberty" },
+          scheduledTime: { local: "2026-03-26 12:20-04:00" },
+        },
+        codeshareStatus: "IsOperator",
+      },
+    ];
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(apiResponse),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await service.lookupFlight(TEST_FLIGHT, TEST_DATE);
+
+    expect(result).toEqual({
+      available: true,
+      flight: {
+        departureAirport: { iata: "LHR", name: "London Heathrow" },
+        departureTime: "2026-03-26T08:00+00:00",
+        arrivalAirport: { iata: "EWR", name: "Newark Liberty" },
+        arrivalTime: "2026-03-26T12:20-04:00",
+      },
+    });
+  });
+
+  it("throws 'Flight lookup timed out' on AbortError", async () => {
+    const abortError = new DOMException("The operation was aborted", "AbortError");
+    const mockFetch = vi.fn().mockRejectedValue(abortError);
+    vi.stubGlobal("fetch", mockFetch);
+
+    await expect(service.lookupFlight(TEST_FLIGHT, TEST_DATE)).rejects.toThrow(
+      "Flight lookup timed out",
+    );
+  });
+});

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -66,7 +66,7 @@ export default defineConfig({
       stderr: "pipe",
     },
     {
-      command: "pnpm dev",
+      command: "NEXT_PUBLIC_DISABLE_DEVTOOLS=true pnpm dev",
       url: "http://localhost:3000",
       timeout: 120 * 1000,
       reuseExistingServer: !process.env.CI,

--- a/apps/web/src/app/providers/providers.tsx
+++ b/apps/web/src/app/providers/providers.tsx
@@ -9,7 +9,8 @@ import { AuthProvider } from "./auth-provider";
 import { Toaster } from "@/components/ui/sonner";
 
 const ReactQueryDevtools =
-  process.env.NODE_ENV === "development"
+  process.env.NODE_ENV === "development" &&
+  process.env.NEXT_PUBLIC_DISABLE_DEVTOOLS !== "true"
     ? dynamic(
         () =>
           import("@tanstack/react-query-devtools").then(

--- a/apps/web/src/components/itinerary/create-member-travel-dialog.tsx
+++ b/apps/web/src/components/itinerary/create-member-travel-dialog.tsx
@@ -120,7 +120,9 @@ export function CreateMemberTravelDialog({
       ? `${airport.name} (${airport.iata})`
       : airport.name;
     form.setValue("location", locationStr);
-    form.setValue("time", time);
+    // Convert to full UTC ISO string for Zod .datetime() validation and DateTimePicker
+    const utcIso = new Date(time).toISOString();
+    form.setValue("time", utcIso);
     form.setValue("flightNumber", flightNumber);
   };
 

--- a/apps/web/src/components/itinerary/create-member-travel-dialog.tsx
+++ b/apps/web/src/components/itinerary/create-member-travel-dialog.tsx
@@ -96,21 +96,10 @@ export function CreateMemberTravelDialog({
 
   const travelType = form.watch("travelType");
   const travelTypeLabel = travelType === "departure" ? "Departure" : "Arrival";
-  const timeValue = form.watch("time");
 
-  // Date for flight lookup: from form time, or trip start/end date as fallback
-  const flightLookupDate = useMemo(() => {
-    if (timeValue) {
-      try {
-        return new Date(timeValue).toISOString().slice(0, 10);
-      } catch {
-        // fall through
-      }
-    }
-    if (travelType === "departure" && tripEndDate) return tripEndDate;
-    if (tripStartDate) return tripStartDate;
-    return undefined;
-  }, [timeValue, travelType, tripStartDate, tripEndDate]);
+  // Default date for flight lookup: trip end date for departures, start date for arrivals
+  const flightLookupDefaultDate =
+    travelType === "departure" ? (tripEndDate ?? undefined) : (tripStartDate ?? undefined);
 
   const handleFlightResult = (result: FlightLookupResult, flightNumber: string) => {
     const isArrival = travelType === "arrival";
@@ -343,7 +332,7 @@ export function CreateMemberTravelDialog({
 
               {/* Flight Lookup */}
               <FlightLookupInput
-                date={flightLookupDate}
+                defaultDate={flightLookupDefaultDate}
                 onResult={handleFlightResult}
                 disabled={isPending}
               />

--- a/apps/web/src/components/itinerary/create-member-travel-dialog.tsx
+++ b/apps/web/src/components/itinerary/create-member-travel-dialog.tsx
@@ -50,6 +50,8 @@ import { useMembers } from "@/hooks/use-invitations";
 import { getInitials } from "@/lib/format";
 import { getUploadUrl } from "@/lib/api";
 import { TIMEZONES } from "@/lib/constants";
+import { FlightLookupInput } from "@/components/itinerary/flight-lookup-input";
+import type { FlightLookupResult } from "@journiful/shared/types";
 
 interface CreateMemberTravelDialogProps {
   open: boolean;
@@ -88,11 +90,39 @@ export function CreateMemberTravelDialog({
       time: "",
       location: "",
       details: "",
+      flightNumber: "",
     },
   });
 
   const travelType = form.watch("travelType");
   const travelTypeLabel = travelType === "departure" ? "Departure" : "Arrival";
+  const timeValue = form.watch("time");
+
+  // Date for flight lookup: from form time, or trip start/end date as fallback
+  const flightLookupDate = useMemo(() => {
+    if (timeValue) {
+      try {
+        return new Date(timeValue).toISOString().slice(0, 10);
+      } catch {
+        // fall through
+      }
+    }
+    if (travelType === "departure" && tripEndDate) return tripEndDate;
+    if (tripStartDate) return tripStartDate;
+    return undefined;
+  }, [timeValue, travelType, tripStartDate, tripEndDate]);
+
+  const handleFlightResult = (result: FlightLookupResult, flightNumber: string) => {
+    const isArrival = travelType === "arrival";
+    const airport = isArrival ? result.arrivalAirport : result.departureAirport;
+    const time = isArrival ? result.arrivalTime : result.departureTime;
+    const locationStr = airport.iata
+      ? `${airport.name} (${airport.iata})`
+      : airport.name;
+    form.setValue("location", locationStr);
+    form.setValue("time", time);
+    form.setValue("flightNumber", flightNumber);
+  };
 
   // Reset form when dialog closes
   useEffect(() => {
@@ -308,6 +338,13 @@ export function CreateMemberTravelDialog({
                   </SelectContent>
                 </Select>
               </FormItem>
+
+              {/* Flight Lookup */}
+              <FlightLookupInput
+                date={flightLookupDate}
+                onResult={handleFlightResult}
+                disabled={isPending}
+              />
 
               {/* Time */}
               <FormField

--- a/apps/web/src/components/itinerary/edit-member-travel-dialog.tsx
+++ b/apps/web/src/components/itinerary/edit-member-travel-dialog.tsx
@@ -122,7 +122,9 @@ export function EditMemberTravelDialog({
       ? `${airport.name} (${airport.iata})`
       : airport.name;
     form.setValue("location", locationStr);
-    form.setValue("time", time);
+    // Convert to full UTC ISO string for Zod .datetime() validation and DateTimePicker
+    const utcIso = new Date(time).toISOString();
+    form.setValue("time", utcIso);
     form.setValue("flightNumber", flightNumber);
   };
 

--- a/apps/web/src/components/itinerary/edit-member-travel-dialog.tsx
+++ b/apps/web/src/components/itinerary/edit-member-travel-dialog.tsx
@@ -97,22 +97,11 @@ export function EditMemberTravelDialog({
 
   const travelType = form.watch("travelType");
   const travelTypeLabel = travelType === "departure" ? "Departure" : "Arrival";
-  const timeValue = form.watch("time");
 
-  // Date for flight lookup: from form time, or existing travel time
-  const flightLookupDate = useMemo(() => {
-    if (timeValue) {
-      try {
-        return new Date(timeValue).toISOString().slice(0, 10);
-      } catch {
-        // fall through
-      }
-    }
-    if (memberTravel.time) {
-      return new Date(memberTravel.time).toISOString().slice(0, 10);
-    }
-    return undefined;
-  }, [timeValue, memberTravel.time]);
+  // Default date for flight lookup: from existing travel record
+  const flightLookupDefaultDate = memberTravel.time
+    ? new Date(memberTravel.time).toISOString().slice(0, 10)
+    : undefined;
 
   const handleFlightResult = (result: FlightLookupResult, flightNumber: string) => {
     const isArrival = travelType === "arrival";
@@ -284,7 +273,7 @@ export function EditMemberTravelDialog({
 
               {/* Flight Lookup */}
               <FlightLookupInput
-                date={flightLookupDate}
+                defaultDate={flightLookupDefaultDate}
                 onResult={handleFlightResult}
                 defaultValue={memberTravel.flightNumber || undefined}
                 disabled={isPending || isDeleting}

--- a/apps/web/src/components/itinerary/edit-member-travel-dialog.tsx
+++ b/apps/web/src/components/itinerary/edit-member-travel-dialog.tsx
@@ -57,6 +57,8 @@ import {
   getDeleteMemberTravelErrorMessage,
 } from "@/hooks/use-member-travel";
 import { TIMEZONES } from "@/lib/constants";
+import { FlightLookupInput } from "@/components/itinerary/flight-lookup-input";
+import type { FlightLookupResult } from "@journiful/shared/types";
 
 interface EditMemberTravelDialogProps {
   open: boolean;
@@ -89,11 +91,40 @@ export function EditMemberTravelDialog({
       time: "",
       location: "",
       details: "",
+      flightNumber: "",
     },
   });
 
   const travelType = form.watch("travelType");
   const travelTypeLabel = travelType === "departure" ? "Departure" : "Arrival";
+  const timeValue = form.watch("time");
+
+  // Date for flight lookup: from form time, or existing travel time
+  const flightLookupDate = useMemo(() => {
+    if (timeValue) {
+      try {
+        return new Date(timeValue).toISOString().slice(0, 10);
+      } catch {
+        // fall through
+      }
+    }
+    if (memberTravel.time) {
+      return new Date(memberTravel.time).toISOString().slice(0, 10);
+    }
+    return undefined;
+  }, [timeValue, memberTravel.time]);
+
+  const handleFlightResult = (result: FlightLookupResult, flightNumber: string) => {
+    const isArrival = travelType === "arrival";
+    const airport = isArrival ? result.arrivalAirport : result.departureAirport;
+    const time = isArrival ? result.arrivalTime : result.departureTime;
+    const locationStr = airport.iata
+      ? `${airport.name} (${airport.iata})`
+      : airport.name;
+    form.setValue("location", locationStr);
+    form.setValue("time", time);
+    form.setValue("flightNumber", flightNumber);
+  };
 
   // Pre-populate form with existing member travel data when dialog opens
   useEffect(() => {
@@ -105,6 +136,7 @@ export function EditMemberTravelDialog({
           : "",
         location: memberTravel.location || "",
         details: memberTravel.details || "",
+        flightNumber: memberTravel.flightNumber || "",
       });
       setSelectedTimezone(timezone);
     }
@@ -247,6 +279,14 @@ export function EditMemberTravelDialog({
                   </SelectContent>
                 </Select>
               </div>
+
+              {/* Flight Lookup */}
+              <FlightLookupInput
+                date={flightLookupDate}
+                onResult={handleFlightResult}
+                defaultValue={memberTravel.flightNumber || undefined}
+                disabled={isPending || isDeleting}
+              />
 
               {/* Time */}
               <FormField

--- a/apps/web/src/components/itinerary/event-detail-sheet.tsx
+++ b/apps/web/src/components/itinerary/event-detail-sheet.tsx
@@ -67,7 +67,6 @@ export function EventDetailSheet({
     if (!event) return;
     deleteEvent(event.id, {
       onSuccess: () => {
-        toast.success("Event deleted");
         onOpenChange(false);
       },
       onError: (error) => {

--- a/apps/web/src/components/itinerary/flight-lookup-input.tsx
+++ b/apps/web/src/components/itinerary/flight-lookup-input.tsx
@@ -11,19 +11,21 @@ import { useFlightLookup } from "@/hooks/flight-queries";
 const FLIGHT_NUMBER_REGEX = /^[A-Z\d]{2,3}\d{1,4}$/i;
 
 interface FlightLookupInputProps {
-  date: string | undefined;
+  /** Default date for lookup (YYYY-MM-DD), pre-filled from trip start/end date */
+  defaultDate?: string | undefined;
   onResult: (result: FlightLookupResult, flightNumber: string) => void;
   defaultValue?: string | undefined;
   disabled?: boolean | undefined;
 }
 
 export function FlightLookupInput({
-  date,
+  defaultDate,
   onResult,
   defaultValue,
   disabled,
 }: FlightLookupInputProps) {
   const [value, setValue] = useState(defaultValue || "");
+  const [date, setDate] = useState(defaultDate || "");
   const [notConfigured, setNotConfigured] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const { mutate, isPending } = useFlightLookup();
@@ -33,12 +35,14 @@ export function FlightLookupInput({
   }
 
   const isValidFormat = FLIGHT_NUMBER_REGEX.test(value.trim());
-  const canLookup = !!date && value.trim().length > 0 && isValidFormat && !isPending && !disabled;
+  const hasDate = date.length === 10;
+  const canLookup =
+    hasDate && value.trim().length > 0 && isValidFormat && !isPending && !disabled;
 
   const handleLookup = () => {
     setErrorMessage(null);
     mutate(
-      { flightNumber: value.trim(), date: date! },
+      { flightNumber: value.trim(), date },
       {
         onSuccess: (response) => {
           if (!response.available) {
@@ -63,8 +67,8 @@ export function FlightLookupInput({
   };
 
   return (
-    <div className="space-y-1.5">
-      <label className="text-sm font-medium">Flight number</label>
+    <div className="space-y-2">
+      <label className="text-sm font-medium">Flight lookup</label>
       <div className="flex gap-2">
         <Input
           type="text"
@@ -76,6 +80,16 @@ export function FlightLookupInput({
           }}
           disabled={isPending || disabled}
           className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md flex-1"
+        />
+        <Input
+          type="date"
+          value={date}
+          onChange={(e) => {
+            setDate(e.target.value);
+            setErrorMessage(null);
+          }}
+          disabled={isPending || disabled}
+          className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md w-[160px]"
         />
         <Button
           type="button"
@@ -91,6 +105,9 @@ export function FlightLookupInput({
           )}
         </Button>
       </div>
+      <p className="text-sm text-muted-foreground">
+        Enter your flight number and travel date to auto-fill details
+      </p>
       {errorMessage && (
         <p className="text-sm text-destructive">{errorMessage}</p>
       )}

--- a/apps/web/src/components/itinerary/flight-lookup-input.tsx
+++ b/apps/web/src/components/itinerary/flight-lookup-input.tsx
@@ -8,7 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { useFlightLookup } from "@/hooks/flight-queries";
 
-const FLIGHT_NUMBER_REGEX = /^[A-Z]{2,3}\d{1,4}$/i;
+const FLIGHT_NUMBER_REGEX = /^[A-Z\d]{2,3}\d{1,4}$/i;
 
 interface FlightLookupInputProps {
   date: string | undefined;

--- a/apps/web/src/components/itinerary/flight-lookup-input.tsx
+++ b/apps/web/src/components/itinerary/flight-lookup-input.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import type { FlightLookupResult } from "@journiful/shared/types";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { useFlightLookup } from "@/hooks/flight-queries";
+
+const FLIGHT_NUMBER_REGEX = /^[A-Z]{2,3}\d{1,4}$/i;
+
+interface FlightLookupInputProps {
+  date: string | undefined;
+  onResult: (result: FlightLookupResult, flightNumber: string) => void;
+  defaultValue?: string | undefined;
+  disabled?: boolean | undefined;
+}
+
+export function FlightLookupInput({
+  date,
+  onResult,
+  defaultValue,
+  disabled,
+}: FlightLookupInputProps) {
+  const [value, setValue] = useState(defaultValue || "");
+  const [notConfigured, setNotConfigured] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const { mutate, isPending } = useFlightLookup();
+
+  if (notConfigured) {
+    return null;
+  }
+
+  const isValidFormat = FLIGHT_NUMBER_REGEX.test(value.trim());
+  const canLookup = !!date && value.trim().length > 0 && isValidFormat && !isPending && !disabled;
+
+  const handleLookup = () => {
+    setErrorMessage(null);
+    mutate(
+      { flightNumber: value.trim(), date: date! },
+      {
+        onSuccess: (response) => {
+          if (!response.available) {
+            setNotConfigured(true);
+            return;
+          }
+          if (response.available && response.flight) {
+            const { departureAirport, arrivalAirport } = response.flight;
+            const from = departureAirport.iata || departureAirport.name;
+            const to = arrivalAirport.iata || arrivalAirport.name;
+            toast.success(`Found: ${from} → ${to}`);
+            onResult(response.flight, value.trim());
+          } else {
+            setErrorMessage("Flight not found for this date");
+          }
+        },
+        onError: () => {
+          setErrorMessage("Lookup temporarily unavailable");
+        },
+      },
+    );
+  };
+
+  return (
+    <div className="space-y-1.5">
+      <label className="text-sm font-medium">Flight number</label>
+      <div className="flex gap-2">
+        <Input
+          type="text"
+          placeholder="e.g., UA123"
+          value={value}
+          onChange={(e) => {
+            setValue(e.target.value);
+            setErrorMessage(null);
+          }}
+          disabled={isPending || disabled}
+          className="h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md flex-1"
+        />
+        <Button
+          type="button"
+          variant="outline"
+          onClick={handleLookup}
+          disabled={!canLookup}
+          className="h-12 rounded-md px-4"
+        >
+          {isPending ? (
+            <Loader2 className="w-4 h-4 animate-spin" />
+          ) : (
+            "Lookup"
+          )}
+        </Button>
+      </div>
+      {errorMessage && (
+        <p className="text-sm text-destructive">{errorMessage}</p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/itinerary/index.ts
+++ b/apps/web/src/components/itinerary/index.ts
@@ -13,5 +13,6 @@ export { CreateAccommodationDialog } from "./create-accommodation-dialog";
 export { EditAccommodationDialog } from "./edit-accommodation-dialog";
 export { CreateMemberTravelDialog } from "./create-member-travel-dialog";
 export { EditMemberTravelDialog } from "./edit-member-travel-dialog";
+export { FlightLookupInput } from "./flight-lookup-input";
 export { WeatherDayBadge } from "./weather-day-badge";
 export { WeatherForecastCard } from "./weather-forecast-card";

--- a/apps/web/src/components/itinerary/itinerary-header.tsx
+++ b/apps/web/src/components/itinerary/itinerary-header.tsx
@@ -141,14 +141,18 @@ export function ItineraryHeader({
       {mounted &&
         hasAnyAction &&
         !isLocked &&
-        !hideFab &&
         createPortal(
           <DropdownMenu open={fabOpen} onOpenChange={setFabOpen}>
             <DropdownMenuTrigger asChild>
               <Button
                 variant="gradient"
-                className="fixed bottom-safe-6 right-6 sm:bottom-safe-8 sm:right-8 z-50 rounded-full w-14 h-14 shadow-lg"
+                className={`fixed bottom-16 right-6 sm:bottom-safe-8 sm:right-8 z-50 rounded-full w-14 h-14 shadow-lg transition-all duration-300 ease-out ${
+                  hideFab
+                    ? "opacity-0 scale-75 pointer-events-none"
+                    : "opacity-100 scale-100"
+                }`}
                 aria-label="Add to itinerary"
+                tabIndex={hideFab ? -1 : undefined}
               >
                 <Plus
                   className={`w-6 h-6 transition-transform duration-200 ${fabOpen ? "rotate-45" : ""}`}

--- a/apps/web/src/components/itinerary/member-travel-detail-sheet.tsx
+++ b/apps/web/src/components/itinerary/member-travel-detail-sheet.tsx
@@ -4,6 +4,7 @@ import {
   Loader2,
   MapPin,
   Pencil,
+  Plane,
   PlaneLanding,
   PlaneTakeoff,
   Trash2,
@@ -187,6 +188,14 @@ export function MemberTravelDetailSheet({
           <p className="text-sm text-muted-foreground mt-1">
             {formattedDateTime}
           </p>
+
+          {/* Flight number */}
+          {memberTravel.flightNumber && (
+            <div className="mt-3 inline-flex items-center gap-1.5 text-sm font-medium">
+              <Plane className="w-3.5 h-3.5 shrink-0" />
+              <span>Flight {memberTravel.flightNumber}</span>
+            </div>
+          )}
 
           {/* Location */}
           {memberTravel.location && (

--- a/apps/web/src/components/trip/member-onboarding-wizard.tsx
+++ b/apps/web/src/components/trip/member-onboarding-wizard.tsx
@@ -154,7 +154,7 @@ export function MemberOnboardingWizard({
       ? `${airport.name} (${airport.iata})`
       : airport.name;
     setArrivalLocationValue(locationStr);
-    setArrivalDateValue(result.arrivalTime);
+    setArrivalDateValue(new Date(result.arrivalTime).toISOString());
     setArrivalFlightNumber(flightNumber);
   };
 
@@ -164,7 +164,7 @@ export function MemberOnboardingWizard({
       ? `${airport.name} (${airport.iata})`
       : airport.name;
     setDepartureLocationValue(locationStr);
-    setDepartureDateValue(result.departureTime);
+    setDepartureDateValue(new Date(result.departureTime).toISOString());
     setDepartureFlightNumber(flightNumber);
   };
 

--- a/apps/web/src/components/trip/member-onboarding-wizard.tsx
+++ b/apps/web/src/components/trip/member-onboarding-wizard.tsx
@@ -28,6 +28,8 @@ import { toast } from "sonner";
 import { parse } from "date-fns";
 import type { TripDetailWithMeta } from "@/hooks/trip-queries";
 import { Loader2, X, Check, Plane, MapPin, Calendar } from "lucide-react";
+import { FlightLookupInput } from "@/components/itinerary/flight-lookup-input";
+import type { FlightLookupResult } from "@journiful/shared/types";
 
 interface MemberOnboardingWizardProps {
   open: boolean;
@@ -47,6 +49,8 @@ export function MemberOnboardingWizard({
   const [arrivalLocation, setArrivalLocation] = useState("");
   const [arrivalTime, setArrivalTime] = useState("");
   const [departureTime, setDepartureTime] = useState("");
+  const [arrivalFlightNumber, setArrivalFlightNumber] = useState("");
+  const [departureFlightNumber, setDepartureFlightNumber] = useState("");
   const [addedEvents, setAddedEvents] = useState<
     Array<{ name: string; startTime: string }>
   >([]);
@@ -109,6 +113,8 @@ export function MemberOnboardingWizard({
       setAddedEvents([]);
       setEventName("");
       setEventStartTime("");
+      setArrivalFlightNumber("");
+      setDepartureFlightNumber("");
 
       if (existingArrival) {
         const arrivalISO = new Date(existingArrival.time).toISOString();
@@ -137,6 +143,30 @@ export function MemberOnboardingWizard({
       }
     }
   }, [open]);
+
+  // Flight lookup dates from trip dates
+  const arrivalLookupDate = trip.startDate || undefined;
+  const departureLookupDate = trip.endDate || undefined;
+
+  const handleArrivalFlightResult = (result: FlightLookupResult, flightNumber: string) => {
+    const airport = result.arrivalAirport;
+    const locationStr = airport.iata
+      ? `${airport.name} (${airport.iata})`
+      : airport.name;
+    setArrivalLocationValue(locationStr);
+    setArrivalDateValue(result.arrivalTime);
+    setArrivalFlightNumber(flightNumber);
+  };
+
+  const handleDepartureFlightResult = (result: FlightLookupResult, flightNumber: string) => {
+    const airport = result.departureAirport;
+    const locationStr = airport.iata
+      ? `${airport.name} (${airport.iata})`
+      : airport.name;
+    setDepartureLocationValue(locationStr);
+    setDepartureDateValue(result.departureTime);
+    setDepartureFlightNumber(flightNumber);
+  };
 
   const doneStepIndex = totalSteps - 1;
   const eventsStepIndex = canAddEvents ? 3 : -1;
@@ -178,6 +208,7 @@ export function MemberOnboardingWizard({
               travelType: "arrival",
               time: arrivalDateValue,
               location: arrivalLocationValue || undefined,
+              flightNumber: arrivalFlightNumber || undefined,
             },
           },
           { onSuccess, onError },
@@ -190,6 +221,7 @@ export function MemberOnboardingWizard({
               travelType: "arrival",
               time: arrivalDateValue,
               location: arrivalLocationValue || undefined,
+              flightNumber: arrivalFlightNumber || undefined,
             },
           },
           { onSuccess, onError },
@@ -218,6 +250,7 @@ export function MemberOnboardingWizard({
               travelType: "departure",
               time: departureDateValue,
               location: departureLocationValue || undefined,
+              flightNumber: departureFlightNumber || undefined,
             },
           },
           { onSuccess, onError },
@@ -230,6 +263,7 @@ export function MemberOnboardingWizard({
               travelType: "departure",
               time: departureDateValue,
               location: departureLocationValue || undefined,
+              flightNumber: departureFlightNumber || undefined,
             },
           },
           { onSuccess, onError },
@@ -416,6 +450,11 @@ export function MemberOnboardingWizard({
 
           {step === 1 && (
             <div className="space-y-4">
+              <FlightLookupInput
+                date={arrivalLookupDate}
+                onResult={handleArrivalFlightResult}
+                disabled={isPending}
+              />
               <div className="space-y-2">
                 <label className="text-sm font-medium">Date & Time</label>
                 <DateTimePicker
@@ -448,6 +487,11 @@ export function MemberOnboardingWizard({
 
           {step === 2 && (
             <div className="space-y-4">
+              <FlightLookupInput
+                date={departureLookupDate}
+                onResult={handleDepartureFlightResult}
+                disabled={isPending}
+              />
               <div className="space-y-2">
                 <label className="text-sm font-medium">Date & Time</label>
                 <DateTimePicker

--- a/apps/web/src/components/trip/member-onboarding-wizard.tsx
+++ b/apps/web/src/components/trip/member-onboarding-wizard.tsx
@@ -451,7 +451,7 @@ export function MemberOnboardingWizard({
           {step === 1 && (
             <div className="space-y-4">
               <FlightLookupInput
-                date={arrivalLookupDate}
+                defaultDate={arrivalLookupDate}
                 onResult={handleArrivalFlightResult}
                 disabled={isPending}
               />
@@ -488,7 +488,7 @@ export function MemberOnboardingWizard({
           {step === 2 && (
             <div className="space-y-4">
               <FlightLookupInput
-                date={departureLookupDate}
+                defaultDate={departureLookupDate}
                 onResult={handleDepartureFlightResult}
                 disabled={isPending}
               />

--- a/apps/web/src/components/trip/mobile/icon-strip.tsx
+++ b/apps/web/src/components/trip/mobile/icon-strip.tsx
@@ -16,7 +16,7 @@ interface IconStripProps {
 
 export function IconStrip({ activeIndex, onIconClick }: IconStripProps) {
   return (
-    <div className="shrink-0 flex items-center justify-around bg-background/90 backdrop-blur-sm pt-safe h-[44px] z-40">
+    <div className="shrink-0 flex items-center justify-around bg-background/90 backdrop-blur-sm pb-safe border-t border-border h-[44px] z-40">
       {ICONS.map(({ icon: Icon, label }, index) => {
         const isActive = index === activeIndex;
         return (

--- a/apps/web/src/components/trip/mobile/mobile-trip-layout.tsx
+++ b/apps/web/src/components/trip/mobile/mobile-trip-layout.tsx
@@ -139,8 +139,6 @@ export function MobileTripLayout({
       scope="page"
     >
       <div className="h-[calc(100dvh-3.5rem)] flex flex-col bg-background overflow-hidden">
-        <IconStrip activeIndex={activeIndex} onIconClick={handleIconClick} />
-
         <AnimatedHero
           trip={trip}
           collapseProgress={collapseT}
@@ -191,6 +189,8 @@ export function MobileTripLayout({
             />
           </MobileTripSwiper>
         </div>
+
+        <IconStrip activeIndex={activeIndex} onIconClick={handleIconClick} />
 
         {/* Modals/Sheets — same as desktop, portaled */}
         {isOrganizer && trip && (

--- a/apps/web/src/components/trip/mobile/panels/info-panel.tsx
+++ b/apps/web/src/components/trip/mobile/panels/info-panel.tsx
@@ -245,8 +245,8 @@ export function InfoPanel({
         </button>
 
         {/* 3. Accommodations */}
-        {accommodations && accommodations.length > 0 && (
-          <CollapsibleSection label="Accommodations" defaultOpen>
+        <CollapsibleSection label="Accommodations" defaultOpen>
+          {accommodations && accommodations.length > 0 ? (
             <div className="space-y-2">
               {accommodations.map((acc) => (
                 <button
@@ -265,8 +265,15 @@ export function InfoPanel({
                 </button>
               ))}
             </div>
-          </CollapsibleSection>
-        )}
+          ) : (
+            <button
+              onClick={onNavigateToItinerary}
+              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              + Add accommodation
+            </button>
+          )}
+        </CollapsibleSection>
 
         {/* 4. Today section (only during trip) */}
         {phase === "duringTrip" && (
@@ -274,6 +281,7 @@ export function InfoPanel({
             <TodaySection
               tripId={tripId}
               timezone={timezone}
+              onAddEvent={onNavigateToItinerary}
             />
           </CollapsibleSection>
         )}

--- a/apps/web/src/components/trip/mobile/panels/info-panel.tsx
+++ b/apps/web/src/components/trip/mobile/panels/info-panel.tsx
@@ -15,6 +15,8 @@ import { RsvpPills } from "@/components/trip/rsvp-pills";
 import { WeatherForecastCard } from "@/components/itinerary/weather-forecast-card";
 import { AccommodationDetailSheet } from "@/components/itinerary/accommodation-detail-sheet";
 import { EditAccommodationDialog } from "@/components/itinerary/edit-accommodation-dialog";
+import { CreateAccommodationDialog } from "@/components/itinerary/create-accommodation-dialog";
+import { CreateEventDialog } from "@/components/itinerary/create-event-dialog";
 import { canModifyAccommodation } from "@/components/itinerary/utils/permissions";
 import { useAccommodations } from "@/hooks/use-accommodations";
 import { useAuth } from "@/app/providers/auth-provider";
@@ -108,6 +110,8 @@ export function InfoPanel({
   const { data: accommodations } = useAccommodations(tripId);
   const [selectedAccommodation, setSelectedAccommodation] = useState<Accommodation | null>(null);
   const [editingAccommodation, setEditingAccommodation] = useState<Accommodation | null>(null);
+  const [isCreateAccommodationOpen, setIsCreateAccommodationOpen] = useState(false);
+  const [isCreateEventOpen, setIsCreateEventOpen] = useState(false);
 
   // Trip is locked one day after end date
   const isLocked = useMemo(() => {
@@ -280,7 +284,7 @@ export function InfoPanel({
             </div>
           ) : (
             <button
-              onClick={onNavigateToItinerary}
+              onClick={() => setIsCreateAccommodationOpen(true)}
               className="text-sm text-muted-foreground hover:text-foreground transition-colors"
             >
               + Add accommodation
@@ -298,7 +302,7 @@ export function InfoPanel({
               isLocked={isLocked}
               tripStartDate={trip.startDate}
               tripEndDate={trip.endDate}
-              onAddEvent={onNavigateToItinerary}
+              onAddEvent={() => setIsCreateEventOpen(true)}
             />
           </CollapsibleSection>
         )}
@@ -361,6 +365,26 @@ export function InfoPanel({
           timezone={timezone}
         />
       )}
+
+      {/* Create accommodation dialog */}
+      <CreateAccommodationDialog
+        open={isCreateAccommodationOpen}
+        onOpenChange={setIsCreateAccommodationOpen}
+        tripId={tripId}
+        timezone={timezone}
+        tripStartDate={trip.startDate}
+        tripEndDate={trip.endDate}
+      />
+
+      {/* Create event dialog */}
+      <CreateEventDialog
+        open={isCreateEventOpen}
+        onOpenChange={setIsCreateEventOpen}
+        tripId={tripId}
+        timezone={timezone}
+        tripStartDate={trip.startDate}
+        tripEndDate={trip.endDate}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/trip/mobile/panels/info-panel.tsx
+++ b/apps/web/src/components/trip/mobile/panels/info-panel.tsx
@@ -294,6 +294,10 @@ export function InfoPanel({
             <TodaySection
               tripId={tripId}
               timezone={timezone}
+              isOrganizer={isOrganizer}
+              isLocked={isLocked}
+              tripStartDate={trip.startDate}
+              tripEndDate={trip.endDate}
               onAddEvent={onNavigateToItinerary}
             />
           </CollapsibleSection>

--- a/apps/web/src/components/trip/mobile/panels/info-panel.tsx
+++ b/apps/web/src/components/trip/mobile/panels/info-panel.tsx
@@ -262,35 +262,37 @@ export function InfoPanel({
         </button>
 
         {/* 3. Accommodations */}
-        <CollapsibleSection label="Accommodations" defaultOpen>
-          {accommodations && accommodations.length > 0 ? (
-            <div className="space-y-2">
-              {accommodations.map((acc) => (
-                <button
-                  key={acc.id}
-                  onClick={() => setSelectedAccommodation(acc)}
-                  className="w-full text-left bg-card linen-texture border border-border rounded-md p-3 hover:bg-accent/50 transition-colors cursor-pointer"
-                >
-                  <div className="flex items-center gap-2">
-                    <Building2 className="size-4 text-muted-foreground shrink-0" />
-                    <span className="font-medium text-sm truncate">{acc.name}</span>
-                  </div>
-                  <div className="text-sm text-muted-foreground truncate mt-0.5 pl-6">
-                    {formatDateRange(acc.checkIn, acc.checkOut, timezone)}
-                    {acc.address ? ` · ${acc.address}` : ""}
-                  </div>
-                </button>
-              ))}
-            </div>
-          ) : (
-            <button
-              onClick={() => setIsCreateAccommodationOpen(true)}
-              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-            >
-              + Add accommodation
-            </button>
-          )}
-        </CollapsibleSection>
+        {((accommodations && accommodations.length > 0) || isOrganizer) && (
+          <CollapsibleSection label="Accommodations" defaultOpen>
+            {accommodations && accommodations.length > 0 ? (
+              <div className="space-y-2">
+                {accommodations.map((acc) => (
+                  <button
+                    key={acc.id}
+                    onClick={() => setSelectedAccommodation(acc)}
+                    className="w-full text-left bg-card linen-texture border border-border rounded-md p-3 hover:bg-accent/50 transition-colors cursor-pointer"
+                  >
+                    <div className="flex items-center gap-2">
+                      <Building2 className="size-4 text-muted-foreground shrink-0" />
+                      <span className="font-medium text-sm truncate">{acc.name}</span>
+                    </div>
+                    <div className="text-sm text-muted-foreground truncate mt-0.5 pl-6">
+                      {formatDateRange(acc.checkIn, acc.checkOut, timezone)}
+                      {acc.address ? ` · ${acc.address}` : ""}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <button
+                onClick={() => setIsCreateAccommodationOpen(true)}
+                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+              >
+                + Add accommodation
+              </button>
+            )}
+          </CollapsibleSection>
+        )}
 
         {/* 4. Today section (only during trip) */}
         {phase === "duringTrip" && (
@@ -302,7 +304,9 @@ export function InfoPanel({
               isLocked={isLocked}
               tripStartDate={trip.startDate}
               tripEndDate={trip.endDate}
-              onAddEvent={() => setIsCreateEventOpen(true)}
+              {...(isOrganizer || trip.allowMembersToAddEvents
+                ? { onAddEvent: () => setIsCreateEventOpen(true) }
+                : {})}
             />
           </CollapsibleSection>
         )}

--- a/apps/web/src/components/trip/mobile/panels/info-panel.tsx
+++ b/apps/web/src/components/trip/mobile/panels/info-panel.tsx
@@ -262,7 +262,7 @@ export function InfoPanel({
         </button>
 
         {/* 3. Accommodations */}
-        {((accommodations && accommodations.length > 0) || isOrganizer) && (
+        {((accommodations && accommodations.length > 0) || (isOrganizer && !isLocked)) && (
           <CollapsibleSection label="Accommodations" defaultOpen>
             {accommodations && accommodations.length > 0 ? (
               <div className="space-y-2">

--- a/apps/web/src/components/trip/mobile/panels/info-panel.tsx
+++ b/apps/web/src/components/trip/mobile/panels/info-panel.tsx
@@ -252,7 +252,7 @@ export function InfoPanel({
                 <button
                   key={acc.id}
                   onClick={() => setSelectedAccommodation(acc)}
-                  className="w-full text-left border border-border rounded-md p-3 hover:bg-accent/50 transition-colors cursor-pointer"
+                  className="w-full text-left bg-card linen-texture border border-border rounded-md p-3 hover:bg-accent/50 transition-colors cursor-pointer"
                 >
                   <div className="flex items-center gap-2">
                     <Building2 className="size-4 text-muted-foreground shrink-0" />

--- a/apps/web/src/components/trip/mobile/panels/info-panel.tsx
+++ b/apps/web/src/components/trip/mobile/panels/info-panel.tsx
@@ -14,7 +14,10 @@ import { CollapsibleSection } from "@/components/ui/collapsible-section";
 import { RsvpPills } from "@/components/trip/rsvp-pills";
 import { WeatherForecastCard } from "@/components/itinerary/weather-forecast-card";
 import { AccommodationDetailSheet } from "@/components/itinerary/accommodation-detail-sheet";
+import { EditAccommodationDialog } from "@/components/itinerary/edit-accommodation-dialog";
+import { canModifyAccommodation } from "@/components/itinerary/utils/permissions";
 import { useAccommodations } from "@/hooks/use-accommodations";
+import { useAuth } from "@/app/providers/auth-provider";
 import { TodaySection } from "./today-section";
 import { linkifyText } from "@/utils/linkify";
 import { getUploadUrl } from "@/lib/api";
@@ -101,8 +104,18 @@ export function InfoPanel({
     [trip.startDate, trip.endDate, timezone],
   );
 
+  const { user } = useAuth();
   const { data: accommodations } = useAccommodations(tripId);
   const [selectedAccommodation, setSelectedAccommodation] = useState<Accommodation | null>(null);
+  const [editingAccommodation, setEditingAccommodation] = useState<Accommodation | null>(null);
+
+  // Trip is locked one day after end date
+  const isLocked = useMemo(() => {
+    if (!trip.endDate) return false;
+    const end = new Date(trip.endDate);
+    end.setDate(end.getDate() + 1);
+    return new Date() > end;
+  }, [trip.endDate]);
 
   // Summary line: "+N going · Organized by X, Y"
   const goingCount = trip.memberCount;
@@ -316,11 +329,34 @@ export function InfoPanel({
           if (!open) setSelectedAccommodation(null);
         }}
         timezone={timezone}
-        canEdit={false}
-        canDelete={false}
-        onEdit={() => {}}
+        canEdit={
+          selectedAccommodation
+            ? canModifyAccommodation(selectedAccommodation, user?.id ?? "", isOrganizer, isLocked)
+            : false
+        }
+        canDelete={
+          selectedAccommodation
+            ? canModifyAccommodation(selectedAccommodation, user?.id ?? "", isOrganizer, isLocked)
+            : false
+        }
+        onEdit={(acc) => {
+          setSelectedAccommodation(null);
+          setEditingAccommodation(acc);
+        }}
         onDelete={() => setSelectedAccommodation(null)}
       />
+
+      {/* Edit accommodation dialog */}
+      {editingAccommodation && (
+        <EditAccommodationDialog
+          open={!!editingAccommodation}
+          onOpenChange={(open) => {
+            if (!open) setEditingAccommodation(null);
+          }}
+          accommodation={editingAccommodation}
+          timezone={timezone}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/trip/mobile/panels/today-section.tsx
+++ b/apps/web/src/components/trip/mobile/panels/today-section.tsx
@@ -11,11 +11,13 @@ import { Skeleton } from "@/components/ui/skeleton";
 interface TodaySectionProps {
   tripId: string;
   timezone: string;
+  onAddEvent?: () => void;
 }
 
 export function TodaySection({
   tripId,
   timezone,
+  onAddEvent,
 }: TodaySectionProps) {
   const { data: events, isPending: eventsLoading } = useEvents(tripId);
 
@@ -77,8 +79,17 @@ export function TodaySection({
   const isLoading = eventsLoading;
   const isEmpty = !isLoading && sortedEvents.length === 0;
 
-  // Return null if no events today (parent handles conditional rendering)
-  if (!isLoading && isEmpty) return null;
+  // Show "add event" link if no events today
+  if (!isLoading && isEmpty) {
+    return onAddEvent ? (
+      <button
+        onClick={onAddEvent}
+        className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+      >
+        + Add an event
+      </button>
+    ) : null;
+  }
 
   return (
     <div>

--- a/apps/web/src/components/trip/mobile/panels/today-section.tsx
+++ b/apps/web/src/components/trip/mobile/panels/today-section.tsx
@@ -3,22 +3,34 @@
 import { useMemo, useState } from "react";
 import type { Event } from "@journiful/shared/types";
 import { useEvents } from "@/hooks/use-events";
+import { useAuth } from "@/app/providers/auth-provider";
 import { getDayInTimezone, formatInTimezone, utcToLocalParts } from "@/lib/utils/timezone";
 import { EVENT_TYPE_CONFIG } from "@/components/itinerary/event-card";
 import { EventDetailSheet } from "@/components/itinerary/event-detail-sheet";
+import { EditEventDialog } from "@/components/itinerary/edit-event-dialog";
+import { canModifyEvent } from "@/components/itinerary/utils/permissions";
 import { Skeleton } from "@/components/ui/skeleton";
 
 interface TodaySectionProps {
   tripId: string;
   timezone: string;
+  isOrganizer?: boolean;
+  isLocked?: boolean;
+  tripStartDate?: string | null;
+  tripEndDate?: string | null;
   onAddEvent?: () => void;
 }
 
 export function TodaySection({
   tripId,
   timezone,
+  isOrganizer = false,
+  isLocked = false,
+  tripStartDate,
+  tripEndDate,
   onAddEvent,
 }: TodaySectionProps) {
+  const { user } = useAuth();
   const { data: events, isPending: eventsLoading } = useEvents(tripId);
 
   const todayString = useMemo(
@@ -72,9 +84,9 @@ export function TodaySection({
     });
   }, [todayEvents]);
 
-
-  // Detail sheet state
+  // Detail sheet and edit dialog state
   const [selectedEvent, setSelectedEvent] = useState<Event | null>(null);
+  const [editingEvent, setEditingEvent] = useState<Event | null>(null);
 
   const isLoading = eventsLoading;
   const isEmpty = !isLoading && sortedEvents.length === 0;
@@ -135,10 +147,35 @@ export function TodaySection({
           if (!open) setSelectedEvent(null);
         }}
         timezone={timezone}
-        canEdit={false}
-        canDelete={false}
-        onEdit={() => {}}
+        canEdit={
+          selectedEvent
+            ? canModifyEvent(selectedEvent, user?.id ?? "", isOrganizer, isLocked)
+            : false
+        }
+        canDelete={
+          selectedEvent
+            ? canModifyEvent(selectedEvent, user?.id ?? "", isOrganizer, isLocked)
+            : false
+        }
+        onEdit={(event) => {
+          setSelectedEvent(null);
+          setEditingEvent(event);
+        }}
       />
+
+      {/* Edit event dialog */}
+      {editingEvent && (
+        <EditEventDialog
+          open={!!editingEvent}
+          onOpenChange={(open) => {
+            if (!open) setEditingEvent(null);
+          }}
+          event={editingEvent}
+          timezone={timezone}
+          tripStartDate={tripStartDate ?? undefined}
+          tripEndDate={tripEndDate ?? undefined}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/trip/mobile/panels/today-section.tsx
+++ b/apps/web/src/components/trip/mobile/panels/today-section.tsx
@@ -90,7 +90,7 @@ export function TodaySection({
       )}
 
       {!isLoading && !isEmpty && (
-        <div className="rounded-md border border-border divide-y divide-border">
+        <div className="bg-card linen-texture rounded-md border border-border divide-y divide-border">
           {sortedEvents.map((event) => {
             const config = EVENT_TYPE_CONFIG[event.eventType];
             const Icon = config.icon;

--- a/apps/web/src/components/ui/__tests__/sonner.test.tsx
+++ b/apps/web/src/components/ui/__tests__/sonner.test.tsx
@@ -33,7 +33,7 @@ describe("Toaster", () => {
     );
   });
 
-  it("renders toaster with bottom-right position and z-[60] class when a toast is shown", async () => {
+  it("renders toaster with top-right position and z-[60] class when a toast is shown", async () => {
     const { container } = render(<Toaster />);
 
     act(() => {
@@ -48,7 +48,7 @@ describe("Toaster", () => {
 
     const toasterEl = container.querySelector("[data-sonner-toaster]");
     expect(toasterEl?.getAttribute("data-x-position")).toBe("right");
-    expect(toasterEl?.getAttribute("data-y-position")).toBe("bottom");
+    expect(toasterEl?.getAttribute("data-y-position")).toBe("top");
     expect(toasterEl?.className).toContain("z-[60]");
   });
 });

--- a/apps/web/src/components/ui/sonner.tsx
+++ b/apps/web/src/components/ui/sonner.tsx
@@ -18,7 +18,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
     <Sonner
       theme={(resolvedTheme as "light" | "dark") ?? "light"}
       className="toaster group z-[60]"
-      position="bottom-right"
+      position="top-right"
       icons={{
         success: <CircleCheckIcon className="size-4" />,
         info: <InfoIcon className="size-4" />,

--- a/apps/web/src/hooks/flight-queries.ts
+++ b/apps/web/src/hooks/flight-queries.ts
@@ -1,0 +1,28 @@
+import { useMutation } from "@tanstack/react-query";
+import { apiRequest } from "@/lib/api";
+import type { FlightLookupResponse } from "@journiful/shared/types";
+
+/**
+ * Hook for looking up flight information by flight number and date.
+ * Uses POST /api/flights/lookup endpoint.
+ */
+export function useFlightLookup() {
+  return useMutation({
+    mutationKey: ["flights", "lookup"],
+    mutationFn: async ({
+      flightNumber,
+      date,
+    }: {
+      flightNumber: string;
+      date: string;
+    }) => {
+      const response = await apiRequest<{
+        success: true;
+      } & FlightLookupResponse>("/flights/lookup", {
+        method: "POST",
+        body: JSON.stringify({ flightNumber, date }),
+      });
+      return response;
+    },
+  });
+}

--- a/apps/web/src/hooks/use-accommodations.ts
+++ b/apps/web/src/hooks/use-accommodations.ts
@@ -506,11 +506,25 @@ export function useDeleteAccommodation() {
       // Cancel any outgoing refetches to avoid overwriting our optimistic update
       await queryClient.cancelQueries({ queryKey: accommodationKeys.lists() });
 
-      // Get the accommodation to find its tripId
-      const accommodation = queryClient.getQueryData<Accommodation>(
+      // Get the accommodation to find its tripId (check detail cache first, then list caches)
+      let tripId: string | undefined;
+      const cached = queryClient.getQueryData<Accommodation>(
         accommodationKeys.detail(accommodationId),
       );
-      const tripId = accommodation?.tripId;
+      if (cached) {
+        tripId = cached.tripId;
+      } else {
+        const listQueries = queryClient.getQueriesData<Accommodation[]>({
+          queryKey: accommodationKeys.lists(),
+        });
+        for (const [, list] of listQueries) {
+          const found = list?.find((a) => a.id === accommodationId);
+          if (found) {
+            tripId = found.tripId;
+            break;
+          }
+        }
+      }
 
       // Snapshot the previous value for rollback
       let previousAccommodations: Accommodation[] | undefined;
@@ -647,11 +661,25 @@ export function useRestoreAccommodation() {
         queryKey: accommodationKeys.lists(),
       });
 
-      // Get the accommodation to find its tripId
-      const accommodation = queryClient.getQueryData<Accommodation>(
+      // Get the accommodation to find its tripId (check detail cache first, then list caches)
+      let tripId: string | undefined;
+      const cached = queryClient.getQueryData<Accommodation>(
         accommodationKeys.detail(accommodationId),
       );
-      const tripId = accommodation?.tripId;
+      if (cached) {
+        tripId = cached.tripId;
+      } else {
+        const listQueries = queryClient.getQueriesData<Accommodation[]>({
+          queryKey: accommodationKeys.lists(),
+        });
+        for (const [, list] of listQueries) {
+          const found = list?.find((a) => a.id === accommodationId);
+          if (found) {
+            tripId = found.tripId;
+            break;
+          }
+        }
+      }
 
       // Snapshot the previous value for rollback
       let previousAccommodations: Accommodation[] | undefined;

--- a/apps/web/src/hooks/use-events.ts
+++ b/apps/web/src/hooks/use-events.ts
@@ -2,6 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
+import { toast } from "sonner";
 import { apiRequest, APIError } from "@/lib/api";
 import type {
   CreateEventInput,
@@ -551,6 +552,12 @@ export function useDeleteEvent() {
 
       // Return context with previous data for rollback
       return { previousEvents, tripId };
+    },
+
+    // On success: show toast (at hook level so it fires even if the calling
+    // component unmounts when the AlertDialog/Sheet closes)
+    onSuccess: () => {
+      toast.success("Event deleted");
     },
 
     // On error: Rollback optimistic update

--- a/apps/web/src/hooks/use-events.ts
+++ b/apps/web/src/hooks/use-events.ts
@@ -515,9 +515,23 @@ export function useDeleteEvent() {
       // Cancel any outgoing refetches to avoid overwriting our optimistic update
       await queryClient.cancelQueries({ queryKey: eventKeys.lists() });
 
-      // Get the event to find its tripId
-      const event = queryClient.getQueryData<Event>(eventKeys.detail(eventId));
-      const tripId = event?.tripId;
+      // Get the event to find its tripId (check detail cache first, then list caches)
+      let tripId: string | undefined;
+      const cached = queryClient.getQueryData<Event>(eventKeys.detail(eventId));
+      if (cached) {
+        tripId = cached.tripId;
+      } else {
+        const listQueries = queryClient.getQueriesData<Event[]>({
+          queryKey: eventKeys.lists(),
+        });
+        for (const [, list] of listQueries) {
+          const found = list?.find((e) => e.id === eventId);
+          if (found) {
+            tripId = found.tripId;
+            break;
+          }
+        }
+      }
 
       // Snapshot the previous value for rollback
       let previousEvents: Event[] | undefined;
@@ -645,9 +659,23 @@ export function useRestoreEvent() {
       // Cancel any outgoing refetches to avoid overwriting our optimistic update
       await queryClient.cancelQueries({ queryKey: eventKeys.lists() });
 
-      // Get the event to find its tripId
-      const event = queryClient.getQueryData<Event>(eventKeys.detail(eventId));
-      const tripId = event?.tripId;
+      // Get the event to find its tripId (check detail cache first, then list caches)
+      let tripId: string | undefined;
+      const cached = queryClient.getQueryData<Event>(eventKeys.detail(eventId));
+      if (cached) {
+        tripId = cached.tripId;
+      } else {
+        const listQueries = queryClient.getQueriesData<Event[]>({
+          queryKey: eventKeys.lists(),
+        });
+        for (const [, list] of listQueries) {
+          const found = list?.find((e) => e.id === eventId);
+          if (found) {
+            tripId = found.tripId;
+            break;
+          }
+        }
+      }
 
       // Snapshot the previous value for rollback
       let previousEvents: Event[] | undefined;

--- a/apps/web/src/hooks/use-member-travel.ts
+++ b/apps/web/src/hooks/use-member-travel.ts
@@ -183,6 +183,7 @@ export function useCreateMemberTravel() {
         time: new Date(data.time),
         location: data.location || null,
         details: data.details || null,
+        flightNumber: data.flightNumber || null,
         deletedAt: null,
         deletedBy: null,
         createdAt: new Date(),

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
       "rollup": ">=4.59.0",
       "flatted": ">=3.4.2",
       "undici": ">=7.24.0",
-      "fast-xml-parser": ">=5.5.6"
+      "fast-xml-parser": ">=5.5.6",
+      "picomatch": ">=4.0.4"
     }
   },
   "packageManager": "pnpm@10.30.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   flatted: '>=3.4.2'
   undici: '>=7.24.0'
   fast-xml-parser: '>=5.5.6'
+  picomatch: '>=4.0.4'
 
 importers:
 
@@ -3580,7 +3581,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: '>=4.0.4'
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -4467,12 +4468,8 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
-    engines: {node: '>=8.6'}
-
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   pino-abstract-transport@3.0.0:
@@ -8736,7 +8733,7 @@ snapshots:
       eslint: 10.1.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.1.0(jiti@2.6.1)))(eslint@10.1.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.1.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.1.0(jiti@2.6.1)))(eslint@10.1.0(jiti@2.6.1)))(eslint@10.1.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.1.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@10.1.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@10.1.0(jiti@2.6.1))
@@ -8769,7 +8766,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.1.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.54.0(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.1.0(jiti@2.6.1)))(eslint@10.1.0(jiti@2.6.1)))(eslint@10.1.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -8784,7 +8781,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.1.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.54.0(eslint@10.1.0(jiti@2.6.1))(typescript@5.9.3))(eslint@10.1.0(jiti@2.6.1)))(eslint@10.1.0(jiti@2.6.1)))(eslint@10.1.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -9039,9 +9036,9 @@ snapshots:
       reusify: 1.1.0
       xtend: 4.0.2
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -9585,7 +9582,7 @@ snapshots:
     dependencies:
       commander: 14.0.3
       listr2: 9.0.5
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       string-argv: 0.3.2
       tinyexec: 1.0.4
       yaml: 2.8.2
@@ -9670,7 +9667,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 4.0.4
 
   mime-db@1.52.0: {}
 
@@ -9896,9 +9893,7 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
-
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   pino-abstract-transport@3.0.0:
     dependencies:
@@ -10574,8 +10569,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinyrainbow@3.0.3: {}
 
@@ -10806,8 +10801,8 @@ snapshots:
   vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.2
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.8
       rollup: 4.59.0
       tinyglobby: 0.2.15
@@ -10833,7 +10828,7 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.2

--- a/shared/schemas/flight.ts
+++ b/shared/schemas/flight.ts
@@ -6,8 +6,8 @@ export const flightLookupRequestSchema = z.object({
     .min(3)
     .max(10)
     .regex(
-      /^[A-Z]{2,3}\d{1,4}$/i,
-      "Format: airline code + number (e.g., UA123)",
+      /^[A-Z\d]{2,3}\d{1,4}$/i,
+      "Format: airline code + number (e.g., UA123, G4123)",
     ),
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Format: YYYY-MM-DD"),
 });

--- a/shared/schemas/flight.ts
+++ b/shared/schemas/flight.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+export const flightLookupRequestSchema = z.object({
+  flightNumber: z
+    .string()
+    .min(3)
+    .max(10)
+    .regex(
+      /^[A-Z]{2,3}\d{1,4}$/i,
+      "Format: airline code + number (e.g., UA123)",
+    ),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Format: YYYY-MM-DD"),
+});
+
+export const flightLookupResultSchema = z.object({
+  departureAirport: z.object({ iata: z.string().nullable(), name: z.string() }),
+  departureTime: z.string(),
+  arrivalAirport: z.object({ iata: z.string().nullable(), name: z.string() }),
+  arrivalTime: z.string(),
+});
+
+export const flightLookupResponseSchema = z.discriminatedUnion("available", [
+  z.object({
+    available: z.literal(true),
+    flight: flightLookupResultSchema.nullable(),
+  }),
+  z.object({ available: z.literal(false) }),
+]);
+
+export type FlightLookupRequest = z.infer<typeof flightLookupRequestSchema>;
+export type FlightLookupResult = z.infer<typeof flightLookupResultSchema>;
+export type FlightLookupResponse = z.infer<typeof flightLookupResponseSchema>;

--- a/shared/schemas/index.ts
+++ b/shared/schemas/index.ts
@@ -167,3 +167,13 @@ export {
   updatePhotoCaptionSchema,
   type UpdatePhotoCaptionInput,
 } from "./photo";
+
+// Re-export flight schemas
+export {
+  flightLookupRequestSchema,
+  flightLookupResultSchema,
+  flightLookupResponseSchema,
+  type FlightLookupRequest,
+  type FlightLookupResult,
+  type FlightLookupResponse,
+} from "./flight";

--- a/shared/schemas/member-travel.ts
+++ b/shared/schemas/member-travel.ts
@@ -18,6 +18,7 @@ const baseMemberTravelSchema = z.object({
       error: "Details must not exceed 500 characters",
     })
     .optional(),
+  flightNumber: z.string().max(10).optional(),
 });
 
 /**
@@ -50,6 +51,7 @@ const memberTravelEntitySchema = z.object({
   time: z.date(),
   location: z.string().nullable(),
   details: z.string().nullable(),
+  flightNumber: z.string().nullable(),
   deletedAt: z.date().nullable(),
   deletedBy: z.string().nullable(),
   createdAt: z.date(),

--- a/shared/types/flight.ts
+++ b/shared/types/flight.ts
@@ -1,0 +1,5 @@
+export type {
+  FlightLookupRequest,
+  FlightLookupResult,
+  FlightLookupResponse,
+} from "../schemas/flight.js";

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -140,3 +140,10 @@ export type {
   UploadPhotosResponse,
   UpdatePhotoResponse,
 } from "./photo";
+
+// Re-export flight types
+export type {
+  FlightLookupRequest,
+  FlightLookupResult,
+  FlightLookupResponse,
+} from "./flight";

--- a/shared/types/member-travel.ts
+++ b/shared/types/member-travel.ts
@@ -15,6 +15,7 @@ export interface MemberTravel {
   time: Date;
   location: string | null;
   details: string | null;
+  flightNumber: string | null;
   deletedAt: Date | null;
   deletedBy: string | null;
   createdAt: Date;


### PR DESCRIPTION
## Summary

- **Flight number lookup**: Users can enter a flight number (e.g., UA123) in member travel forms to auto-fill departure/arrival time and airport location via AeroDataBox API
- **Info panel improvements**: Accommodation and event cards now support edit/delete, empty states show "add" links with proper permission gates, card backgrounds match description section
- **Mobile UX**: Tab bar moved to bottom, FAB raised above it with smooth fade-in animation

## Flight Lookup Details

- New `FlightLookupInput` component with inline date picker (self-contained, no circular dependency)
- Backend proxy through Fastify with PostgreSQL caching (3hr TTL, negative caching for 204s)
- AeroDataBox API via RapidAPI (600 req/month free tier)
- Integrated into create/edit dialogs, onboarding wizard, and detail sheet
- 14 backend tests (10 unit + 4 integration)

## Info Panel Fixes

- Accommodation detail sheet now supports edit/delete (was hardcoded to `canEdit={false}`)
- Today section events now support edit/delete with proper permissions
- Cache invalidation fixed for delete/restore from info panel (list cache fallback)
- Empty states: "+ Add accommodation" (organizer only), "+ Add an event" (permission-gated)
- Card backgrounds unified with `bg-card linen-texture`

## Test plan

- [ ] Enter flight number in create travel dialog, verify time + location auto-fill
- [ ] Verify flight lookup works in onboarding wizard (arrival + departure steps)
- [ ] Verify flight number displayed in travel detail sheet
- [ ] Test invalid flight number format shows error
- [ ] Test flight not found shows appropriate message
- [ ] Verify accommodation edit/delete works from info panel
- [ ] Verify event edit/delete works from today section
- [ ] Verify "+ Add" links respect permissions (organizer vs member)
- [ ] Verify mobile tab bar at bottom, FAB above it with smooth animation
- [ ] Run `pnpm typecheck` — passes
- [ ] Run API flight tests — 14/14 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)