### PR TITLE
Fix global rate limit for shared WiFi networks

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -172,6 +172,9 @@ export async function buildApp(
     global: opts.rateLimit?.global ?? true,
     max: 300,
     timeWindow: "1 minute",
+    keyGenerator: (request) =>
+      (request as typeof request & { user?: { sub: string } }).user?.sub ||
+      request.ip,
     allowList: ["127.0.0.1"],
     skipOnError: false,
     store: PgRateLimitStore,

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -163,11 +163,15 @@ export async function buildApp(
   });
 
   // Register rate limit plugin with PostgreSQL-backed store
+  // Global limit is a safety net against abuse — per-route configs handle
+  // fine-grained limits (see defaultRateLimitConfig / writeRateLimitConfig).
+  // A single trip page load fires ~15 parallel requests, so the global limit
+  // must be high enough to not punish normal browsing.
   const PgRateLimitStore = createPgRateLimitStoreClass(app.db);
   await app.register(rateLimit, {
     global: opts.rateLimit?.global ?? true,
-    max: 100,
-    timeWindow: "15 minutes",
+    max: 300,
+    timeWindow: "1 minute",
     allowList: ["127.0.0.1"],
     skipOnError: false,
     store: PgRateLimitStore,

--- a/apps/api/src/services/flight.service.ts
+++ b/apps/api/src/services/flight.service.ts
@@ -123,6 +123,11 @@ export class FlightService implements IFlightService {
       return { available: true, flight: null };
     }
 
+    // Handle 429 — rate limited by AeroDataBox/RapidAPI
+    if (response.status === 429) {
+      return { available: false };
+    }
+
     // 15. Handle non-200/204
     if (!response.ok) {
       const errorBody = await response


### PR DESCRIPTION
## Summary
- Changed global rate limit window from 100/15min to 300/1min to avoid blocking normal browsing
- Key global rate limit on authenticated user ID instead of IP, falling back to IP for unauthenticated requests
- Fixes issue where users on the same WiFi (shared public IP) would collectively exhaust the global rate limit
- Per-route rate limits (`defaultRateLimitConfig`, `writeRateLimitConfig`) already keyed on user ID — this aligns the global limit

## Test plan
- [ ] Verify authenticated requests are rate-limited per user, not per IP
- [ ] Verify unauthenticated requests still rate-limit by IP
- [ ] Confirm normal browsing (multiple users on same network) doesn't trigger 429s

🤖 Generated with [Claude Code](https://claude.com/claude-code)