### PR TITLE
Fix mobile FAB, hero animation, and dialog swipe UX

### DIFF
--- a/apps/web/src/components/itinerary/itinerary-header.tsx
+++ b/apps/web/src/components/itinerary/itinerary-header.tsx
@@ -148,7 +148,7 @@ export function ItineraryHeader({
             <DropdownMenuTrigger asChild>
               <Button
                 variant="gradient"
-                className={`fixed bottom-16 right-6 sm:bottom-safe-8 sm:right-8 z-50 rounded-full w-14 h-14 shadow-lg transition-all duration-300 ease-out ${
+                className={`fixed bottom-20 right-6 md:bottom-safe-8 md:right-8 z-50 rounded-full w-14 h-14 shadow-lg transition-all duration-300 ease-out ${
                   hideFab
                     ? "opacity-0 scale-75 pointer-events-none"
                     : "opacity-100 scale-100"

--- a/apps/web/src/components/messaging/message-input.tsx
+++ b/apps/web/src/components/messaging/message-input.tsx
@@ -108,7 +108,7 @@ export function MessageInput({
         compact && "p-3",
       )}
     >
-      <div className="flex items-start gap-3">
+      <div className="flex items-end gap-3">
         {!compact && user && (
           <Avatar size="default">
             <AvatarImage
@@ -119,6 +119,24 @@ export function MessageInput({
           </Avatar>
         )}
         <div className="flex-1 min-w-0">
+          {content.length > CHAR_COUNT_THRESHOLD && (
+            <div
+              id="char-count"
+              className="text-xs text-muted-foreground mb-1"
+              aria-live="polite"
+            >
+              <span
+                className={cn(
+                  content.length >= CHAR_COUNT_WARNING &&
+                    content.length < MAX_LENGTH &&
+                    "text-warning",
+                  content.length >= MAX_LENGTH && "text-destructive",
+                )}
+              >
+                {content.length}/{MAX_LENGTH}
+              </span>
+            </div>
+          )}
           <textarea
             ref={textareaRef}
             value={content}
@@ -132,45 +150,26 @@ export function MessageInput({
             aria-describedby="char-count"
             className={cn(
               "w-full resize-none bg-transparent text-sm placeholder:text-muted-foreground outline-none",
-              compact ? "min-h-[36px]" : "min-h-[44px]",
+              compact ? "min-h-[36px]" : "min-h-[36px]",
             )}
             rows={1}
             disabled={createMessage.isPending}
           />
-          <div className="flex items-center justify-between mt-2">
-            <div
-              id="char-count"
-              className="text-xs text-muted-foreground"
-              aria-live="polite"
-            >
-              {content.length > CHAR_COUNT_THRESHOLD && (
-                <span
-                  className={cn(
-                    content.length >= CHAR_COUNT_WARNING &&
-                      content.length < MAX_LENGTH &&
-                      "text-warning",
-                    content.length >= MAX_LENGTH && "text-destructive",
-                  )}
-                >
-                  {content.length}/{MAX_LENGTH}
-                </span>
-              )}
-            </div>
-            <Button
-              variant="gradient"
-              size={compact ? "icon-xs" : "icon"}
-              onClick={handleSend}
-              disabled={!content.trim() || createMessage.isPending}
-              aria-label="Send message"
-            >
-              {createMessage.isPending ? (
-                <Loader2 className="w-4 h-4 animate-spin" />
-              ) : (
-                <Send className="w-4 h-4" />
-              )}
-            </Button>
-          </div>
         </div>
+        <Button
+          variant="gradient"
+          size={compact ? "icon-xs" : "icon"}
+          className="shrink-0"
+          onClick={handleSend}
+          disabled={!content.trim() || createMessage.isPending}
+          aria-label="Send message"
+        >
+          {createMessage.isPending ? (
+            <Loader2 className="w-4 h-4 animate-spin" />
+          ) : (
+            <Send className="w-4 h-4" />
+          )}
+        </Button>
       </div>
     </div>
   );

--- a/apps/web/src/components/trip/mobile/mobile-trip-layout.tsx
+++ b/apps/web/src/components/trip/mobile/mobile-trip-layout.tsx
@@ -15,6 +15,7 @@ import {
 import { MembersList } from "@/components/trip/members-list";
 import { NotificationPreferences } from "@/components/notifications/notification-preferences";
 import { TripThemeProvider } from "@/components/trip/trip-theme-provider";
+import { useHasOpenDialog } from "@/hooks/use-has-open-dialog";
 import { IconStrip } from "./icon-strip";
 import { AnimatedHero } from "./animated-hero";
 import {
@@ -90,6 +91,7 @@ export function MobileTripLayout({
   initialShowOnboarding,
 }: MobileTripLayoutProps) {
   const [activeIndex, setActiveIndex] = useState(0);
+  const hasOpenDialog = useHasOpenDialog();
 
   const [isEditOpen, setIsEditOpen] = useState(false);
   const [isCustomizeOpen, setIsCustomizeOpen] = useState(false);
@@ -103,11 +105,19 @@ export function MobileTripLayout({
 
   const swiperRef = useRef<MobileTripSwiperRef>(null);
 
-  // Hero collapse: scroll-driven on Info panel, fully collapsed on other panels
+  // Hero collapse: scroll-driven on Info panel, fully collapsed on other panels.
+  // `isScrollDriving` disables CSS transitions so scroll feels instant; it is
+  // only true while the user is actively scrolling the info panel, never during
+  // a slide transition (so the hero animates smoothly between panels).
   const [infoScrollCollapse, setInfoScrollCollapse] = useState(0);
+  const [isScrollDriving, setIsScrollDriving] = useState(false);
+  const scrollDrivingTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleInfoScroll = useCallback((scrollTop: number) => {
     setInfoScrollCollapse(Math.min(1, scrollTop / 120));
+    setIsScrollDriving(true);
+    if (scrollDrivingTimer.current) clearTimeout(scrollDrivingTimer.current);
+    scrollDrivingTimer.current = setTimeout(() => setIsScrollDriving(false), 150);
   }, []);
 
   const collapseT = activeIndex === 0 ? infoScrollCollapse : 1;
@@ -139,7 +149,7 @@ export function MobileTripLayout({
         <AnimatedHero
           trip={trip}
           collapseProgress={collapseT}
-          disableTransition={activeIndex === 0}
+          disableTransition={isScrollDriving}
           isOrganizer={isOrganizer}
           onCustomize={() => setIsCustomizeOpen(true)}
         />
@@ -149,6 +159,7 @@ export function MobileTripLayout({
             ref={swiperRef}
             onSlideChange={setActiveIndex}
             onProgress={() => {}}
+            allowTouchMove={!hasOpenDialog}
           >
             <InfoPanel
               trip={trip}
@@ -188,6 +199,7 @@ export function MobileTripLayout({
               tripId={tripId}
               isOrganizer={isOrganizer}
               disabled={isLocked}
+              hideFab={activeIndex !== 4}
             />
           </MobileTripSwiper>
         </div>

--- a/apps/web/src/components/trip/mobile/mobile-trip-swiper.tsx
+++ b/apps/web/src/components/trip/mobile/mobile-trip-swiper.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { useRef, useCallback, useImperativeHandle, forwardRef } from "react";
+import { useRef, useCallback, useEffect, useImperativeHandle, forwardRef } from "react";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { HashNavigation, A11y } from "swiper/modules";
 import type { Swiper as SwiperType } from "swiper";
@@ -17,13 +17,14 @@ export interface MobileTripSwiperRef {
 interface MobileTripSwiperProps {
   onSlideChange: (index: number) => void;
   onProgress: (progress: number) => void;
+  allowTouchMove?: boolean;
   children: [ReactNode, ReactNode, ReactNode, ReactNode, ReactNode];
 }
 
 export const MobileTripSwiper = forwardRef<
   MobileTripSwiperRef,
   MobileTripSwiperProps
->(function MobileTripSwiper({ onSlideChange, onProgress, children }, ref) {
+>(function MobileTripSwiper({ onSlideChange, onProgress, allowTouchMove = true, children }, ref) {
   const swiperRef = useRef<SwiperType | null>(null);
 
   useImperativeHandle(ref, () => ({
@@ -35,6 +36,13 @@ export const MobileTripSwiper = forwardRef<
   const handleSwiper = useCallback((swiper: SwiperType) => {
     swiperRef.current = swiper;
   }, []);
+
+  // Dynamically enable/disable touch swiping (e.g. when a dialog is open)
+  useEffect(() => {
+    if (swiperRef.current) {
+      swiperRef.current.allowTouchMove = allowTouchMove;
+    }
+  }, [allowTouchMove]);
 
   const handleSlideChange = useCallback(
     (swiper: SwiperType) => {
@@ -56,6 +64,7 @@ export const MobileTripSwiper = forwardRef<
       slidesPerView={1}
       spaceBetween={0}
       speed={300}
+      allowTouchMove={allowTouchMove}
       hashNavigation={{ replaceState: true, watchState: true }}
       onSwiper={handleSwiper}
       onSlideChange={handleSlideChange}

--- a/apps/web/src/components/trip/mobile/panels/messages-panel.tsx
+++ b/apps/web/src/components/trip/mobile/panels/messages-panel.tsx
@@ -162,7 +162,7 @@ export function MessagesPanel({
       </div>
 
       {/* Input pinned at bottom */}
-      <div className="shrink-0 border-t border-border px-4 py-2 pb-safe bg-background">
+      <div className="shrink-0 border-t border-border px-4 py-2 pb-3 bg-background">
         <MessageInput
           tripId={tripId}
           disabled={inputDisabled}

--- a/apps/web/src/components/trip/mobile/panels/photos-panel.tsx
+++ b/apps/web/src/components/trip/mobile/panels/photos-panel.tsx
@@ -145,7 +145,7 @@ export function PhotosPanel({
         createPortal(
           <Button
             variant="gradient"
-            className={`fixed bottom-16 right-6 z-50 rounded-full w-14 h-14 shadow-lg transition-all duration-300 ease-out ${
+            className={`fixed bottom-20 right-6 z-50 rounded-full w-14 h-14 shadow-lg transition-all duration-300 ease-out ${
               hideFab
                 ? "opacity-0 scale-75 pointer-events-none"
                 : "opacity-100 scale-100"

--- a/apps/web/src/components/trip/mobile/panels/settle-panel.tsx
+++ b/apps/web/src/components/trip/mobile/panels/settle-panel.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useState } from "react";
+import { createPortal } from "react-dom";
 import { Plus } from "lucide-react";
+import { useMounted } from "@/hooks/use-mounted";
 import { BalanceList } from "@/components/settle/balance-list";
 import { PaymentList } from "@/components/settle/payment-list";
 import { PaymentForm } from "@/components/settle/payment-form";
@@ -13,10 +15,12 @@ interface SettlePanelProps {
   tripId: string;
   isOrganizer: boolean;
   disabled?: boolean;
+  hideFab?: boolean;
 }
 
-export function SettlePanel({ tripId, isOrganizer, disabled }: SettlePanelProps) {
+export function SettlePanel({ tripId, isOrganizer, disabled, hideFab }: SettlePanelProps) {
   const [isFormOpen, setIsFormOpen] = useState(false);
+  const mounted = useMounted();
   const [editingPayment, setEditingPayment] = useState<Payment | undefined>();
   const [settleEntry, setSettleEntry] = useState<BalanceEntry | undefined>();
 
@@ -42,7 +46,7 @@ export function SettlePanel({ tripId, isOrganizer, disabled }: SettlePanelProps)
   };
 
   return (
-    <div className="h-full flex flex-col overflow-hidden relative">
+    <div className="h-full flex flex-col overflow-hidden">
       {/* Section heading */}
       <h2 className="text-xl font-semibold font-playfair shrink-0 px-4 pt-4">Settle</h2>
 
@@ -68,18 +72,26 @@ export function SettlePanel({ tripId, isOrganizer, disabled }: SettlePanelProps)
         </div>
       </div>
 
-      {/* FAB */}
-      {!disabled && (
-        <Button
-          variant="gradient"
-          size="icon"
-          className="absolute bottom-6 right-6 z-40 h-14 w-14 rounded-full shadow-lg"
-          onClick={handleAddExpense}
-          aria-label="Add expense"
-        >
-          <Plus className="h-6 w-6" />
-        </Button>
-      )}
+      {/* FAB — portaled to body like other panel FABs */}
+      {!disabled &&
+        mounted &&
+        createPortal(
+          <Button
+            variant="gradient"
+            size="icon"
+            className={`fixed bottom-20 right-6 z-50 h-14 w-14 rounded-full shadow-lg transition-all duration-300 ease-out ${
+              hideFab
+                ? "opacity-0 scale-75 pointer-events-none"
+                : "opacity-100 scale-100"
+            }`}
+            onClick={handleAddExpense}
+            aria-label="Add expense"
+            tabIndex={hideFab ? -1 : undefined}
+          >
+            <Plus className="h-6 w-6" />
+          </Button>,
+          document.body,
+        )}
 
       {/* Payment form sheet */}
       {!disabled && (

--- a/apps/web/src/hooks/use-has-open-dialog.ts
+++ b/apps/web/src/hooks/use-has-open-dialog.ts
@@ -1,0 +1,23 @@
+import { useState, useEffect } from "react";
+
+/**
+ * Returns true when any dialog or sheet is open in the DOM.
+ * Uses a MutationObserver to watch for elements with [role="dialog"].
+ */
+export function useHasOpenDialog() {
+  const [hasDialog, setHasDialog] = useState(false);
+
+  useEffect(() => {
+    const check = () => {
+      setHasDialog(document.querySelectorAll('[role="dialog"]').length > 0);
+    };
+
+    check();
+
+    const observer = new MutationObserver(check);
+    observer.observe(document.body, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, []);
+
+  return hasDialog;
+}


### PR DESCRIPTION
## Summary
- Fix floating action button hidden on larger phones (640-767px width) — `sm:` breakpoint was overriding mobile position, placing FAB behind the icon strip
- Add proper padding (bottom-20) between all FABs and the bottom tab bar
- Unify settle panel FAB to use portaled fixed positioning like itinerary/photos
- Fix hero cover photo animation: expanding from itinerary→info now animates smoothly (was snapping due to transition being disabled on info panel)
- Prevent horizontal swipe navigation when a dialog/sheet is open — swipe right in a dialog now only closes the dialog
- Restructure message input: send button inline with textarea, padding above tab bar

## Test plan
- [ ] Open trip on mobile (especially phones ≥640px wide) — verify FAB appears on itinerary, photos, and settle tabs
- [ ] Swipe between info↔itinerary — hero should animate smoothly in both directions
- [ ] Open any dialog/sheet, swipe right — should close dialog without navigating to previous tab
- [ ] Messages tab: send button should align with bottom of textarea, input has spacing above tab bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)