### PR TITLE
Add legal pages and SMS consent flow for 10DLC compliance

### DIFF
--- a/apps/api/src/controllers/auth.controller.ts
+++ b/apps/api/src/controllers/auth.controller.ts
@@ -93,7 +93,7 @@ export const authController = {
     reply: FastifyReply,
   ) {
     // Body is validated by Fastify route schema
-    const { phoneNumber, code } = request.body;
+    const { phoneNumber, code, smsConsent } = request.body;
 
     // Validate phone number format and get E.164 format
     const phoneValidation = validatePhoneNumber(phoneNumber);
@@ -154,6 +154,11 @@ export const authController = {
 
       // Get existing user or create new one
       const user = await authService.getOrCreateUser(e164PhoneNumber);
+
+      // Record SMS consent if provided
+      if (smsConsent) {
+        await authService.recordSmsConsent(user.id, "1.0");
+      }
 
       // Process any pending invitations for this phone number (fault-tolerant: awaited but wrapped in try/catch so failures don't break auth)
       try {

--- a/apps/api/src/db/migrations/0025_jazzy_echo.sql
+++ b/apps/api/src/db/migrations/0025_jazzy_echo.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "users" ADD COLUMN "sms_consent_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN "sms_consent_version" varchar(20);

--- a/apps/api/src/db/migrations/meta/0025_snapshot.json
+++ b/apps/api/src/db/migrations/meta/0025_snapshot.json
@@ -1,0 +1,2605 @@
+{
+  "id": "e1974eee-39af-4f75-9cd5-48dddab89ca5",
+  "prevId": "c4d2110b-269d-41ee-843d-fccb75a855a6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accommodations": {
+      "name": "accommodations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "check_in": {
+          "name": "check_in",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_out": {
+          "name": "check_out",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "links": {
+          "name": "links",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accommodations_trip_id_idx": {
+          "name": "accommodations_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_created_by_idx": {
+          "name": "accommodations_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_check_in_idx": {
+          "name": "accommodations_check_in_idx",
+          "columns": [
+            {
+              "expression": "check_in",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_deleted_at_idx": {
+          "name": "accommodations_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_trip_id_deleted_at_idx": {
+          "name": "accommodations_trip_id_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_trip_id_not_deleted_idx": {
+          "name": "accommodations_trip_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accommodations\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accommodations_trip_id_trips_id_fk": {
+          "name": "accommodations_trip_id_trips_id_fk",
+          "tableFrom": "accommodations",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accommodations_created_by_users_id_fk": {
+          "name": "accommodations_created_by_users_id_fk",
+          "tableFrom": "accommodations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "accommodations_deleted_by_users_id_fk": {
+          "name": "accommodations_deleted_by_users_id_fk",
+          "tableFrom": "accommodations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_attempts": {
+      "name": "auth_attempts",
+      "schema": "",
+      "columns": {
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_failed_at": {
+          "name": "last_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blacklisted_tokens": {
+      "name": "blacklisted_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "jti": {
+          "name": "jti",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blacklisted_tokens_expires_at_idx": {
+          "name": "blacklisted_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blacklisted_tokens_user_id_users_id_fk": {
+          "name": "blacklisted_tokens_user_id_users_id_fk",
+          "tableFrom": "blacklisted_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "blacklisted_tokens_jti_unique": {
+          "name": "blacklisted_tokens_jti_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "jti"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meetup_location": {
+          "name": "meetup_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meetup_time": {
+          "name": "meetup_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_day": {
+          "name": "all_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_optional": {
+          "name": "is_optional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "links": {
+          "name": "links",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_trip_id_idx": {
+          "name": "events_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_created_by_idx": {
+          "name": "events_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_start_time_idx": {
+          "name": "events_start_time_idx",
+          "columns": [
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_deleted_at_idx": {
+          "name": "events_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_trip_id_deleted_at_idx": {
+          "name": "events_trip_id_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_trip_id_not_deleted_idx": {
+          "name": "events_trip_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_trip_id_trips_id_fk": {
+          "name": "events_trip_id_trips_id_fk",
+          "tableFrom": "events",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_created_by_users_id_fk": {
+          "name": "events_created_by_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_deleted_by_users_id_fk": {
+          "name": "events_deleted_by_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flight_cache": {
+      "name": "flight_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "flight_number": {
+          "name": "flight_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "flight_cache_flight_number_date_unique": {
+          "name": "flight_cache_flight_number_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "flight_number",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_phone": {
+          "name": "invitee_phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitations_trip_id_idx": {
+          "name": "invitations_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_invitee_phone_idx": {
+          "name": "invitations_invitee_phone_idx",
+          "columns": [
+            {
+              "expression": "invitee_phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_trip_id_trips_id_fk": {
+          "name": "invitations_trip_id_trips_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_id_users_id_fk": {
+          "name": "invitations_inviter_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitations_trip_phone_unique": {
+          "name": "invitations_trip_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trip_id",
+            "invitee_phone"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member_travel": {
+      "name": "member_travel",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "travel_type": {
+          "name": "travel_type",
+          "type": "member_travel_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flight_number": {
+          "name": "flight_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_travel_trip_id_idx": {
+          "name": "member_travel_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_member_id_idx": {
+          "name": "member_travel_member_id_idx",
+          "columns": [
+            {
+              "expression": "member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_time_idx": {
+          "name": "member_travel_time_idx",
+          "columns": [
+            {
+              "expression": "time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_deleted_at_idx": {
+          "name": "member_travel_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_member_id_deleted_at_idx": {
+          "name": "member_travel_member_id_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_trip_id_deleted_at_idx": {
+          "name": "member_travel_trip_id_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_trip_id_not_deleted_idx": {
+          "name": "member_travel_trip_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"member_travel\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_travel_trip_id_trips_id_fk": {
+          "name": "member_travel_trip_id_trips_id_fk",
+          "tableFrom": "member_travel",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_travel_member_id_members_id_fk": {
+          "name": "member_travel_member_id_members_id_fk",
+          "tableFrom": "member_travel",
+          "tableTo": "members",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_travel_deleted_by_users_id_fk": {
+          "name": "member_travel_deleted_by_users_id_fk",
+          "tableFrom": "member_travel",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "rsvp_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'no_response'"
+        },
+        "is_organizer": {
+          "name": "is_organizer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "share_phone": {
+          "name": "share_phone",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "calendar_excluded": {
+          "name": "calendar_excluded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "members_trip_id_idx": {
+          "name": "members_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "members_user_id_idx": {
+          "name": "members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "members_trip_id_is_organizer_idx": {
+          "name": "members_trip_id_is_organizer_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_organizer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "members_trip_id_trips_id_fk": {
+          "name": "members_trip_id_trips_id_fk",
+          "tableFrom": "members",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "members_user_id_users_id_fk": {
+          "name": "members_user_id_users_id_fk",
+          "tableFrom": "members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "members_trip_user_unique": {
+          "name": "members_trip_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trip_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_reactions": {
+      "name": "message_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_reactions_message_id_idx": {
+          "name": "message_reactions_message_id_idx",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_reactions_user_id_idx": {
+          "name": "message_reactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_reactions_message_id_messages_id_fk": {
+          "name": "message_reactions_message_id_messages_id_fk",
+          "tableFrom": "message_reactions",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_reactions_user_id_users_id_fk": {
+          "name": "message_reactions_user_id_users_id_fk",
+          "tableFrom": "message_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "message_reactions_message_user_emoji_unique": {
+          "name": "message_reactions_message_user_emoji_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id",
+            "user_id",
+            "emoji"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_trip_id_created_at_idx": {
+          "name": "messages_trip_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_parent_id_idx": {
+          "name": "messages_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_author_id_idx": {
+          "name": "messages_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_trip_toplevel_idx": {
+          "name": "messages_trip_toplevel_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"messages\".\"parent_id\" IS NULL AND \"messages\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_trip_id_not_deleted_idx": {
+          "name": "messages_trip_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"messages\".\"deleted_at\" IS NULL AND \"messages\".\"parent_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_trip_id_trips_id_fk": {
+          "name": "messages_trip_id_trips_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_author_id_users_id_fk": {
+          "name": "messages_author_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_parent_id_messages_id_fk": {
+          "name": "messages_parent_id_messages_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_deleted_by_users_id_fk": {
+          "name": "messages_deleted_by_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.muted_members": {
+      "name": "muted_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted_by": {
+          "name": "muted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "muted_members_trip_id_trips_id_fk": {
+          "name": "muted_members_trip_id_trips_id_fk",
+          "tableFrom": "muted_members",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "muted_members_user_id_users_id_fk": {
+          "name": "muted_members_user_id_users_id_fk",
+          "tableFrom": "muted_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "muted_members_muted_by_users_id_fk": {
+          "name": "muted_members_muted_by_users_id_fk",
+          "tableFrom": "muted_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "muted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "muted_members_trip_user_unique": {
+          "name": "muted_members_trip_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trip_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daily_itinerary": {
+          "name": "daily_itinerary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "trip_messages": {
+          "name": "trip_messages",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_user_id_users_id_fk": {
+          "name": "notification_preferences_user_id_users_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_preferences_trip_id_trips_id_fk": {
+          "name": "notification_preferences_trip_id_trips_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_preferences_user_trip_unique": {
+          "name": "notification_preferences_user_trip_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "trip_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_created_at_idx": {
+          "name": "notifications_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_id_created_at_desc_idx": {
+          "name": "notifications_user_id_created_at_desc_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notifications\".\"read_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_trip_user_created_at_idx": {
+          "name": "notifications_trip_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_trip_id_trips_id_fk": {
+          "name": "notifications_trip_id_trips_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_entries": {
+      "name": "rate_limit_entries",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rate_limit_entries_expires_at_idx": {
+          "name": "rate_limit_entries_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sent_reminders": {
+      "name": "sent_reminders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sent_reminders_type_ref_idx": {
+          "name": "sent_reminders_type_ref_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sent_reminders_user_id_users_id_fk": {
+          "name": "sent_reminders_user_id_users_id_fk",
+          "tableFrom": "sent_reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sent_reminders_type_ref_user_unique": {
+          "name": "sent_reminders_type_ref_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "type",
+            "reference_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trip_photos": {
+      "name": "trip_photos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "photo_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trip_photos_trip_id_idx": {
+          "name": "trip_photos_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trip_photos_uploaded_by_idx": {
+          "name": "trip_photos_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trip_photos_trip_id_trips_id_fk": {
+          "name": "trip_photos_trip_id_trips_id_fk",
+          "tableFrom": "trip_photos",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_photos_uploaded_by_users_id_fk": {
+          "name": "trip_photos_uploaded_by_users_id_fk",
+          "tableFrom": "trip_photos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trips": {
+      "name": "trips",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_lat": {
+          "name": "destination_lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_lon": {
+          "name": "destination_lon",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_display_name": {
+          "name": "destination_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_timezone": {
+          "name": "preferred_timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_id": {
+          "name": "theme_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_font": {
+          "name": "theme_font",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allow_members_to_add_events": {
+          "name": "allow_members_to_add_events",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_all_members": {
+          "name": "show_all_members",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancelled": {
+          "name": "cancelled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trips_created_by_idx": {
+          "name": "trips_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trips_created_by_users_id_fk": {
+          "name": "trips_created_by_users_id_fk",
+          "tableFrom": "trips",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_photo_url": {
+          "name": "profile_photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handles": {
+          "name": "handles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature_unit": {
+          "name": "temperature_unit",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'celsius'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "calendar_token": {
+          "name": "calendar_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_at": {
+          "name": "sms_consent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_version": {
+          "name": "sms_consent_version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_phone_number_idx": {
+          "name": "users_phone_number_idx",
+          "columns": [
+            {
+              "expression": "phone_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_phone_number_unique": {
+          "name": "users_phone_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone_number"
+          ]
+        },
+        "users_calendar_token_unique": {
+          "name": "users_calendar_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "calendar_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weather_cache": {
+      "name": "weather_cache",
+      "schema": "",
+      "columns": {
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "weather_cache_trip_id_trips_id_fk": {
+          "name": "weather_cache_trip_id_trips_id_fk",
+          "tableFrom": "weather_cache",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.event_type": {
+      "name": "event_type",
+      "schema": "public",
+      "values": [
+        "travel",
+        "meal",
+        "activity"
+      ]
+    },
+    "public.invitation_status": {
+      "name": "invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "declined",
+        "failed"
+      ]
+    },
+    "public.member_travel_type": {
+      "name": "member_travel_type",
+      "schema": "public",
+      "values": [
+        "arrival",
+        "departure"
+      ]
+    },
+    "public.photo_status": {
+      "name": "photo_status",
+      "schema": "public",
+      "values": [
+        "processing",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.rsvp_status": {
+      "name": "rsvp_status",
+      "schema": "public",
+      "values": [
+        "going",
+        "not_going",
+        "maybe",
+        "no_response"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1774477047713,
       "tag": "0024_wandering_vapor",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1774721830963,
+      "tag": "0025_jazzy_echo",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -33,6 +33,8 @@ export const users = pgTable(
       .notNull()
       .defaultNow(),
     calendarToken: uuid("calendar_token").unique(),
+    smsConsentAt: timestamp("sms_consent_at", { withTimezone: true }),
+    smsConsentVersion: varchar("sms_consent_version", { length: 20 }),
     updatedAt: timestamp("updated_at", { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/apps/api/src/services/auth.service.ts
+++ b/apps/api/src/services/auth.service.ts
@@ -98,6 +98,13 @@ export interface IAuthService {
    * @param phoneNumber - The phone number to reset (E.164 format)
    */
   resetFailedAttempts(phoneNumber: string): Promise<void>;
+
+  /**
+   * Records SMS consent timestamp and disclosure version on a user record
+   * @param userId - The UUID of the user
+   * @param version - The disclosure version shown (e.g., "1.0")
+   */
+  recordSmsConsent(userId: string, version: string): Promise<void>;
 }
 
 /** Maximum number of failed verification attempts before lockout */
@@ -362,5 +369,16 @@ export class AuthService implements IAuthService {
     await this.db
       .delete(authAttempts)
       .where(eq(authAttempts.phoneNumber, phoneNumber));
+  }
+
+  async recordSmsConsent(userId: string, version: string): Promise<void> {
+    await this.db
+      .update(users)
+      .set({
+        smsConsentAt: new Date(),
+        smsConsentVersion: version,
+        updatedAt: new Date(),
+      })
+      .where(eq(users.id, userId));
   }
 }

--- a/apps/api/tests/integration/account-lockout.test.ts
+++ b/apps/api/tests/integration/account-lockout.test.ts
@@ -20,7 +20,7 @@ describe("Account Lockout Integration", () => {
     await app.inject({
       method: "POST",
       url: "/api/auth/request-code",
-      payload: { phoneNumber },
+      payload: { phoneNumber, smsConsent: true },
     });
   }
 
@@ -28,7 +28,7 @@ describe("Account Lockout Integration", () => {
     return app.inject({
       method: "POST",
       url: "/api/auth/verify-code",
-      payload: { phoneNumber, code },
+      payload: { phoneNumber, code, smsConsent: true },
     });
   }
 

--- a/apps/api/tests/integration/auth.request-code.test.ts
+++ b/apps/api/tests/integration/auth.request-code.test.ts
@@ -37,6 +37,7 @@ describe("POST /api/auth/request-code", () => {
         url: "/api/auth/request-code",
         payload: {
           phoneNumber: newPhone(),
+          smsConsent: true,
         },
       });
 
@@ -60,6 +61,7 @@ describe("POST /api/auth/request-code", () => {
           url: "/api/auth/request-code",
           payload: {
             phoneNumber,
+            smsConsent: true,
           },
         });
 
@@ -78,7 +80,7 @@ describe("POST /api/auth/request-code", () => {
       const response1 = await app.inject({
         method: "POST",
         url: "/api/auth/request-code",
-        payload: { phoneNumber },
+        payload: { phoneNumber, smsConsent: true },
       });
 
       expect(response1.statusCode).toBe(200);
@@ -86,7 +88,7 @@ describe("POST /api/auth/request-code", () => {
       const response2 = await app.inject({
         method: "POST",
         url: "/api/auth/request-code",
-        payload: { phoneNumber },
+        payload: { phoneNumber, smsConsent: true },
       });
 
       expect(response2.statusCode).toBe(200);
@@ -124,6 +126,7 @@ describe("POST /api/auth/request-code", () => {
         url: "/api/auth/request-code",
         payload: {
           phoneNumber: "+123",
+          smsConsent: true,
         },
       });
 
@@ -142,6 +145,7 @@ describe("POST /api/auth/request-code", () => {
         url: "/api/auth/request-code",
         payload: {
           phoneNumber: "+123456789012345678901",
+          smsConsent: true,
         },
       });
 
@@ -168,6 +172,7 @@ describe("POST /api/auth/request-code", () => {
           url: "/api/auth/request-code",
           payload: {
             phoneNumber,
+            smsConsent: true,
           },
         });
 
@@ -192,6 +197,7 @@ describe("POST /api/auth/request-code", () => {
         url: "/api/auth/request-code",
         payload: {
           phoneNumber: "invalid",
+          smsConsent: true,
         },
       });
 
@@ -218,7 +224,7 @@ describe("POST /api/auth/request-code", () => {
         const response = await app.inject({
           method: "POST",
           url: "/api/auth/request-code",
-          payload: { phoneNumber },
+          payload: { phoneNumber, smsConsent: true },
         });
 
         expect(response.statusCode).toBe(200);
@@ -235,14 +241,14 @@ describe("POST /api/auth/request-code", () => {
         await app.inject({
           method: "POST",
           url: "/api/auth/request-code",
-          payload: { phoneNumber },
+          payload: { phoneNumber, smsConsent: true },
         });
       }
 
       const response = await app.inject({
         method: "POST",
         url: "/api/auth/request-code",
-        payload: { phoneNumber },
+        payload: { phoneNumber, smsConsent: true },
       });
 
       expect(response.statusCode).toBe(429);
@@ -268,14 +274,14 @@ describe("POST /api/auth/request-code", () => {
         await app.inject({
           method: "POST",
           url: "/api/auth/request-code",
-          payload: { phoneNumber: phoneNumber1 },
+          payload: { phoneNumber: phoneNumber1, smsConsent: true },
         });
       }
 
       const response1 = await app.inject({
         method: "POST",
         url: "/api/auth/request-code",
-        payload: { phoneNumber: phoneNumber1 },
+        payload: { phoneNumber: phoneNumber1, smsConsent: true },
       });
 
       expect(response1.statusCode).toBe(429);
@@ -283,7 +289,7 @@ describe("POST /api/auth/request-code", () => {
       const response2 = await app.inject({
         method: "POST",
         url: "/api/auth/request-code",
-        payload: { phoneNumber: phoneNumber2 },
+        payload: { phoneNumber: phoneNumber2, smsConsent: true },
       });
 
       expect(response2.statusCode).toBe(200);

--- a/apps/api/tests/integration/auth.verify-code.test.ts
+++ b/apps/api/tests/integration/auth.verify-code.test.ts
@@ -24,7 +24,7 @@ describe("POST /api/auth/verify-code", () => {
     await app.inject({
       method: "POST",
       url: "/api/auth/request-code",
-      payload: { phoneNumber },
+      payload: { phoneNumber, smsConsent: true },
     });
   }
 
@@ -42,6 +42,7 @@ describe("POST /api/auth/verify-code", () => {
         payload: {
           phoneNumber,
           code: "123456",
+          smsConsent: true,
         },
       });
 
@@ -80,6 +81,7 @@ describe("POST /api/auth/verify-code", () => {
         payload: {
           phoneNumber,
           code: "123456",
+          smsConsent: true,
         },
       });
 
@@ -112,6 +114,7 @@ describe("POST /api/auth/verify-code", () => {
         payload: {
           phoneNumber,
           code: "123456",
+          smsConsent: true,
         },
       });
 
@@ -136,6 +139,7 @@ describe("POST /api/auth/verify-code", () => {
         payload: {
           phoneNumber,
           code: "123456",
+          smsConsent: true,
         },
       });
 
@@ -166,6 +170,7 @@ describe("POST /api/auth/verify-code", () => {
         payload: {
           phoneNumber,
           code: "123456",
+          smsConsent: true,
         },
       });
 
@@ -191,6 +196,7 @@ describe("POST /api/auth/verify-code", () => {
         url: "/api/auth/verify-code",
         payload: {
           code: "123456",
+          smsConsent: true,
         },
       });
 
@@ -215,6 +221,7 @@ describe("POST /api/auth/verify-code", () => {
         url: "/api/auth/verify-code",
         payload: {
           phoneNumber: generateUniquePhone(),
+          smsConsent: true,
         },
       });
 
@@ -247,6 +254,7 @@ describe("POST /api/auth/verify-code", () => {
           payload: {
             phoneNumber,
             code: "123456",
+            smsConsent: true,
           },
         });
 
@@ -276,6 +284,7 @@ describe("POST /api/auth/verify-code", () => {
           payload: {
             phoneNumber,
             code,
+            smsConsent: true,
           },
         });
 
@@ -302,6 +311,7 @@ describe("POST /api/auth/verify-code", () => {
         payload: {
           phoneNumber,
           code: "654321",
+          smsConsent: true,
         },
       });
 
@@ -332,6 +342,7 @@ describe("POST /api/auth/verify-code", () => {
         payload: {
           phoneNumber,
           code: "123456",
+          smsConsent: true,
         },
       });
 
@@ -375,7 +386,7 @@ describe("POST /api/auth/verify-code", () => {
       const response1 = await app.inject({
         method: "POST",
         url: "/api/auth/verify-code",
-        payload: { phoneNumber, code: "123456" },
+        payload: { phoneNumber, code: "123456", smsConsent: true },
       });
 
       expect(response1.statusCode).toBe(200);
@@ -385,7 +396,7 @@ describe("POST /api/auth/verify-code", () => {
       const response2 = await app.inject({
         method: "POST",
         url: "/api/auth/verify-code",
-        payload: { phoneNumber, code: "123456" },
+        payload: { phoneNumber, code: "123456", smsConsent: true },
       });
 
       expect(response2.statusCode).toBe(200);
@@ -454,6 +465,7 @@ describe("POST /api/auth/verify-code", () => {
         payload: {
           phoneNumber: inviteePhone,
           code: "123456",
+          smsConsent: true,
         },
       });
 

--- a/apps/api/tests/integration/security.test.ts
+++ b/apps/api/tests/integration/security.test.ts
@@ -143,7 +143,7 @@ describe("Security & Schema Validation", () => {
       const response = await app.inject({
         method: "POST",
         url: "/api/auth/request-code",
-        payload: { phoneNumber: newPhone() },
+        payload: { phoneNumber: newPhone(), smsConsent: true },
       });
 
       expect(response.headers["cache-control"]).toBe(
@@ -217,7 +217,7 @@ describe("Security & Schema Validation", () => {
           await rateLimitApp.inject({
             method: "POST",
             url: "/api/auth/verify-code",
-            payload: { phoneNumber: rateLimitPhone, code: "000000" },
+            payload: { phoneNumber: rateLimitPhone, code: "000000", smsConsent: true },
           });
         }
 
@@ -225,7 +225,7 @@ describe("Security & Schema Validation", () => {
         const response = await rateLimitApp.inject({
           method: "POST",
           url: "/api/auth/verify-code",
-          payload: { phoneNumber: rateLimitPhone, code: "000000" },
+          payload: { phoneNumber: rateLimitPhone, code: "000000", smsConsent: true },
         });
 
         expect(response.statusCode).toBe(429);

--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -6,7 +6,9 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
 import { requestCodeSchema, type RequestCodeInput } from "@journiful/shared";
 import { useAuth } from "@/app/providers/auth-provider";
+import Link from "next/link";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { PhoneInput } from "@/components/ui/phone-input";
 import {
   Form,
@@ -27,14 +29,15 @@ export default function LoginPage() {
     resolver: zodResolver(requestCodeSchema),
     defaultValues: {
       phoneNumber: "",
+      smsConsent: false,
     },
   });
 
   async function onSubmit(data: RequestCodeInput) {
     try {
       setIsSubmitting(true);
-      await login(data.phoneNumber);
-      router.push(`/verify?phone=${encodeURIComponent(data.phoneNumber)}`);
+      await login(data.phoneNumber, data.smsConsent);
+      router.push(`/verify?phone=${encodeURIComponent(data.phoneNumber)}&smsConsent=true`);
     } catch (error) {
       form.setError("phoneNumber", {
         message: error instanceof Error ? error.message : "Request failed",
@@ -92,9 +95,42 @@ export default function LoginPage() {
                 )}
               />
 
+              <div className="flex items-start gap-2">
+                <Checkbox
+                  id="smsConsent"
+                  checked={form.watch("smsConsent")}
+                  onCheckedChange={(checked) =>
+                    form.setValue("smsConsent", checked === true)
+                  }
+                  disabled={isSubmitting}
+                />
+                <label
+                  htmlFor="smsConsent"
+                  className="text-xs text-muted-foreground leading-relaxed"
+                >
+                  I agree to receive text messages from Journiful, including
+                  trip updates, event reminders, and verification codes. Msg
+                  frequency varies. Msg &amp; data rates may apply. Reply STOP
+                  to opt out. Consent is not required to use Journiful.{" "}
+                  <Link
+                    href="/sms-terms"
+                    className="text-primary underline hover:text-primary/80"
+                  >
+                    SMS Terms
+                  </Link>{" "}
+                  &amp;{" "}
+                  <Link
+                    href="/privacy"
+                    className="text-primary underline hover:text-primary/80"
+                  >
+                    Privacy Policy
+                  </Link>
+                </label>
+              </div>
+
               <Button
                 type="submit"
-                disabled={isSubmitting}
+                disabled={isSubmitting || !form.watch("smsConsent")}
                 variant="gradient"
                 className="w-full h-12"
               >
@@ -104,7 +140,21 @@ export default function LoginPage() {
           </Form>
 
           <p className="text-xs text-center text-muted-foreground">
-            By continuing, you agree to our Terms of Service and Privacy Policy
+            By continuing, you agree to our{" "}
+            <Link
+              href="/terms"
+              className="text-primary underline hover:text-primary/80"
+            >
+              Terms of Service
+            </Link>{" "}
+            and{" "}
+            <Link
+              href="/privacy"
+              className="text-primary underline hover:text-primary/80"
+            >
+              Privacy Policy
+            </Link>
+            .
           </p>
         </div>
       </div>

--- a/apps/web/src/app/(auth)/verify/page.tsx
+++ b/apps/web/src/app/(auth)/verify/page.tsx
@@ -25,6 +25,7 @@ function VerifyPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const phoneNumber = searchParams.get("phone") || "";
+  const smsConsent = searchParams.get("smsConsent") === "true";
   const { verify, login } = useAuth();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isResending, setIsResending] = useState(false);
@@ -36,6 +37,7 @@ function VerifyPageContent() {
     defaultValues: {
       phoneNumber,
       code: "",
+      smsConsent,
     },
   });
 
@@ -49,7 +51,7 @@ function VerifyPageContent() {
   async function onSubmit(data: VerifyCodeInput) {
     try {
       setIsSubmitting(true);
-      const result = await verify(data.phoneNumber, data.code);
+      const result = await verify(data.phoneNumber, data.code, data.smsConsent);
 
       if (result.requiresProfile) {
         router.push("/complete-profile");
@@ -68,7 +70,7 @@ function VerifyPageContent() {
     try {
       setIsResending(true);
       setResendSuccess(null);
-      await login(phoneNumber);
+      await login(phoneNumber, smsConsent);
       setResendSuccess("A new code has been sent to your phone");
       form.setValue("code", "");
     } catch (error) {

--- a/apps/web/src/app/(legal)/layout.tsx
+++ b/apps/web/src/app/(legal)/layout.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+
+export default function LegalLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-background linen-texture">
+      <header className="w-full border-b border-border bg-background linen-texture">
+        <div className="mx-auto flex h-14 max-w-3xl items-center px-4">
+          <Link
+            href="/"
+            className="font-display text-2xl font-bold tracking-tight text-foreground"
+          >
+            Journiful
+          </Link>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-3xl px-4 py-12">{children}</main>
+
+      <footer className="border-t border-border bg-background linen-texture">
+        <div className="mx-auto flex max-w-3xl items-center justify-center gap-4 px-4 py-6 text-xs text-muted-foreground">
+          <Link href="/terms" className="hover:text-foreground">
+            Terms of Service
+          </Link>
+          <span aria-hidden="true">&middot;</span>
+          <Link href="/privacy" className="hover:text-foreground">
+            Privacy Policy
+          </Link>
+          <span aria-hidden="true">&middot;</span>
+          <Link href="/sms-terms" className="hover:text-foreground">
+            SMS Terms
+          </Link>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/apps/web/src/app/(legal)/layout.tsx
+++ b/apps/web/src/app/(legal)/layout.tsx
@@ -4,30 +4,43 @@ import Link from "next/link";
 export default function LegalLayout({ children }: { children: ReactNode }) {
   return (
     <div className="min-h-screen bg-background linen-texture">
-      <header className="w-full border-b border-border bg-background linen-texture">
-        <div className="mx-auto flex h-14 max-w-3xl items-center px-4">
+      <header className="sticky top-0 z-40 w-full border-b border-border bg-background linen-texture">
+        <div className="mx-auto flex h-14 max-w-2xl items-center justify-between px-6">
           <Link
             href="/"
             className="font-display text-2xl font-bold tracking-tight text-foreground"
           >
             Journiful
           </Link>
+          <Link
+            href="/login"
+            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Sign in
+          </Link>
         </div>
       </header>
 
-      <main className="mx-auto max-w-3xl px-4 py-12">{children}</main>
+      <main className="mx-auto max-w-2xl px-6 py-16">{children}</main>
 
-      <footer className="border-t border-border bg-background linen-texture">
-        <div className="mx-auto flex max-w-3xl items-center justify-center gap-4 px-4 py-6 text-xs text-muted-foreground">
-          <Link href="/terms" className="hover:text-foreground">
+      <footer className="border-t border-border">
+        <div className="mx-auto flex max-w-2xl flex-wrap items-center justify-center gap-x-6 gap-y-2 px-6 py-8 text-sm text-muted-foreground">
+          <Link
+            href="/terms"
+            className="hover:text-foreground transition-colors"
+          >
             Terms of Service
           </Link>
-          <span aria-hidden="true">&middot;</span>
-          <Link href="/privacy" className="hover:text-foreground">
+          <Link
+            href="/privacy"
+            className="hover:text-foreground transition-colors"
+          >
             Privacy Policy
           </Link>
-          <span aria-hidden="true">&middot;</span>
-          <Link href="/sms-terms" className="hover:text-foreground">
+          <Link
+            href="/sms-terms"
+            className="hover:text-foreground transition-colors"
+          >
             SMS Terms
           </Link>
         </div>

--- a/apps/web/src/app/(legal)/privacy/page.tsx
+++ b/apps/web/src/app/(legal)/privacy/page.tsx
@@ -1,0 +1,205 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy",
+  description:
+    "Journiful Privacy Policy. Learn how we collect, use, and protect your personal information including phone number, trip data, and SMS communications.",
+};
+
+export default function PrivacyPolicyPage() {
+  return (
+    <article className="prose prose-neutral max-w-none">
+      <h1 className="font-playfair text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+        Privacy Policy
+      </h1>
+      <p className="text-sm text-muted-foreground">
+        Last updated: March 28, 2026
+        <br />
+        Effective date: March 28, 2026
+      </p>
+      <p>
+        This Privacy Policy describes how Journiful (&quot;we,&quot;
+        &quot;us,&quot; or &quot;our&quot;) collects, uses, and shares
+        information when you use our trip planning application and related
+        services. This policy is provided for informational purposes and does
+        not constitute legal advice.
+      </p>
+
+      <h2 className="font-accent text-xl font-semibold text-foreground">
+        Information We Collect
+      </h2>
+      <p>We collect the following types of information:</p>
+      <ul className="list-disc pl-6 text-foreground">
+        <li>
+          <strong>Phone number</strong> &mdash; used for account registration,
+          authentication, and SMS communications
+        </li>
+        <li>
+          <strong>Display name</strong> &mdash; the name you choose to identify
+          yourself within trips
+        </li>
+        <li>
+          <strong>Trip data</strong> &mdash; itineraries, events,
+          accommodations, messages, and other content you create or contribute to
+        </li>
+        <li>
+          <strong>Usage data</strong> &mdash; how you interact with the
+          application, including pages visited, features used, and actions taken
+        </li>
+        <li>
+          <strong>Device information</strong> &mdash; browser type, operating
+          system, and device identifiers used for security and troubleshooting
+        </li>
+      </ul>
+
+      <h2 className="font-accent text-xl font-semibold text-foreground">
+        How We Use Your Information
+      </h2>
+      <ul className="list-disc pl-6 text-foreground">
+        <li>
+          <strong>App functionality</strong> &mdash; to provide, maintain, and
+          improve the Journiful trip planning experience
+        </li>
+        <li>
+          <strong>SMS communications</strong> &mdash; to send trip updates, event
+          reminders, invite notifications, and verification codes
+        </li>
+        <li>
+          <strong>Analytics</strong> &mdash; to understand usage patterns and
+          improve our service
+        </li>
+        <li>
+          <strong>Security</strong> &mdash; to detect and prevent fraud, abuse,
+          and unauthorized access
+        </li>
+      </ul>
+
+      <h2 className="font-accent text-xl font-semibold text-foreground">
+        SMS Data Collection and Use
+      </h2>
+      <p>
+        When you opt in to Journiful Trip Notifications, we collect your phone
+        number and a record of your consent (including the date, time, and
+        version of the disclosure you agreed to). This data is used solely to
+        send you transactional SMS messages related to your Journiful account
+        and trip activity.
+      </p>
+      <p>
+        <strong>
+          Your phone number and opt-in data will not be shared with or sold to
+          third parties for marketing purposes.
+        </strong>{" "}
+        SMS data is shared only with our messaging service provider (Twilio) for
+        the purpose of delivering messages to you.
+      </p>
+      <p>
+        For full details on our SMS program, see our{" "}
+        <Link href="/sms-terms" className="text-primary underline">
+          SMS Terms &amp; Conditions
+        </Link>
+        .
+      </p>
+
+      <h2 className="font-accent text-xl font-semibold text-foreground">
+        Data Sharing
+      </h2>
+      <p>
+        We do <strong>not</strong> sell your personal data. We may share limited
+        information with:
+      </p>
+      <ul className="list-disc pl-6 text-foreground">
+        <li>
+          <strong>Service providers</strong> &mdash; trusted third parties such
+          as Twilio (SMS delivery), cloud hosting providers, and analytics
+          services that help us operate Journiful
+        </li>
+        <li>
+          <strong>Legal requirements</strong> &mdash; when required by law,
+          regulation, or legal process
+        </li>
+        <li>
+          <strong>Safety</strong> &mdash; to protect the rights, safety, or
+          property of Journiful, our users, or the public
+        </li>
+      </ul>
+
+      <h2 className="font-accent text-xl font-semibold text-foreground">
+        Data Retention and Deletion
+      </h2>
+      <p>
+        We retain your personal information for as long as your account is
+        active or as needed to provide you with our services. You may request
+        deletion of your account and associated data at any time by contacting{" "}
+        <a
+          href="mailto:support@journiful.com"
+          className="text-primary underline"
+        >
+          support@journiful.com
+        </a>
+        . Upon receiving a deletion request, we will remove your data within 30
+        days, except where retention is required by law.
+      </p>
+
+      <h2 className="font-accent text-xl font-semibold text-foreground">
+        Your Rights
+      </h2>
+      <p>You have the right to:</p>
+      <ul className="list-disc pl-6 text-foreground">
+        <li>
+          <strong>Access</strong> the personal information we hold about you
+        </li>
+        <li>
+          <strong>Correct</strong> inaccurate or incomplete information
+        </li>
+        <li>
+          <strong>Delete</strong> your account and personal data
+        </li>
+      </ul>
+      <p>
+        To exercise any of these rights, contact{" "}
+        <a
+          href="mailto:support@journiful.com"
+          className="text-primary underline"
+        >
+          support@journiful.com
+        </a>
+        .
+      </p>
+
+      <h2 className="font-accent text-xl font-semibold text-foreground">
+        Children&apos;s Privacy
+      </h2>
+      <p>
+        Journiful is not directed to children under the age of 13. We do not
+        knowingly collect personal information from children under 13. If we
+        become aware that we have collected data from a child under 13, we will
+        take steps to delete it promptly.
+      </p>
+
+      <h2 className="font-accent text-xl font-semibold text-foreground">
+        Changes to This Policy
+      </h2>
+      <p>
+        We may update this Privacy Policy from time to time. When we make
+        material changes, we will notify you through the Journiful application
+        or via SMS. Your continued use of Journiful after changes take effect
+        constitutes acceptance of the updated policy.
+      </p>
+
+      <h2 className="font-accent text-xl font-semibold text-foreground">
+        Contact Us
+      </h2>
+      <p>
+        If you have questions about this Privacy Policy, contact us at{" "}
+        <a
+          href="mailto:support@journiful.com"
+          className="text-primary underline"
+        >
+          support@journiful.com
+        </a>
+        .
+      </p>
+    </article>
+  );
+}

--- a/apps/web/src/app/(legal)/privacy/page.tsx
+++ b/apps/web/src/app/(legal)/privacy/page.tsx
@@ -2,204 +2,284 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 export const metadata: Metadata = {
-  title: "Privacy Policy",
+  title: "Privacy Policy | Journiful",
   description:
-    "Journiful Privacy Policy. Learn how we collect, use, and protect your personal information including phone number, trip data, and SMS communications.",
+    "Journiful Privacy Policy. How we collect, use, and protect your personal information including phone number, trip data, and SMS communications.",
 };
 
 export default function PrivacyPolicyPage() {
   return (
-    <article className="prose prose-neutral max-w-none">
-      <h1 className="font-playfair text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-        Privacy Policy
-      </h1>
-      <p className="text-sm text-muted-foreground">
-        Last updated: March 28, 2026
-        <br />
-        Effective date: March 28, 2026
-      </p>
-      <p>
-        This Privacy Policy describes how Journiful (&quot;we,&quot;
-        &quot;us,&quot; or &quot;our&quot;) collects, uses, and shares
-        information when you use our trip planning application and related
-        services. This policy is provided for informational purposes and does
-        not constitute legal advice.
-      </p>
+    <article>
+      <header className="mb-12">
+        <h1 className="font-playfair text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+          Privacy Policy
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Last updated: March 28, 2026 &middot; Effective: March 28, 2026
+        </p>
+      </header>
 
-      <h2 className="font-accent text-xl font-semibold text-foreground">
-        Information We Collect
-      </h2>
-      <p>We collect the following types of information:</p>
-      <ul className="list-disc pl-6 text-foreground">
-        <li>
-          <strong>Phone number</strong> &mdash; used for account registration,
-          authentication, and SMS communications
-        </li>
-        <li>
-          <strong>Display name</strong> &mdash; the name you choose to identify
-          yourself within trips
-        </li>
-        <li>
-          <strong>Trip data</strong> &mdash; itineraries, events,
-          accommodations, messages, and other content you create or contribute to
-        </li>
-        <li>
-          <strong>Usage data</strong> &mdash; how you interact with the
-          application, including pages visited, features used, and actions taken
-        </li>
-        <li>
-          <strong>Device information</strong> &mdash; browser type, operating
-          system, and device identifiers used for security and troubleshooting
-        </li>
-      </ul>
+      <div className="space-y-10 text-[15px] leading-relaxed text-foreground/90">
+        <p>
+          This Privacy Policy describes how Journiful (&ldquo;we,&rdquo;
+          &ldquo;us,&rdquo; or &ldquo;our&rdquo;) collects, uses, and shares
+          information when you use our trip planning application and related
+          services. This document is provided for informational purposes and does
+          not constitute legal advice.
+        </p>
 
-      <h2 className="font-accent text-xl font-semibold text-foreground">
-        How We Use Your Information
-      </h2>
-      <ul className="list-disc pl-6 text-foreground">
-        <li>
-          <strong>App functionality</strong> &mdash; to provide, maintain, and
-          improve the Journiful trip planning experience
-        </li>
-        <li>
-          <strong>SMS communications</strong> &mdash; to send trip updates, event
-          reminders, invite notifications, and verification codes
-        </li>
-        <li>
-          <strong>Analytics</strong> &mdash; to understand usage patterns and
-          improve our service
-        </li>
-        <li>
-          <strong>Security</strong> &mdash; to detect and prevent fraud, abuse,
-          and unauthorized access
-        </li>
-      </ul>
+        <div className="border-t border-border" />
 
-      <h2 className="font-accent text-xl font-semibold text-foreground">
-        SMS Data Collection and Use
-      </h2>
-      <p>
-        When you opt in to Journiful Trip Notifications, we collect your phone
-        number and a record of your consent (including the date, time, and
-        version of the disclosure you agreed to). This data is used solely to
-        send you transactional SMS messages related to your Journiful account
-        and trip activity.
-      </p>
-      <p>
-        <strong>
-          Your phone number and opt-in data will not be shared with or sold to
-          third parties for marketing purposes.
-        </strong>{" "}
-        SMS data is shared only with our messaging service provider (Twilio) for
-        the purpose of delivering messages to you.
-      </p>
-      <p>
-        For full details on our SMS program, see our{" "}
-        <Link href="/sms-terms" className="text-primary underline">
-          SMS Terms &amp; Conditions
-        </Link>
-        .
-      </p>
+        <section>
+          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+            Information We Collect
+          </h2>
+          <p className="mb-3">We collect the following types of information:</p>
+          <dl className="space-y-3">
+            <div>
+              <dt className="font-medium text-foreground">Phone number</dt>
+              <dd className="text-foreground/80">
+                Used for account registration, authentication, and SMS
+                communications.
+              </dd>
+            </div>
+            <div>
+              <dt className="font-medium text-foreground">Display name</dt>
+              <dd className="text-foreground/80">
+                The name you choose to identify yourself within trips.
+              </dd>
+            </div>
+            <div>
+              <dt className="font-medium text-foreground">Trip data</dt>
+              <dd className="text-foreground/80">
+                Itineraries, events, accommodations, messages, and other content
+                you create or contribute to.
+              </dd>
+            </div>
+            <div>
+              <dt className="font-medium text-foreground">Usage data</dt>
+              <dd className="text-foreground/80">
+                How you interact with the application, including pages visited
+                and features used.
+              </dd>
+            </div>
+            <div>
+              <dt className="font-medium text-foreground">
+                Device information
+              </dt>
+              <dd className="text-foreground/80">
+                Browser type, operating system, and device identifiers used for
+                security and troubleshooting.
+              </dd>
+            </div>
+          </dl>
+        </section>
 
-      <h2 className="font-accent text-xl font-semibold text-foreground">
-        Data Sharing
-      </h2>
-      <p>
-        We do <strong>not</strong> sell your personal data. We may share limited
-        information with:
-      </p>
-      <ul className="list-disc pl-6 text-foreground">
-        <li>
-          <strong>Service providers</strong> &mdash; trusted third parties such
-          as Twilio (SMS delivery), cloud hosting providers, and analytics
-          services that help us operate Journiful
-        </li>
-        <li>
-          <strong>Legal requirements</strong> &mdash; when required by law,
-          regulation, or legal process
-        </li>
-        <li>
-          <strong>Safety</strong> &mdash; to protect the rights, safety, or
-          property of Journiful, our users, or the public
-        </li>
-      </ul>
+        <div className="border-t border-border" />
 
-      <h2 className="font-accent text-xl font-semibold text-foreground">
-        Data Retention and Deletion
-      </h2>
-      <p>
-        We retain your personal information for as long as your account is
-        active or as needed to provide you with our services. You may request
-        deletion of your account and associated data at any time by contacting{" "}
-        <a
-          href="mailto:support@journiful.com"
-          className="text-primary underline"
-        >
-          support@journiful.com
-        </a>
-        . Upon receiving a deletion request, we will remove your data within 30
-        days, except where retention is required by law.
-      </p>
+        <section>
+          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+            How We Use Your Information
+          </h2>
+          <dl className="space-y-3">
+            <div>
+              <dt className="font-medium text-foreground">App functionality</dt>
+              <dd className="text-foreground/80">
+                To provide, maintain, and improve the Journiful trip planning
+                experience.
+              </dd>
+            </div>
+            <div>
+              <dt className="font-medium text-foreground">
+                SMS communications
+              </dt>
+              <dd className="text-foreground/80">
+                To send trip updates, event reminders, invite notifications, and
+                verification codes.
+              </dd>
+            </div>
+            <div>
+              <dt className="font-medium text-foreground">Analytics</dt>
+              <dd className="text-foreground/80">
+                To understand usage patterns and improve our service.
+              </dd>
+            </div>
+            <div>
+              <dt className="font-medium text-foreground">Security</dt>
+              <dd className="text-foreground/80">
+                To detect and prevent fraud, abuse, and unauthorized access.
+              </dd>
+            </div>
+          </dl>
+        </section>
 
-      <h2 className="font-accent text-xl font-semibold text-foreground">
-        Your Rights
-      </h2>
-      <p>You have the right to:</p>
-      <ul className="list-disc pl-6 text-foreground">
-        <li>
-          <strong>Access</strong> the personal information we hold about you
-        </li>
-        <li>
-          <strong>Correct</strong> inaccurate or incomplete information
-        </li>
-        <li>
-          <strong>Delete</strong> your account and personal data
-        </li>
-      </ul>
-      <p>
-        To exercise any of these rights, contact{" "}
-        <a
-          href="mailto:support@journiful.com"
-          className="text-primary underline"
-        >
-          support@journiful.com
-        </a>
-        .
-      </p>
+        <div className="border-t border-border" />
 
-      <h2 className="font-accent text-xl font-semibold text-foreground">
-        Children&apos;s Privacy
-      </h2>
-      <p>
-        Journiful is not directed to children under the age of 13. We do not
-        knowingly collect personal information from children under 13. If we
-        become aware that we have collected data from a child under 13, we will
-        take steps to delete it promptly.
-      </p>
+        <section>
+          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+            SMS Data Collection and Use
+          </h2>
+          <p className="mb-3">
+            When you opt in to Journiful Trip Notifications, we collect your
+            phone number and a record of your consent (including the date, time,
+            and version of the disclosure you agreed to). This data is used
+            solely to send you transactional SMS messages related to your
+            Journiful account and trip activity.
+          </p>
+          <p className="mb-3 rounded-md border border-border bg-card p-4 text-sm font-medium text-foreground">
+            Your phone number and opt-in data will not be shared with or sold to
+            third parties for marketing purposes.
+          </p>
+          <p className="text-foreground/80">
+            SMS data is shared only with our messaging service provider (Twilio)
+            for the purpose of delivering messages to you. For full details on
+            our SMS program, see our{" "}
+            <Link
+              href="/sms-terms"
+              className="text-primary underline underline-offset-2 hover:text-primary/80"
+            >
+              SMS Terms &amp; Conditions
+            </Link>
+            .
+          </p>
+        </section>
 
-      <h2 className="font-accent text-xl font-semibold text-foreground">
-        Changes to This Policy
-      </h2>
-      <p>
-        We may update this Privacy Policy from time to time. When we make
-        material changes, we will notify you through the Journiful application
-        or via SMS. Your continued use of Journiful after changes take effect
-        constitutes acceptance of the updated policy.
-      </p>
+        <div className="border-t border-border" />
 
-      <h2 className="font-accent text-xl font-semibold text-foreground">
-        Contact Us
-      </h2>
-      <p>
-        If you have questions about this Privacy Policy, contact us at{" "}
-        <a
-          href="mailto:support@journiful.com"
-          className="text-primary underline"
-        >
-          support@journiful.com
-        </a>
-        .
-      </p>
+        <section>
+          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+            Data Sharing
+          </h2>
+          <p className="mb-3">
+            We do <strong className="text-foreground">not</strong> sell your
+            personal data. We may share limited information with:
+          </p>
+          <dl className="space-y-3">
+            <div>
+              <dt className="font-medium text-foreground">
+                Service providers
+              </dt>
+              <dd className="text-foreground/80">
+                Trusted third parties such as Twilio (SMS delivery), cloud
+                hosting providers, and analytics services that help us operate
+                Journiful.
+              </dd>
+            </div>
+            <div>
+              <dt className="font-medium text-foreground">
+                Legal requirements
+              </dt>
+              <dd className="text-foreground/80">
+                When required by law, regulation, or legal process.
+              </dd>
+            </div>
+            <div>
+              <dt className="font-medium text-foreground">Safety</dt>
+              <dd className="text-foreground/80">
+                To protect the rights, safety, or property of Journiful, our
+                users, or the public.
+              </dd>
+            </div>
+          </dl>
+        </section>
+
+        <div className="border-t border-border" />
+
+        <section>
+          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+            Data Retention and Deletion
+          </h2>
+          <p>
+            We retain your personal information for as long as your account is
+            active or as needed to provide you with our services. You may request
+            deletion of your account and associated data at any time by
+            contacting{" "}
+            <a
+              href="mailto:support@journiful.com"
+              className="text-primary underline underline-offset-2 hover:text-primary/80"
+            >
+              support@journiful.com
+            </a>
+            . Upon receiving a deletion request, we will remove your data within
+            30 days, except where retention is required by law.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+            Your Rights
+          </h2>
+          <p className="mb-3">You have the right to:</p>
+          <ul className="list-disc space-y-1 pl-5 text-foreground/80">
+            <li>
+              <strong className="text-foreground">Access</strong> the personal
+              information we hold about you
+            </li>
+            <li>
+              <strong className="text-foreground">Correct</strong> inaccurate or
+              incomplete information
+            </li>
+            <li>
+              <strong className="text-foreground">Delete</strong> your account
+              and personal data
+            </li>
+          </ul>
+          <p className="mt-3">
+            To exercise any of these rights, contact{" "}
+            <a
+              href="mailto:support@journiful.com"
+              className="text-primary underline underline-offset-2 hover:text-primary/80"
+            >
+              support@journiful.com
+            </a>
+            .
+          </p>
+        </section>
+
+        <div className="border-t border-border" />
+
+        <section>
+          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+            Children&apos;s Privacy
+          </h2>
+          <p>
+            Journiful is not directed to children under the age of 13. We do not
+            knowingly collect personal information from children under 13. If we
+            become aware that we have collected data from a child under 13, we
+            will take steps to delete it promptly.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+            Changes to This Policy
+          </h2>
+          <p>
+            We may update this Privacy Policy from time to time. When we make
+            material changes, we will notify you through the Journiful
+            application or via SMS. Your continued use of Journiful after changes
+            take effect constitutes acceptance of the updated policy.
+          </p>
+        </section>
+
+        <div className="border-t border-border" />
+
+        <section>
+          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+            Contact Us
+          </h2>
+          <p>
+            If you have questions about this Privacy Policy, contact us at{" "}
+            <a
+              href="mailto:support@journiful.com"
+              className="text-primary underline underline-offset-2 hover:text-primary/80"
+            >
+              support@journiful.com
+            </a>
+            .
+          </p>
+        </section>
+      </div>
     </article>
   );
 }

--- a/apps/web/src/app/(legal)/privacy/page.tsx
+++ b/apps/web/src/app/(legal)/privacy/page.tsx
@@ -10,16 +10,16 @@ export const metadata: Metadata = {
 export default function PrivacyPolicyPage() {
   return (
     <article>
-      <header className="mb-12">
+      <header className="mb-10">
         <h1 className="font-playfair text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
           Privacy Policy
         </h1>
-        <p className="mt-2 text-sm text-muted-foreground">
+        <p className="mt-3 text-sm text-muted-foreground">
           Last updated: March 28, 2026 &middot; Effective: March 28, 2026
         </p>
       </header>
 
-      <div className="space-y-10 text-[15px] leading-relaxed text-foreground/90">
+      <div className="space-y-8 text-[15px] leading-relaxed text-foreground/90">
         <p>
           This Privacy Policy describes how Journiful (&ldquo;we,&rdquo;
           &ldquo;us,&rdquo; or &ldquo;our&rdquo;) collects, uses, and shares
@@ -28,95 +28,67 @@ export default function PrivacyPolicyPage() {
           not constitute legal advice.
         </p>
 
-        <div className="border-t border-border" />
-
         <section>
-          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+          <h2 className="font-accent text-lg font-semibold text-foreground mb-3">
             Information We Collect
           </h2>
           <p className="mb-3">We collect the following types of information:</p>
-          <dl className="space-y-3">
-            <div>
-              <dt className="font-medium text-foreground">Phone number</dt>
-              <dd className="text-foreground/80">
-                Used for account registration, authentication, and SMS
-                communications.
-              </dd>
-            </div>
-            <div>
-              <dt className="font-medium text-foreground">Display name</dt>
-              <dd className="text-foreground/80">
-                The name you choose to identify yourself within trips.
-              </dd>
-            </div>
-            <div>
-              <dt className="font-medium text-foreground">Trip data</dt>
-              <dd className="text-foreground/80">
-                Itineraries, events, accommodations, messages, and other content
-                you create or contribute to.
-              </dd>
-            </div>
-            <div>
-              <dt className="font-medium text-foreground">Usage data</dt>
-              <dd className="text-foreground/80">
-                How you interact with the application, including pages visited
-                and features used.
-              </dd>
-            </div>
-            <div>
-              <dt className="font-medium text-foreground">
-                Device information
-              </dt>
-              <dd className="text-foreground/80">
-                Browser type, operating system, and device identifiers used for
-                security and troubleshooting.
-              </dd>
-            </div>
-          </dl>
+          <ul className="list-disc space-y-2 pl-5 text-foreground/80">
+            <li>
+              <strong className="text-foreground">Phone number</strong> &mdash;
+              used for account registration, authentication, and SMS
+              communications
+            </li>
+            <li>
+              <strong className="text-foreground">Display name</strong> &mdash;
+              the name you choose to identify yourself within trips
+            </li>
+            <li>
+              <strong className="text-foreground">Trip data</strong> &mdash;
+              itineraries, events, accommodations, messages, and other content
+              you create or contribute to
+            </li>
+            <li>
+              <strong className="text-foreground">Usage data</strong> &mdash;
+              how you interact with the application, including pages visited and
+              features used
+            </li>
+            <li>
+              <strong className="text-foreground">Device information</strong>{" "}
+              &mdash; browser type, operating system, and device identifiers used
+              for security and troubleshooting
+            </li>
+          </ul>
         </section>
 
-        <div className="border-t border-border" />
-
         <section>
-          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+          <h2 className="font-accent text-lg font-semibold text-foreground mb-3">
             How We Use Your Information
           </h2>
-          <dl className="space-y-3">
-            <div>
-              <dt className="font-medium text-foreground">App functionality</dt>
-              <dd className="text-foreground/80">
-                To provide, maintain, and improve the Journiful trip planning
-                experience.
-              </dd>
-            </div>
-            <div>
-              <dt className="font-medium text-foreground">
-                SMS communications
-              </dt>
-              <dd className="text-foreground/80">
-                To send trip updates, event reminders, invite notifications, and
-                verification codes.
-              </dd>
-            </div>
-            <div>
-              <dt className="font-medium text-foreground">Analytics</dt>
-              <dd className="text-foreground/80">
-                To understand usage patterns and improve our service.
-              </dd>
-            </div>
-            <div>
-              <dt className="font-medium text-foreground">Security</dt>
-              <dd className="text-foreground/80">
-                To detect and prevent fraud, abuse, and unauthorized access.
-              </dd>
-            </div>
-          </dl>
+          <ul className="list-disc space-y-2 pl-5 text-foreground/80">
+            <li>
+              <strong className="text-foreground">App functionality</strong>{" "}
+              &mdash; to provide, maintain, and improve the Journiful trip
+              planning experience
+            </li>
+            <li>
+              <strong className="text-foreground">SMS communications</strong>{" "}
+              &mdash; to send trip updates, event reminders, invite
+              notifications, and verification codes
+            </li>
+            <li>
+              <strong className="text-foreground">Analytics</strong> &mdash; to
+              understand usage patterns and improve our service
+            </li>
+            <li>
+              <strong className="text-foreground">Security</strong> &mdash; to
+              detect and prevent fraud, abuse, and unauthorized access
+            </li>
+          </ul>
         </section>
 
-        <div className="border-t border-border" />
-
         <section>
-          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+          <h2 className="font-accent text-lg font-semibold text-foreground mb-3">
             SMS Data Collection and Use
           </h2>
           <p className="mb-3">
@@ -126,11 +98,11 @@ export default function PrivacyPolicyPage() {
             solely to send you transactional SMS messages related to your
             Journiful account and trip activity.
           </p>
-          <p className="mb-3 rounded-md border border-border bg-card p-4 text-sm font-medium text-foreground">
+          <p className="mb-3 font-medium text-foreground">
             Your phone number and opt-in data will not be shared with or sold to
             third parties for marketing purposes.
           </p>
-          <p className="text-foreground/80">
+          <p>
             SMS data is shared only with our messaging service provider (Twilio)
             for the purpose of delivering messages to you. For full details on
             our SMS program, see our{" "}
@@ -144,49 +116,35 @@ export default function PrivacyPolicyPage() {
           </p>
         </section>
 
-        <div className="border-t border-border" />
-
         <section>
-          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+          <h2 className="font-accent text-lg font-semibold text-foreground mb-3">
             Data Sharing
           </h2>
           <p className="mb-3">
             We do <strong className="text-foreground">not</strong> sell your
             personal data. We may share limited information with:
           </p>
-          <dl className="space-y-3">
-            <div>
-              <dt className="font-medium text-foreground">
-                Service providers
-              </dt>
-              <dd className="text-foreground/80">
-                Trusted third parties such as Twilio (SMS delivery), cloud
-                hosting providers, and analytics services that help us operate
-                Journiful.
-              </dd>
-            </div>
-            <div>
-              <dt className="font-medium text-foreground">
-                Legal requirements
-              </dt>
-              <dd className="text-foreground/80">
-                When required by law, regulation, or legal process.
-              </dd>
-            </div>
-            <div>
-              <dt className="font-medium text-foreground">Safety</dt>
-              <dd className="text-foreground/80">
-                To protect the rights, safety, or property of Journiful, our
-                users, or the public.
-              </dd>
-            </div>
-          </dl>
+          <ul className="list-disc space-y-2 pl-5 text-foreground/80">
+            <li>
+              <strong className="text-foreground">Service providers</strong>{" "}
+              &mdash; trusted third parties such as Twilio (SMS delivery), cloud
+              hosting providers, and analytics services that help us operate
+              Journiful
+            </li>
+            <li>
+              <strong className="text-foreground">Legal requirements</strong>{" "}
+              &mdash; when required by law, regulation, or legal process
+            </li>
+            <li>
+              <strong className="text-foreground">Safety</strong> &mdash; to
+              protect the rights, safety, or property of Journiful, our users,
+              or the public
+            </li>
+          </ul>
         </section>
 
-        <div className="border-t border-border" />
-
         <section>
-          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+          <h2 className="font-accent text-lg font-semibold text-foreground mb-3">
             Data Retention and Deletion
           </h2>
           <p>
@@ -206,7 +164,7 @@ export default function PrivacyPolicyPage() {
         </section>
 
         <section>
-          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+          <h2 className="font-accent text-lg font-semibold text-foreground mb-3">
             Your Rights
           </h2>
           <p className="mb-3">You have the right to:</p>
@@ -236,10 +194,8 @@ export default function PrivacyPolicyPage() {
           </p>
         </section>
 
-        <div className="border-t border-border" />
-
         <section>
-          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+          <h2 className="font-accent text-lg font-semibold text-foreground mb-2">
             Children&apos;s Privacy
           </h2>
           <p>
@@ -251,7 +207,7 @@ export default function PrivacyPolicyPage() {
         </section>
 
         <section>
-          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+          <h2 className="font-accent text-lg font-semibold text-foreground mb-2">
             Changes to This Policy
           </h2>
           <p>
@@ -262,10 +218,8 @@ export default function PrivacyPolicyPage() {
           </p>
         </section>
 
-        <div className="border-t border-border" />
-
         <section>
-          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+          <h2 className="font-accent text-lg font-semibold text-foreground mb-2">
             Contact Us
           </h2>
           <p>

--- a/apps/web/src/app/(legal)/sms-terms/page.tsx
+++ b/apps/web/src/app/(legal)/sms-terms/page.tsx
@@ -10,16 +10,16 @@ export const metadata: Metadata = {
 export default function SmsTermsPage() {
   return (
     <article>
-      <header className="mb-12">
+      <header className="mb-10">
         <h1 className="font-playfair text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
           SMS Terms &amp; Conditions
         </h1>
-        <p className="mt-2 text-sm text-muted-foreground">
+        <p className="mt-3 text-sm text-muted-foreground">
           Last updated: March 28, 2026
         </p>
       </header>
 
-      <div className="space-y-10 text-[15px] leading-relaxed text-foreground/90">
+      <div className="space-y-8 text-[15px] leading-relaxed text-foreground/90">
         <section>
           <p>
             Journiful Trip Notifications is an SMS program operated by Journiful.
@@ -34,10 +34,8 @@ export default function SmsTermsPage() {
           </ul>
         </section>
 
-        <div className="border-t border-border" />
-
         <section>
-          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+          <h2 className="font-accent text-lg font-semibold text-foreground mb-2">
             Message Frequency
           </h2>
           <p>
@@ -47,7 +45,7 @@ export default function SmsTermsPage() {
         </section>
 
         <section>
-          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+          <h2 className="font-accent text-lg font-semibold text-foreground mb-2">
             Fees
           </h2>
           <p>
@@ -56,27 +54,23 @@ export default function SmsTermsPage() {
           </p>
         </section>
 
-        <div className="border-t border-border" />
-
         <section>
-          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+          <h2 className="font-accent text-lg font-semibold text-foreground mb-2">
             Opt-Out
           </h2>
           <p>
-            Reply <strong className="text-foreground">STOP</strong> to any
-            message to unsubscribe. You will receive a single confirmation
-            message. After opting out, you will no longer receive text messages
-            from Journiful unless you opt in again.
+            Reply <strong>STOP</strong> to any message to unsubscribe. You will
+            receive a single confirmation message. After opting out, you will no
+            longer receive text messages from Journiful unless you opt in again.
           </p>
         </section>
 
         <section>
-          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+          <h2 className="font-accent text-lg font-semibold text-foreground mb-2">
             Help
           </h2>
           <p>
-            Reply <strong className="text-foreground">HELP</strong> for help, or
-            contact{" "}
+            Reply <strong>HELP</strong> for help, or contact{" "}
             <a
               href="mailto:support@journiful.com"
               className="text-primary underline underline-offset-2 hover:text-primary/80"
@@ -87,10 +81,8 @@ export default function SmsTermsPage() {
           </p>
         </section>
 
-        <div className="border-t border-border" />
-
         <section>
-          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+          <h2 className="font-accent text-lg font-semibold text-foreground mb-2">
             Carrier Information
           </h2>
           <p>
@@ -100,7 +92,7 @@ export default function SmsTermsPage() {
         </section>
 
         <section>
-          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+          <h2 className="font-accent text-lg font-semibold text-foreground mb-2">
             Privacy
           </h2>
           <p>
@@ -118,7 +110,7 @@ export default function SmsTermsPage() {
         </section>
 
         <section>
-          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+          <h2 className="font-accent text-lg font-semibold text-foreground mb-2">
             Customer Care
           </h2>
           <p>

--- a/apps/web/src/app/(legal)/sms-terms/page.tsx
+++ b/apps/web/src/app/(legal)/sms-terms/page.tsx
@@ -2,112 +2,137 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 export const metadata: Metadata = {
-  title: "SMS Terms & Conditions",
+  title: "SMS Terms & Conditions | Journiful",
   description:
-    "SMS Terms and Conditions for Journiful Trip Notifications. Learn about message frequency, opt-out instructions, and carrier information.",
+    "SMS Terms and Conditions for Journiful Trip Notifications. Message frequency, opt-out instructions, and carrier information.",
 };
 
 export default function SmsTermsPage() {
   return (
-    <article className="prose prose-neutral max-w-none">
-      <h1 className="font-playfair text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-        SMS Terms &amp; Conditions
-      </h1>
-      <p className="text-sm text-muted-foreground">
-        Last updated: March 28, 2026
-      </p>
+    <article>
+      <header className="mb-12">
+        <h1 className="font-playfair text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+          SMS Terms &amp; Conditions
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Last updated: March 28, 2026
+        </p>
+      </header>
 
-      <h2 className="font-accent text-xl font-semibold text-foreground">
-        Program Name
-      </h2>
-      <p>Journiful Trip Notifications</p>
+      <div className="space-y-10 text-[15px] leading-relaxed text-foreground/90">
+        <section>
+          <p>
+            Journiful Trip Notifications is an SMS program operated by Journiful.
+            By opting in, you consent to receive text messages related to your
+            use of Journiful, including:
+          </p>
+          <ul className="mt-3 list-disc space-y-1 pl-5 text-foreground/80">
+            <li>Trip updates and changes</li>
+            <li>Event reminders and RSVP notifications</li>
+            <li>Trip invite notifications</li>
+            <li>Phone number verification codes</li>
+          </ul>
+        </section>
 
-      <h2 className="font-accent text-xl font-semibold text-foreground">
-        Program Description
-      </h2>
-      <p>
-        By opting in to Journiful Trip Notifications, you consent to receive
-        text messages related to your use of Journiful, including:
-      </p>
-      <ul className="list-disc pl-6 text-foreground">
-        <li>Trip updates and changes</li>
-        <li>Event reminders and RSVP notifications</li>
-        <li>Trip invite notifications</li>
-        <li>Phone number verification codes</li>
-      </ul>
+        <div className="border-t border-border" />
 
-      <h2 className="font-accent text-xl font-semibold text-foreground">
-        Message Frequency
-      </h2>
-      <p>
-        Message frequency varies based on trip activity. Typically 1&ndash;10
-        messages per month.
-      </p>
+        <section>
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+            Message Frequency
+          </h2>
+          <p>
+            Message frequency varies based on trip activity. Typically 1&ndash;10
+            messages per month.
+          </p>
+        </section>
 
-      <h2 className="font-accent text-xl font-semibold text-foreground">
-        Fees
-      </h2>
-      <p>
-        Message and data rates may apply. Your carrier&apos;s standard messaging
-        rates will apply to all messages sent and received.
-      </p>
+        <section>
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+            Fees
+          </h2>
+          <p>
+            Message and data rates may apply. Your carrier&apos;s standard
+            messaging rates will apply to all messages sent and received.
+          </p>
+        </section>
 
-      <h2 className="font-accent text-xl font-semibold text-foreground">
-        Opt-Out
-      </h2>
-      <p>
-        Reply <strong>STOP</strong> to any message to unsubscribe. You will
-        receive a single confirmation message. After opting out, you will no
-        longer receive text messages from Journiful unless you opt in again.
-      </p>
+        <div className="border-t border-border" />
 
-      <h2 className="font-accent text-xl font-semibold text-foreground">
-        Help
-      </h2>
-      <p>
-        Reply <strong>HELP</strong> for help, or contact{" "}
-        <a
-          href="mailto:support@journiful.com"
-          className="text-primary underline"
-        >
-          support@journiful.com
-        </a>
-        .
-      </p>
+        <section>
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+            Opt-Out
+          </h2>
+          <p>
+            Reply <strong className="text-foreground">STOP</strong> to any
+            message to unsubscribe. You will receive a single confirmation
+            message. After opting out, you will no longer receive text messages
+            from Journiful unless you opt in again.
+          </p>
+        </section>
 
-      <h2 className="font-accent text-xl font-semibold text-foreground">
-        Customer Care
-      </h2>
-      <p>
-        For questions or support, contact us at{" "}
-        <a
-          href="mailto:support@journiful.com"
-          className="text-primary underline"
-        >
-          support@journiful.com
-        </a>
-        .
-      </p>
+        <section>
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+            Help
+          </h2>
+          <p>
+            Reply <strong className="text-foreground">HELP</strong> for help, or
+            contact{" "}
+            <a
+              href="mailto:support@journiful.com"
+              className="text-primary underline underline-offset-2 hover:text-primary/80"
+            >
+              support@journiful.com
+            </a>
+            .
+          </p>
+        </section>
 
-      <h2 className="font-accent text-xl font-semibold text-foreground">
-        Carrier Information
-      </h2>
-      <p>
-        Supported carriers include AT&amp;T, T-Mobile, Verizon, and others.
-        Carriers are not liable for delayed or undelivered messages.
-      </p>
+        <div className="border-t border-border" />
 
-      <h2 className="font-accent text-xl font-semibold text-foreground">
-        Privacy
-      </h2>
-      <p>
-        Your phone number and opt-in data will not be shared with or sold to
-        third parties for marketing purposes. For more information, see our{" "}
-        <Link href="/privacy" className="text-primary underline">
-          Privacy Policy
-        </Link>
-        .
-      </p>
+        <section>
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+            Carrier Information
+          </h2>
+          <p>
+            Supported carriers include AT&amp;T, T-Mobile, Verizon, and others.
+            Carriers are not liable for delayed or undelivered messages.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+            Privacy
+          </h2>
+          <p>
+            Your phone number and opt-in data will not be shared with or sold to
+            third parties for marketing purposes. For more information, see
+            our{" "}
+            <Link
+              href="/privacy"
+              className="text-primary underline underline-offset-2 hover:text-primary/80"
+            >
+              Privacy Policy
+            </Link>
+            .
+          </p>
+        </section>
+
+        <section>
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+            Customer Care
+          </h2>
+          <p>
+            For questions or support, contact us at{" "}
+            <a
+              href="mailto:support@journiful.com"
+              className="text-primary underline underline-offset-2 hover:text-primary/80"
+            >
+              support@journiful.com
+            </a>
+            .
+          </p>
+        </section>
+      </div>
     </article>
   );
 }

--- a/apps/web/src/app/(legal)/sms-terms/page.tsx
+++ b/apps/web/src/app/(legal)/sms-terms/page.tsx
@@ -1,0 +1,113 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "SMS Terms & Conditions",
+  description:
+    "SMS Terms and Conditions for Journiful Trip Notifications. Learn about message frequency, opt-out instructions, and carrier information.",
+};
+
+export default function SmsTermsPage() {
+  return (
+    <article className="prose prose-neutral max-w-none">
+      <h1 className="font-playfair text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+        SMS Terms &amp; Conditions
+      </h1>
+      <p className="text-sm text-muted-foreground">
+        Last updated: March 28, 2026
+      </p>
+
+      <h2 className="font-accent text-xl font-semibold text-foreground">
+        Program Name
+      </h2>
+      <p>Journiful Trip Notifications</p>
+
+      <h2 className="font-accent text-xl font-semibold text-foreground">
+        Program Description
+      </h2>
+      <p>
+        By opting in to Journiful Trip Notifications, you consent to receive
+        text messages related to your use of Journiful, including:
+      </p>
+      <ul className="list-disc pl-6 text-foreground">
+        <li>Trip updates and changes</li>
+        <li>Event reminders and RSVP notifications</li>
+        <li>Trip invite notifications</li>
+        <li>Phone number verification codes</li>
+      </ul>
+
+      <h2 className="font-accent text-xl font-semibold text-foreground">
+        Message Frequency
+      </h2>
+      <p>
+        Message frequency varies based on trip activity. Typically 1&ndash;10
+        messages per month.
+      </p>
+
+      <h2 className="font-accent text-xl font-semibold text-foreground">
+        Fees
+      </h2>
+      <p>
+        Message and data rates may apply. Your carrier&apos;s standard messaging
+        rates will apply to all messages sent and received.
+      </p>
+
+      <h2 className="font-accent text-xl font-semibold text-foreground">
+        Opt-Out
+      </h2>
+      <p>
+        Reply <strong>STOP</strong> to any message to unsubscribe. You will
+        receive a single confirmation message. After opting out, you will no
+        longer receive text messages from Journiful unless you opt in again.
+      </p>
+
+      <h2 className="font-accent text-xl font-semibold text-foreground">
+        Help
+      </h2>
+      <p>
+        Reply <strong>HELP</strong> for help, or contact{" "}
+        <a
+          href="mailto:support@journiful.com"
+          className="text-primary underline"
+        >
+          support@journiful.com
+        </a>
+        .
+      </p>
+
+      <h2 className="font-accent text-xl font-semibold text-foreground">
+        Customer Care
+      </h2>
+      <p>
+        For questions or support, contact us at{" "}
+        <a
+          href="mailto:support@journiful.com"
+          className="text-primary underline"
+        >
+          support@journiful.com
+        </a>
+        .
+      </p>
+
+      <h2 className="font-accent text-xl font-semibold text-foreground">
+        Carrier Information
+      </h2>
+      <p>
+        Supported carriers include AT&amp;T, T-Mobile, Verizon, and others.
+        Carriers are not liable for delayed or undelivered messages.
+      </p>
+
+      <h2 className="font-accent text-xl font-semibold text-foreground">
+        Privacy
+      </h2>
+      <p>
+        Your phone number and opt-in data will not be shared with or sold to
+        third parties for marketing purposes. For more information, see our{" "}
+        <Link href="/privacy" className="text-primary underline">
+          Privacy Policy
+        </Link>
+        .
+      </p>
+    </article>
+  );
+}

--- a/apps/web/src/app/(legal)/terms/page.tsx
+++ b/apps/web/src/app/(legal)/terms/page.tsx
@@ -2,159 +2,197 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 export const metadata: Metadata = {
-  title: "Terms of Service",
+  title: "Terms of Service | Journiful",
   description:
-    "Journiful Terms of Service. Read our terms governing the use of the Journiful group trip planning application.",
+    "Journiful Terms of Service. Terms governing the use of the Journiful group trip planning application.",
 };
 
 export default function TermsOfServicePage() {
   return (
-    <article className="prose prose-neutral max-w-none">
-      <h1 className="font-playfair text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-        Terms of Service
-      </h1>
-      <p className="text-sm text-muted-foreground">
-        Last updated: March 28, 2026
-        <br />
-        Effective date: March 28, 2026
-      </p>
-      <p>
-        These Terms of Service (&quot;Terms&quot;) govern your use of the
-        Journiful application and related services (&quot;Service&quot;)
-        operated by Journiful (&quot;we,&quot; &quot;us,&quot; or
-        &quot;our&quot;). This document is provided for informational purposes
-        and does not constitute legal advice.
-      </p>
+    <article>
+      <header className="mb-12">
+        <h1 className="font-playfair text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+          Terms of Service
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Last updated: March 28, 2026 &middot; Effective: March 28, 2026
+        </p>
+      </header>
 
-      <h2 className="font-accent text-xl font-semibold text-foreground">
-        Acceptance of Terms
-      </h2>
-      <p>
-        By accessing or using Journiful, you agree to be bound by these Terms.
-        If you do not agree, you may not use the Service.
-      </p>
+      <div className="space-y-10 text-[15px] leading-relaxed text-foreground/90">
+        <p>
+          These Terms of Service (&ldquo;Terms&rdquo;) govern your use of the
+          Journiful application and related services (&ldquo;Service&rdquo;)
+          operated by Journiful (&ldquo;we,&rdquo; &ldquo;us,&rdquo; or
+          &ldquo;our&rdquo;). This document is provided for informational
+          purposes and does not constitute legal advice.
+        </p>
 
-      <h2 className="font-accent text-xl font-semibold text-foreground">
-        Account Registration
-      </h2>
-      <p>
-        Journiful uses phone-based authentication. To create an account, you
-        must provide a valid phone number. Each phone number may be associated
-        with only one account. You are responsible for maintaining the security
-        of your account and for all activity that occurs under it.
-      </p>
+        <div className="border-t border-border" />
 
-      <h2 className="font-accent text-xl font-semibold text-foreground">
-        User Responsibilities
-      </h2>
-      <p>When using Journiful, you agree to:</p>
-      <ul className="list-disc pl-6 text-foreground">
-        <li>Provide accurate and truthful information</li>
-        <li>
-          Not use the Service for any unlawful, abusive, or harmful purpose
-        </li>
-        <li>
-          Not interfere with or disrupt the Service or its infrastructure
-        </li>
-        <li>
-          Not attempt to gain unauthorized access to other users&apos; accounts
-          or data
-        </li>
-        <li>Respect the privacy and rights of other users</li>
-      </ul>
+        <section>
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+            Acceptance of Terms
+          </h2>
+          <p>
+            By accessing or using Journiful, you agree to be bound by these
+            Terms. If you do not agree, you may not use the Service.
+          </p>
+        </section>
 
-      <h2 className="font-accent text-xl font-semibold text-foreground">
-        Trip Content and User-Generated Content
-      </h2>
-      <p>
-        You retain ownership of all content you create or contribute to
-        Journiful, including trip itineraries, events, messages, and photos. By
-        posting content, you grant Journiful a non-exclusive, worldwide,
-        royalty-free license to use, display, and distribute that content solely
-        for the purpose of operating and providing the Service to you and your
-        trip members.
-      </p>
-      <p>
-        You are responsible for the content you post and must not share content
-        that is illegal, defamatory, or infringes on the rights of others.
-      </p>
+        <section>
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+            Account Registration
+          </h2>
+          <p>
+            Journiful uses phone-based authentication. To create an account, you
+            must provide a valid phone number. Each phone number may be
+            associated with only one account. You are responsible for maintaining
+            the security of your account and for all activity that occurs under
+            it.
+          </p>
+        </section>
 
-      <h2 className="font-accent text-xl font-semibold text-foreground">
-        SMS Communications
-      </h2>
-      <p>
-        By opting in to SMS notifications, you consent to receive text messages
-        from Journiful related to your account and trip activity. Message and
-        data rates may apply. You may opt out at any time by replying STOP. For
-        complete details, see our{" "}
-        <Link href="/sms-terms" className="text-primary underline">
-          SMS Terms &amp; Conditions
-        </Link>
-        .
-      </p>
+        <div className="border-t border-border" />
 
-      <h2 className="font-accent text-xl font-semibold text-foreground">
-        Intellectual Property
-      </h2>
-      <p>
-        The Journiful name, logo, design, and all related software, features,
-        and documentation are the property of Journiful and are protected by
-        intellectual property laws. You may not copy, modify, distribute, or
-        create derivative works based on the Service without our prior written
-        consent.
-      </p>
+        <section>
+          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+            User Responsibilities
+          </h2>
+          <p className="mb-3">When using Journiful, you agree to:</p>
+          <ul className="list-disc space-y-1 pl-5 text-foreground/80">
+            <li>Provide accurate and truthful information</li>
+            <li>
+              Not use the Service for any unlawful, abusive, or harmful purpose
+            </li>
+            <li>
+              Not interfere with or disrupt the Service or its infrastructure
+            </li>
+            <li>
+              Not attempt to gain unauthorized access to other users&apos;
+              accounts or data
+            </li>
+            <li>Respect the privacy and rights of other users</li>
+          </ul>
+        </section>
 
-      <h2 className="font-accent text-xl font-semibold text-foreground">
-        Limitation of Liability
-      </h2>
-      <p>
-        To the maximum extent permitted by law, Journiful shall not be liable
-        for any indirect, incidental, special, consequential, or punitive
-        damages arising out of or related to your use of the Service. Our total
-        liability shall not exceed the amount you paid us, if any, in the twelve
-        months preceding the claim.
-      </p>
+        <section>
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+            Trip Content and User-Generated Content
+          </h2>
+          <p className="mb-3">
+            You retain ownership of all content you create or contribute to
+            Journiful, including trip itineraries, events, messages, and photos.
+            By posting content, you grant Journiful a non-exclusive, worldwide,
+            royalty-free license to use, display, and distribute that content
+            solely for the purpose of operating and providing the Service to you
+            and your trip members.
+          </p>
+          <p>
+            You are responsible for the content you post and must not share
+            content that is illegal, defamatory, or infringes on the rights of
+            others.
+          </p>
+        </section>
 
-      <h2 className="font-accent text-xl font-semibold text-foreground">
-        Termination
-      </h2>
-      <p>
-        We may suspend or terminate your account at any time if we reasonably
-        believe you have violated these Terms or if continued access poses a
-        risk to the Service or other users. You may delete your account at any
-        time by contacting{" "}
-        <a
-          href="mailto:support@journiful.com"
-          className="text-primary underline"
-        >
-          support@journiful.com
-        </a>
-        .
-      </p>
+        <div className="border-t border-border" />
 
-      <h2 className="font-accent text-xl font-semibold text-foreground">
-        Governing Law
-      </h2>
-      <p>
-        These Terms shall be governed by and construed in accordance with the
-        laws of the State of Delaware, without regard to its conflict of law
-        provisions. Any disputes arising under these Terms shall be resolved in
-        the courts located in Delaware.
-      </p>
+        <section>
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+            SMS Communications
+          </h2>
+          <p>
+            By opting in to SMS notifications, you consent to receive text
+            messages from Journiful related to your account and trip activity.
+            Message and data rates may apply. You may opt out at any time by
+            replying STOP. For complete details, see our{" "}
+            <Link
+              href="/sms-terms"
+              className="text-primary underline underline-offset-2 hover:text-primary/80"
+            >
+              SMS Terms &amp; Conditions
+            </Link>
+            .
+          </p>
+        </section>
 
-      <h2 className="font-accent text-xl font-semibold text-foreground">
-        Contact Us
-      </h2>
-      <p>
-        If you have questions about these Terms, contact us at{" "}
-        <a
-          href="mailto:support@journiful.com"
-          className="text-primary underline"
-        >
-          support@journiful.com
-        </a>
-        .
-      </p>
+        <section>
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+            Intellectual Property
+          </h2>
+          <p>
+            The Journiful name, logo, design, and all related software,
+            features, and documentation are the property of Journiful and are
+            protected by intellectual property laws. You may not copy, modify,
+            distribute, or create derivative works based on the Service without
+            our prior written consent.
+          </p>
+        </section>
+
+        <div className="border-t border-border" />
+
+        <section>
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+            Limitation of Liability
+          </h2>
+          <p>
+            To the maximum extent permitted by law, Journiful shall not be
+            liable for any indirect, incidental, special, consequential, or
+            punitive damages arising out of or related to your use of the
+            Service. Our total liability shall not exceed the amount you paid us,
+            if any, in the twelve months preceding the claim.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+            Termination
+          </h2>
+          <p>
+            We may suspend or terminate your account at any time if we
+            reasonably believe you have violated these Terms or if continued
+            access poses a risk to the Service or other users. You may delete
+            your account at any time by contacting{" "}
+            <a
+              href="mailto:support@journiful.com"
+              className="text-primary underline underline-offset-2 hover:text-primary/80"
+            >
+              support@journiful.com
+            </a>
+            .
+          </p>
+        </section>
+
+        <section>
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+            Governing Law
+          </h2>
+          <p>
+            These Terms shall be governed by and construed in accordance with the
+            laws of the State of Delaware, without regard to its conflict of law
+            provisions. Any disputes arising under these Terms shall be resolved
+            in the courts located in Delaware.
+          </p>
+        </section>
+
+        <div className="border-t border-border" />
+
+        <section>
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+            Contact Us
+          </h2>
+          <p>
+            If you have questions about these Terms, contact us at{" "}
+            <a
+              href="mailto:support@journiful.com"
+              className="text-primary underline underline-offset-2 hover:text-primary/80"
+            >
+              support@journiful.com
+            </a>
+            .
+          </p>
+        </section>
+      </div>
     </article>
   );
 }

--- a/apps/web/src/app/(legal)/terms/page.tsx
+++ b/apps/web/src/app/(legal)/terms/page.tsx
@@ -10,16 +10,16 @@ export const metadata: Metadata = {
 export default function TermsOfServicePage() {
   return (
     <article>
-      <header className="mb-12">
+      <header className="mb-10">
         <h1 className="font-playfair text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
           Terms of Service
         </h1>
-        <p className="mt-2 text-sm text-muted-foreground">
+        <p className="mt-3 text-sm text-muted-foreground">
           Last updated: March 28, 2026 &middot; Effective: March 28, 2026
         </p>
       </header>
 
-      <div className="space-y-10 text-[15px] leading-relaxed text-foreground/90">
+      <div className="space-y-8 text-[15px] leading-relaxed text-foreground/90">
         <p>
           These Terms of Service (&ldquo;Terms&rdquo;) govern your use of the
           Journiful application and related services (&ldquo;Service&rdquo;)
@@ -28,10 +28,8 @@ export default function TermsOfServicePage() {
           purposes and does not constitute legal advice.
         </p>
 
-        <div className="border-t border-border" />
-
         <section>
-          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+          <h2 className="font-accent text-lg font-semibold text-foreground mb-2">
             Acceptance of Terms
           </h2>
           <p>
@@ -41,7 +39,7 @@ export default function TermsOfServicePage() {
         </section>
 
         <section>
-          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+          <h2 className="font-accent text-lg font-semibold text-foreground mb-2">
             Account Registration
           </h2>
           <p>
@@ -53,10 +51,8 @@ export default function TermsOfServicePage() {
           </p>
         </section>
 
-        <div className="border-t border-border" />
-
         <section>
-          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+          <h2 className="font-accent text-lg font-semibold text-foreground mb-3">
             User Responsibilities
           </h2>
           <p className="mb-3">When using Journiful, you agree to:</p>
@@ -77,7 +73,7 @@ export default function TermsOfServicePage() {
         </section>
 
         <section>
-          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+          <h2 className="font-accent text-lg font-semibold text-foreground mb-2">
             Trip Content and User-Generated Content
           </h2>
           <p className="mb-3">
@@ -95,10 +91,8 @@ export default function TermsOfServicePage() {
           </p>
         </section>
 
-        <div className="border-t border-border" />
-
         <section>
-          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+          <h2 className="font-accent text-lg font-semibold text-foreground mb-2">
             SMS Communications
           </h2>
           <p>
@@ -117,7 +111,7 @@ export default function TermsOfServicePage() {
         </section>
 
         <section>
-          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+          <h2 className="font-accent text-lg font-semibold text-foreground mb-2">
             Intellectual Property
           </h2>
           <p>
@@ -129,10 +123,8 @@ export default function TermsOfServicePage() {
           </p>
         </section>
 
-        <div className="border-t border-border" />
-
         <section>
-          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+          <h2 className="font-accent text-lg font-semibold text-foreground mb-2">
             Limitation of Liability
           </h2>
           <p>
@@ -145,7 +137,7 @@ export default function TermsOfServicePage() {
         </section>
 
         <section>
-          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+          <h2 className="font-accent text-lg font-semibold text-foreground mb-2">
             Termination
           </h2>
           <p>
@@ -164,7 +156,7 @@ export default function TermsOfServicePage() {
         </section>
 
         <section>
-          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+          <h2 className="font-accent text-lg font-semibold text-foreground mb-2">
             Governing Law
           </h2>
           <p>
@@ -175,10 +167,8 @@ export default function TermsOfServicePage() {
           </p>
         </section>
 
-        <div className="border-t border-border" />
-
         <section>
-          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-foreground/60">
+          <h2 className="font-accent text-lg font-semibold text-foreground mb-2">
             Contact Us
           </h2>
           <p>

--- a/apps/web/src/app/(legal)/terms/page.tsx
+++ b/apps/web/src/app/(legal)/terms/page.tsx
@@ -1,0 +1,160 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Terms of Service",
+  description:
+    "Journiful Terms of Service. Read our terms governing the use of the Journiful group trip planning application.",
+};
+
+export default function TermsOfServicePage() {
+  return (
+    <article className="prose prose-neutral max-w-none">
+      <h1 className="font-playfair text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+        Terms of Service
+      </h1>
+      <p className="text-sm text-muted-foreground">
+        Last updated: March 28, 2026
+        <br />
+        Effective date: March 28, 2026
+      </p>
+      <p>
+        These Terms of Service (&quot;Terms&quot;) govern your use of the
+        Journiful application and related services (&quot;Service&quot;)
+        operated by Journiful (&quot;we,&quot; &quot;us,&quot; or
+        &quot;our&quot;). This document is provided for informational purposes
+        and does not constitute legal advice.
+      </p>
+
+      <h2 className="font-accent text-xl font-semibold text-foreground">
+        Acceptance of Terms
+      </h2>
+      <p>
+        By accessing or using Journiful, you agree to be bound by these Terms.
+        If you do not agree, you may not use the Service.
+      </p>
+
+      <h2 className="font-accent text-xl font-semibold text-foreground">
+        Account Registration
+      </h2>
+      <p>
+        Journiful uses phone-based authentication. To create an account, you
+        must provide a valid phone number. Each phone number may be associated
+        with only one account. You are responsible for maintaining the security
+        of your account and for all activity that occurs under it.
+      </p>
+
+      <h2 className="font-accent text-xl font-semibold text-foreground">
+        User Responsibilities
+      </h2>
+      <p>When using Journiful, you agree to:</p>
+      <ul className="list-disc pl-6 text-foreground">
+        <li>Provide accurate and truthful information</li>
+        <li>
+          Not use the Service for any unlawful, abusive, or harmful purpose
+        </li>
+        <li>
+          Not interfere with or disrupt the Service or its infrastructure
+        </li>
+        <li>
+          Not attempt to gain unauthorized access to other users&apos; accounts
+          or data
+        </li>
+        <li>Respect the privacy and rights of other users</li>
+      </ul>
+
+      <h2 className="font-accent text-xl font-semibold text-foreground">
+        Trip Content and User-Generated Content
+      </h2>
+      <p>
+        You retain ownership of all content you create or contribute to
+        Journiful, including trip itineraries, events, messages, and photos. By
+        posting content, you grant Journiful a non-exclusive, worldwide,
+        royalty-free license to use, display, and distribute that content solely
+        for the purpose of operating and providing the Service to you and your
+        trip members.
+      </p>
+      <p>
+        You are responsible for the content you post and must not share content
+        that is illegal, defamatory, or infringes on the rights of others.
+      </p>
+
+      <h2 className="font-accent text-xl font-semibold text-foreground">
+        SMS Communications
+      </h2>
+      <p>
+        By opting in to SMS notifications, you consent to receive text messages
+        from Journiful related to your account and trip activity. Message and
+        data rates may apply. You may opt out at any time by replying STOP. For
+        complete details, see our{" "}
+        <Link href="/sms-terms" className="text-primary underline">
+          SMS Terms &amp; Conditions
+        </Link>
+        .
+      </p>
+
+      <h2 className="font-accent text-xl font-semibold text-foreground">
+        Intellectual Property
+      </h2>
+      <p>
+        The Journiful name, logo, design, and all related software, features,
+        and documentation are the property of Journiful and are protected by
+        intellectual property laws. You may not copy, modify, distribute, or
+        create derivative works based on the Service without our prior written
+        consent.
+      </p>
+
+      <h2 className="font-accent text-xl font-semibold text-foreground">
+        Limitation of Liability
+      </h2>
+      <p>
+        To the maximum extent permitted by law, Journiful shall not be liable
+        for any indirect, incidental, special, consequential, or punitive
+        damages arising out of or related to your use of the Service. Our total
+        liability shall not exceed the amount you paid us, if any, in the twelve
+        months preceding the claim.
+      </p>
+
+      <h2 className="font-accent text-xl font-semibold text-foreground">
+        Termination
+      </h2>
+      <p>
+        We may suspend or terminate your account at any time if we reasonably
+        believe you have violated these Terms or if continued access poses a
+        risk to the Service or other users. You may delete your account at any
+        time by contacting{" "}
+        <a
+          href="mailto:support@journiful.com"
+          className="text-primary underline"
+        >
+          support@journiful.com
+        </a>
+        .
+      </p>
+
+      <h2 className="font-accent text-xl font-semibold text-foreground">
+        Governing Law
+      </h2>
+      <p>
+        These Terms shall be governed by and construed in accordance with the
+        laws of the State of Delaware, without regard to its conflict of law
+        provisions. Any disputes arising under these Terms shall be resolved in
+        the courts located in Delaware.
+      </p>
+
+      <h2 className="font-accent text-xl font-semibold text-foreground">
+        Contact Us
+      </h2>
+      <p>
+        If you have questions about these Terms, contact us at{" "}
+        <a
+          href="mailto:support@journiful.com"
+          className="text-primary underline"
+        >
+          support@journiful.com
+        </a>
+        .
+      </p>
+    </article>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -168,6 +168,24 @@ export default async function Home() {
             <Link href="/login">Start planning</Link>
           </Button>
         </section>
+
+        {/* Footer */}
+        <footer className="flex flex-col items-center gap-2 px-4 pb-8 text-center text-xs text-muted-foreground">
+          <div className="flex items-center gap-2">
+            <Link href="/terms" className="hover:text-foreground">
+              Terms of Service
+            </Link>
+            <span aria-hidden="true">&middot;</span>
+            <Link href="/privacy" className="hover:text-foreground">
+              Privacy Policy
+            </Link>
+            <span aria-hidden="true">&middot;</span>
+            <Link href="/sms-terms" className="hover:text-foreground">
+              SMS Terms
+            </Link>
+          </div>
+          <p>&copy; 2026 Journiful. All rights reserved.</p>
+        </footer>
       </main>
 
       {/* Structured Data */}

--- a/apps/web/src/app/providers/auth-provider.test.tsx
+++ b/apps/web/src/app/providers/auth-provider.test.tsx
@@ -123,7 +123,7 @@ describe("AuthProvider", () => {
         expect.objectContaining({
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ phoneNumber: "+15551234567" }),
+          body: JSON.stringify({ phoneNumber: "+15551234567", smsConsent: true }),
         }),
       );
     });
@@ -192,7 +192,7 @@ describe("AuthProvider", () => {
           method: "POST",
           credentials: "include",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ phoneNumber: "+15551234567", code: "123456" }),
+          body: JSON.stringify({ phoneNumber: "+15551234567", code: "123456", smsConsent: true }),
         }),
       );
     });

--- a/apps/web/src/app/providers/auth-provider.tsx
+++ b/apps/web/src/app/providers/auth-provider.tsx
@@ -16,10 +16,11 @@ import { API_URL } from "@/lib/api";
 interface AuthContextType {
   user: User | null;
   loading: boolean;
-  login: (phoneNumber: string) => Promise<void>;
+  login: (phoneNumber: string, smsConsent?: boolean) => Promise<void>;
   verify: (
     phoneNumber: string,
     code: string,
+    smsConsent?: boolean,
   ) => Promise<{ requiresProfile: boolean }>;
   completeProfile: (data: {
     displayName: string;
@@ -60,11 +61,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     fetchUser();
   }, [fetchUser]);
 
-  const login = useCallback(async (phoneNumber: string) => {
+  const login = useCallback(async (phoneNumber: string, smsConsent?: boolean) => {
     const response = await fetch(`${API_URL}/auth/request-code`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ phoneNumber }),
+      body: JSON.stringify({ phoneNumber, smsConsent: smsConsent ?? true }),
     });
 
     if (!response.ok) {
@@ -73,12 +74,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
-  const verify = useCallback(async (phoneNumber: string, code: string) => {
+  const verify = useCallback(async (phoneNumber: string, code: string, smsConsent?: boolean) => {
     const response = await fetch(`${API_URL}/auth/verify-code`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       credentials: "include",
-      body: JSON.stringify({ phoneNumber, code }),
+      body: JSON.stringify({ phoneNumber, code, smsConsent: smsConsent ?? true }),
     });
 
     if (!response.ok) {

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -15,5 +15,23 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "monthly",
       priority: 0.5,
     },
+    {
+      url: `${siteUrl}/terms`,
+      lastModified: new Date("2026-03-28"),
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+    {
+      url: `${siteUrl}/privacy`,
+      lastModified: new Date("2026-03-28"),
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
+    {
+      url: `${siteUrl}/sms-terms`,
+      lastModified: new Date("2026-03-28"),
+      changeFrequency: "yearly",
+      priority: 0.3,
+    },
   ];
 }

--- a/apps/web/tests/e2e/auth-journey.spec.ts
+++ b/apps/web/tests/e2e/auth-journey.spec.ts
@@ -40,6 +40,7 @@ test.describe("Auth Journey", () => {
       // library processes input character-by-character. fill() desynchronizes
       // the internal state from react-hook-form, silently breaking submission.
       await fillPhoneInput(loginPage.phoneInput, phone);
+      await loginPage.smsConsentCheckbox.check();
       await loginPage.continueButton.click();
       await expect(page).toHaveURL(/verify/, {
         timeout: SLOW_NAVIGATION_TIMEOUT,

--- a/apps/web/tests/e2e/helpers/auth.ts
+++ b/apps/web/tests/e2e/helpers/auth.ts
@@ -27,11 +27,11 @@ export async function createUserViaAPI(
   displayName: string = "Test User",
 ): Promise<string> {
   await request.post(`${API_BASE}/auth/request-code`, {
-    data: { phoneNumber: phone },
+    data: { phoneNumber: phone, smsConsent: true },
   });
 
   const verifyResponse = await request.post(`${API_BASE}/auth/verify-code`, {
-    data: { phoneNumber: phone, code: "123456" },
+    data: { phoneNumber: phone, code: "123456", smsConsent: true },
   });
 
   const cookies = verifyResponse.headers()["set-cookie"];
@@ -57,6 +57,7 @@ export async function loginViaBrowser(
 
   const phoneInput = page.getByRole("textbox", { name: /phone/i });
   await fillPhoneInput(phoneInput, phone);
+  await page.getByRole("checkbox", { name: /I agree to receive text messages/i }).check();
   await page.getByRole("button", { name: "Continue" }).click();
 
   await page.waitForURL("**/verify**");
@@ -169,6 +170,7 @@ export async function authenticateUserViaBrowserWithPhone(
 
   const phoneInput = page.getByRole("textbox", { name: /phone/i });
   await fillPhoneInput(phoneInput, phone);
+  await page.getByRole("checkbox", { name: /I agree to receive text messages/i }).check();
   await page.getByRole("button", { name: "Continue" }).click();
 
   await page.waitForURL("**/verify**");

--- a/apps/web/tests/e2e/helpers/pages/login.page.ts
+++ b/apps/web/tests/e2e/helpers/pages/login.page.ts
@@ -5,6 +5,7 @@ export class LoginPage {
   readonly page: Page;
   readonly heading: Locator;
   readonly phoneInput: Locator;
+  readonly smsConsentCheckbox: Locator;
   readonly continueButton: Locator;
   readonly verifyHeading: Locator;
   readonly codeInput: Locator;
@@ -17,6 +18,7 @@ export class LoginPage {
     this.page = page;
     this.heading = page.getByRole("heading", { name: "Get started" });
     this.phoneInput = page.getByRole("textbox", { name: /phone/i });
+    this.smsConsentCheckbox = page.getByRole("checkbox", { name: /I agree to receive text messages/i });
     this.continueButton = page.getByRole("button", { name: "Continue" });
     this.verifyHeading = page.getByRole("heading", {
       name: "Verify your number",
@@ -40,6 +42,7 @@ export class LoginPage {
 
   async login(phone: string) {
     await fillPhoneInput(this.phoneInput, phone);
+    await this.smsConsentCheckbox.check();
     await this.continueButton.click();
     await this.page.waitForURL("**/verify**");
     await this.codeInput.fill("123456");

--- a/shared/__tests__/auth-schemas.test.ts
+++ b/shared/__tests__/auth-schemas.test.ts
@@ -18,7 +18,9 @@ describe("requestCodeSchema", () => {
     ];
 
     validPhoneNumbers.forEach((phoneNumber) => {
-      expect(() => requestCodeSchema.parse({ phoneNumber })).not.toThrow();
+      expect(() =>
+        requestCodeSchema.parse({ phoneNumber, smsConsent: true }),
+      ).not.toThrow();
     });
   });
 
@@ -31,7 +33,10 @@ describe("requestCodeSchema", () => {
     ];
 
     shortPhoneNumbers.forEach((phoneNumber) => {
-      const result = requestCodeSchema.safeParse({ phoneNumber });
+      const result = requestCodeSchema.safeParse({
+        phoneNumber,
+        smsConsent: true,
+      });
       expect(result.success).toBe(false);
     });
   });
@@ -43,13 +48,19 @@ describe("requestCodeSchema", () => {
     ];
 
     longPhoneNumbers.forEach((phoneNumber) => {
-      const result = requestCodeSchema.safeParse({ phoneNumber });
+      const result = requestCodeSchema.safeParse({
+        phoneNumber,
+        smsConsent: true,
+      });
       expect(result.success).toBe(false);
     });
   });
 
   it("should provide helpful error messages for short phone numbers", () => {
-    const result = requestCodeSchema.safeParse({ phoneNumber: "123" });
+    const result = requestCodeSchema.safeParse({
+      phoneNumber: "123",
+      smsConsent: true,
+    });
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error.issues[0]?.message).toContain(
@@ -61,6 +72,7 @@ describe("requestCodeSchema", () => {
   it("should provide helpful error messages for long phone numbers", () => {
     const result = requestCodeSchema.safeParse({
       phoneNumber: "123456789012345678901",
+      smsConsent: true,
     });
     expect(result.success).toBe(false);
     if (!result.success) {
@@ -71,7 +83,22 @@ describe("requestCodeSchema", () => {
   });
 
   it("should reject missing phoneNumber field", () => {
-    const result = requestCodeSchema.safeParse({});
+    const result = requestCodeSchema.safeParse({ smsConsent: true });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject missing smsConsent", () => {
+    const result = requestCodeSchema.safeParse({
+      phoneNumber: "+14155552671",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject smsConsent set to false", () => {
+    const result = requestCodeSchema.safeParse({
+      phoneNumber: "+14155552671",
+      smsConsent: false,
+    });
     expect(result.success).toBe(false);
   });
 });
@@ -79,10 +106,10 @@ describe("requestCodeSchema", () => {
 describe("verifyCodeSchema", () => {
   it("should accept valid phone number and code combinations", () => {
     const validInputs = [
-      { phoneNumber: "+14155552671", code: "123456" },
-      { phoneNumber: "4155552671", code: "000000" },
-      { phoneNumber: "+442071838750", code: "999999" },
-      { phoneNumber: "1234567890", code: "123456" },
+      { phoneNumber: "+14155552671", code: "123456", smsConsent: true },
+      { phoneNumber: "4155552671", code: "000000", smsConsent: true },
+      { phoneNumber: "+442071838750", code: "999999", smsConsent: true },
+      { phoneNumber: "1234567890", code: "123456", smsConsent: true },
     ];
 
     validInputs.forEach((input) => {
@@ -92,10 +119,10 @@ describe("verifyCodeSchema", () => {
 
   it("should reject codes that are not exactly 6 digits", () => {
     const invalidCodes = [
-      { phoneNumber: "1234567890", code: "12345" }, // Too short
-      { phoneNumber: "1234567890", code: "1234567" }, // Too long
-      { phoneNumber: "1234567890", code: "" }, // Empty
-      { phoneNumber: "1234567890", code: "1" }, // Way too short
+      { phoneNumber: "1234567890", code: "12345", smsConsent: true },
+      { phoneNumber: "1234567890", code: "1234567", smsConsent: true },
+      { phoneNumber: "1234567890", code: "", smsConsent: true },
+      { phoneNumber: "1234567890", code: "1", smsConsent: true },
     ];
 
     invalidCodes.forEach((input) => {
@@ -106,11 +133,11 @@ describe("verifyCodeSchema", () => {
 
   it("should reject codes that contain non-digit characters", () => {
     const invalidCodes = [
-      { phoneNumber: "1234567890", code: "12345a" }, // Contains letter
-      { phoneNumber: "1234567890", code: "12-456" }, // Contains hyphen
-      { phoneNumber: "1234567890", code: "12 456" }, // Contains space
-      { phoneNumber: "1234567890", code: "123.56" }, // Contains period
-      { phoneNumber: "1234567890", code: "abcdef" }, // All letters
+      { phoneNumber: "1234567890", code: "12345a", smsConsent: true },
+      { phoneNumber: "1234567890", code: "12-456", smsConsent: true },
+      { phoneNumber: "1234567890", code: "12 456", smsConsent: true },
+      { phoneNumber: "1234567890", code: "123.56", smsConsent: true },
+      { phoneNumber: "1234567890", code: "abcdef", smsConsent: true },
     ];
 
     invalidCodes.forEach((input) => {
@@ -121,9 +148,9 @@ describe("verifyCodeSchema", () => {
 
   it("should reject invalid phone numbers", () => {
     const invalidPhoneNumbers = [
-      { phoneNumber: "123", code: "123456" }, // Too short
-      { phoneNumber: "123456789012345678901", code: "123456" }, // Too long
-      { phoneNumber: "", code: "123456" }, // Empty
+      { phoneNumber: "123", code: "123456", smsConsent: true },
+      { phoneNumber: "123456789012345678901", code: "123456", smsConsent: true },
+      { phoneNumber: "", code: "123456", smsConsent: true },
     ];
 
     invalidPhoneNumbers.forEach((input) => {
@@ -136,6 +163,7 @@ describe("verifyCodeSchema", () => {
     const result = verifyCodeSchema.safeParse({
       phoneNumber: "1234567890",
       code: "12345",
+      smsConsent: true,
     });
     expect(result.success).toBe(false);
     if (!result.success) {
@@ -147,6 +175,7 @@ describe("verifyCodeSchema", () => {
     const result = verifyCodeSchema.safeParse({
       phoneNumber: "1234567890",
       code: "12345a",
+      smsConsent: true,
     });
     expect(result.success).toBe(false);
     if (!result.success) {
@@ -158,10 +187,16 @@ describe("verifyCodeSchema", () => {
   });
 
   it("should reject missing required fields", () => {
-    const result1 = verifyCodeSchema.safeParse({ phoneNumber: "1234567890" });
+    const result1 = verifyCodeSchema.safeParse({
+      phoneNumber: "1234567890",
+      smsConsent: true,
+    });
     expect(result1.success).toBe(false);
 
-    const result2 = verifyCodeSchema.safeParse({ code: "123456" });
+    const result2 = verifyCodeSchema.safeParse({
+      code: "123456",
+      smsConsent: true,
+    });
     expect(result2.success).toBe(false);
 
     const result3 = verifyCodeSchema.safeParse({});

--- a/shared/__tests__/exports.test.ts
+++ b/shared/__tests__/exports.test.ts
@@ -131,12 +131,14 @@ describe("Package Exports", () => {
 
     const requestInput: RequestCodeInput = {
       phoneNumber: "+14155552671",
+      smsConsent: true,
     };
     expect(requestInput).toBeDefined();
 
     const verifyInput: VerifyCodeInput = {
       phoneNumber: "+14155552671",
       code: "123456",
+      smsConsent: true,
     };
     expect(verifyInput).toBeDefined();
 
@@ -222,6 +224,7 @@ describe("Package Exports", () => {
   it("should validate schemas with inferred types", () => {
     const requestInput: RequestCodeInput = {
       phoneNumber: "+14155552671",
+      smsConsent: true,
     };
     const validated = requestCodeSchema.parse(requestInput);
     expect(validated.phoneNumber).toBe("+14155552671");
@@ -229,6 +232,7 @@ describe("Package Exports", () => {
     const verifyInput: VerifyCodeInput = {
       phoneNumber: "+14155552671",
       code: "123456",
+      smsConsent: true,
     };
     const validatedVerify = verifyCodeSchema.parse(verifyInput);
     expect(validatedVerify.code).toBe("123456");

--- a/shared/schemas/auth.ts
+++ b/shared/schemas/auth.ts
@@ -17,6 +17,9 @@ export const requestCodeSchema = z.object({
     .max(20, {
       error: "Phone number must not exceed 20 characters",
     }),
+  smsConsent: z.boolean().refine((v) => v === true, {
+    error: "SMS consent is required",
+  }),
 });
 
 /**
@@ -41,6 +44,9 @@ export const verifyCodeSchema = z.object({
     .regex(/^\d{6}$/, {
       error: "Verification code must contain only digits",
     }),
+  smsConsent: z.boolean().refine((v) => v === true, {
+    error: "SMS consent is required",
+  }),
 });
 
 /**
@@ -72,6 +78,7 @@ export const userResponseSchema = z.object({
   timezone: z.string().nullable(),
   handles: z.record(z.string(), z.string()).nullable().optional(),
   temperatureUnit: z.enum(["celsius", "fahrenheit"]).nullable().optional(),
+  smsConsentAt: z.date().nullable().optional(),
   createdAt: z.date(),
   updatedAt: z.date(),
 });


### PR DESCRIPTION
## Summary

- Create three public legal pages (`/terms`, `/privacy`, `/sms-terms`) in a shared `(legal)` route group with consistent layout
- Add TCPA-compliant SMS consent checkbox to login flow (unchecked by default, must check to proceed)
- Backend records consent timestamp and disclosure version on user record via new DB columns
- Update landing page footer and sitemap with legal page links

## Details

**Legal Pages:**
- SMS Terms contains all 10 TCPA/10DLC required disclosures (program name, frequency, opt-out, carrier disclaimer, etc.)
- Privacy Policy includes explicit SMS data collection section (required for 10DLC registration)
- Terms of Service covers app usage with SMS cross-reference

**Login Consent Flow:**
- Unchecked checkbox with disclosure text and links to `/sms-terms` and `/privacy`
- Submit disabled until consent given
- Consent boolean passes login → verify via URL params
- Backend writes `sms_consent_at` + `sms_consent_version` on user record at verification

**Database:**
- Migration `0025_jazzy_echo.sql`: adds `sms_consent_at` (timestamptz) and `sms_consent_version` (varchar) to users table

## Test plan

- [x] All auth integration tests pass (45/45) with smsConsent in payloads
- [x] All shared schema tests pass (323/323) including new consent validation tests
- [x] E2E login page helper updated with consent checkbox
- [ ] Manual: visit `/terms`, `/privacy`, `/sms-terms` — render correctly, publicly accessible
- [ ] Manual: login flow — checkbox appears unchecked, button disabled until checked

> **Note:** All legal content is AI-drafted and should be reviewed by legal counsel before production use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)