### PR TITLE
Add contextual affiliate suggestion cards

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -65,3 +65,7 @@ VAPID_SUBJECT=mailto:hello@journiful.app
 # AeroDataBox Flight Lookup (optional -- feature hidden if not set)
 # Sign up at https://rapidapi.com/aedbx-aedbx/api/aerodatabox (free Basic plan)
 # AERODATABOX_API_KEY=your-api-key
+
+# Booking.com Affiliate (optional -- suggestions hidden if not set)
+# Get your affiliate ID from https://www.booking.com/affiliate-program/v2/index.html
+# BOOKING_AFFILIATE_ID=your-affiliate-id

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -44,6 +44,7 @@ import pushServicePlugin from "./plugins/push-service.js";
 import guestServicePlugin from "./plugins/guest-service.js";
 import paymentServicePlugin from "./plugins/payment-service.js";
 import balanceServicePlugin from "./plugins/balance-service.js";
+import affiliateServicePlugin from "./plugins/affiliate-service.js";
 import queueWorkersPlugin from "./queues/index.js";
 
 // Middleware
@@ -69,6 +70,7 @@ import { pushRoutes } from "./routes/push.routes.js";
 import { guestRoutes } from "./routes/guest.routes.js";
 import { paymentRoutes } from "./routes/payment.routes.js";
 import { balanceRoutes } from "./routes/balance.routes.js";
+import { affiliateRoutes } from "./routes/affiliate.routes.js";
 
 // Config
 import { env } from "./config/env.js";
@@ -238,6 +240,7 @@ export async function buildApp(
   await app.register(guestServicePlugin);
   await app.register(paymentServicePlugin);
   await app.register(balanceServicePlugin);
+  await app.register(affiliateServicePlugin);
   await app.register(queueWorkersPlugin);
 
   // Register Swagger/OpenAPI documentation (non-production only)
@@ -268,6 +271,7 @@ export async function buildApp(
   await app.register(guestRoutes, { prefix: "/api" });
   await app.register(paymentRoutes, { prefix: "/api" });
   await app.register(balanceRoutes, { prefix: "/api" });
+  await app.register(affiliateRoutes, { prefix: "/api" });
 
   // Not-found handler for unmatched routes
   app.setNotFoundHandler((request, reply) => {

--- a/apps/api/src/config/affiliates.ts
+++ b/apps/api/src/config/affiliates.ts
@@ -1,0 +1,69 @@
+import type { TripContext, GapType } from "@journiful/shared/types";
+import { env } from "./env.js";
+
+export type { TripContext, GapType };
+
+const aid = () => env.BOOKING_AFFILIATE_ID;
+
+export const BOOKING_DEEP_LINKS = {
+  flights: (ctx: TripContext) => {
+    const params = new URLSearchParams({ aid: aid() });
+    const dest = encodeURIComponent(ctx.destination);
+    if (ctx.startDate) params.set("depart", ctx.startDate);
+    if (ctx.endDate) params.set("return", ctx.endDate);
+    return `https://www.booking.com/flights/index.html?type=round&from=anywhere&to=${dest}&${params}`;
+  },
+  hotels: (ctx: TripContext) => {
+    const params = new URLSearchParams({ aid: aid() });
+    if (ctx.lat && ctx.lon) {
+      params.set("latitude", String(ctx.lat));
+      params.set("longitude", String(ctx.lon));
+    }
+    if (ctx.startDate) params.set("checkin", ctx.startDate);
+    if (ctx.endDate) params.set("checkout", ctx.endDate);
+    return `https://www.booking.com/searchresults.html?${params}`;
+  },
+  attractions: (ctx: TripContext) => {
+    const params = new URLSearchParams({ aid: aid() });
+    const dest = encodeURIComponent(ctx.destination);
+    return `https://www.booking.com/attractions/searchresults/${dest}.html?${params}`;
+  },
+} as const;
+
+export type BookingLinkType = keyof typeof BOOKING_DEEP_LINKS;
+
+interface SuggestionTemplate {
+  linkType: BookingLinkType;
+  title: string;
+  description: string;
+}
+
+export const SUGGESTION_TEMPLATES: Record<GapType, SuggestionTemplate> = {
+  missing_travel: {
+    linkType: "flights",
+    title: "Book your flights",
+    description: "You haven't added travel details yet. Find flights to {destination}.",
+  },
+  no_accommodation: {
+    linkType: "hotels",
+    title: "Find a place to stay",
+    description: "No accommodation added yet. Browse hotels in {destination}.",
+  },
+  empty_day: {
+    linkType: "attractions",
+    title: "Explore things to do",
+    description: "Nothing planned for {day}. Discover activities in {destination}.",
+  },
+  missing_meal: {
+    linkType: "attractions",
+    title: "Find a restaurant",
+    description: "No meals planned for {day}. Browse dining options in {destination}.",
+  },
+};
+
+export const BOOKING_PARTNER = {
+  slug: "booking-com",
+  name: "Booking.com",
+} as const;
+
+export const MAX_SUGGESTIONS = 3;

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -94,6 +94,9 @@ const envSchema = z.object({
   // AeroDataBox Flight Lookup (optional)
   AERODATABOX_API_KEY: z.string().default(""),
 
+  // Booking.com Affiliate (optional — suggestions hidden if not set)
+  BOOKING_AFFILIATE_ID: z.string().default(""),
+
   ALLOWED_MIME_TYPES: z
     .string()
     .transform((val) => val.split(",").map((type) => type.trim()))

--- a/apps/api/src/controllers/affiliate.controller.ts
+++ b/apps/api/src/controllers/affiliate.controller.ts
@@ -1,0 +1,60 @@
+import type { FastifyRequest, FastifyReply } from "fastify";
+import type { DismissSuggestionInput } from "@journiful/shared/schemas";
+import type {} from "@/types/index.js";
+
+export const affiliateController = {
+  async getSuggestions(
+    request: FastifyRequest<{ Params: { tripId: string } }>,
+    reply: FastifyReply,
+  ) {
+    try {
+      const suggestions = await request.server.affiliateService.getSuggestions(
+        request.user.sub,
+        request.params.tripId,
+      );
+      return reply.send({ success: true, suggestions });
+    } catch (error) {
+      if (error && typeof error === "object" && "statusCode" in error) {
+        throw error;
+      }
+      request.log.error({ err: error }, "Failed to get suggestions");
+      return reply.status(500).send({
+        success: false,
+        error: {
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to get suggestions",
+        },
+      });
+    }
+  },
+
+  async dismissSuggestion(
+    request: FastifyRequest<{
+      Params: { tripId: string };
+      Body: DismissSuggestionInput;
+    }>,
+    reply: FastifyReply,
+  ) {
+    try {
+      await request.server.affiliateService.dismissSuggestion(
+        request.user.sub,
+        request.params.tripId,
+        request.body.suggestionType,
+        request.body.suggestionKey,
+      );
+      return reply.status(204).send();
+    } catch (error) {
+      if (error && typeof error === "object" && "statusCode" in error) {
+        throw error;
+      }
+      request.log.error({ err: error }, "Failed to dismiss suggestion");
+      return reply.status(500).send({
+        success: false,
+        error: {
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to dismiss suggestion",
+        },
+      });
+    }
+  },
+};

--- a/apps/api/src/controllers/affiliate.controller.ts
+++ b/apps/api/src/controllers/affiliate.controller.ts
@@ -1,5 +1,9 @@
 import type { FastifyRequest, FastifyReply } from "fastify";
-import type { DismissSuggestionInput } from "@journiful/shared/schemas";
+import type {
+  DismissSuggestionInput,
+  TrackClickInput,
+  TrackImpressionsInput,
+} from "@journiful/shared/schemas";
 import type {} from "@/types/index.js";
 
 export const affiliateController = {
@@ -53,6 +57,62 @@ export const affiliateController = {
         error: {
           code: "INTERNAL_SERVER_ERROR",
           message: "Failed to dismiss suggestion",
+        },
+      });
+    }
+  },
+
+  async trackClick(
+    request: FastifyRequest<{ Body: TrackClickInput }>,
+    reply: FastifyReply,
+  ) {
+    try {
+      await request.server.affiliateService.trackClick(
+        request.user.sub,
+        request.body.tripId,
+        request.body.partnerSlug,
+        request.body.suggestionType,
+      );
+      return reply.send({ redirectUrl: request.body.affiliateUrl });
+    } catch (error) {
+      if (error && typeof error === "object" && "statusCode" in error) {
+        throw error;
+      }
+      request.log.error({ err: error }, "Failed to track click");
+      return reply.status(500).send({
+        success: false,
+        error: {
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to track click",
+        },
+      });
+    }
+  },
+
+  async trackImpressions(
+    request: FastifyRequest<{
+      Params: { tripId: string };
+      Body: TrackImpressionsInput;
+    }>,
+    reply: FastifyReply,
+  ) {
+    try {
+      await request.server.affiliateService.trackImpressions(
+        request.user.sub,
+        request.params.tripId,
+        request.body.impressions,
+      );
+      return reply.status(204).send();
+    } catch (error) {
+      if (error && typeof error === "object" && "statusCode" in error) {
+        throw error;
+      }
+      request.log.error({ err: error }, "Failed to track impressions");
+      return reply.status(500).send({
+        success: false,
+        error: {
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to track impressions",
         },
       });
     }

--- a/apps/api/src/db/migrations/0028_faithful_gateway.sql
+++ b/apps/api/src/db/migrations/0028_faithful_gateway.sql
@@ -1,0 +1,28 @@
+CREATE TABLE "affiliate_dismissals" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"trip_id" uuid NOT NULL,
+	"suggestion_type" varchar(50) NOT NULL,
+	"suggestion_key" varchar(100) NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "affiliate_events" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"trip_id" uuid NOT NULL,
+	"partner_slug" varchar(50) NOT NULL,
+	"suggestion_type" varchar(50) NOT NULL,
+	"event_type" varchar(20) NOT NULL,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "affiliate_dismissals" ADD CONSTRAINT "affiliate_dismissals_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "affiliate_dismissals" ADD CONSTRAINT "affiliate_dismissals_trip_id_trips_id_fk" FOREIGN KEY ("trip_id") REFERENCES "public"."trips"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "affiliate_events" ADD CONSTRAINT "affiliate_events_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "affiliate_events" ADD CONSTRAINT "affiliate_events_trip_id_trips_id_fk" FOREIGN KEY ("trip_id") REFERENCES "public"."trips"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "affiliate_dismissals_user_trip_idx" ON "affiliate_dismissals" USING btree ("user_id","trip_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "affiliate_dismissals_unique_idx" ON "affiliate_dismissals" USING btree ("user_id","trip_id","suggestion_type","suggestion_key");--> statement-breakpoint
+CREATE INDEX "affiliate_events_user_trip_idx" ON "affiliate_events" USING btree ("user_id","trip_id");--> statement-breakpoint
+CREATE INDEX "affiliate_events_created_at_idx" ON "affiliate_events" USING btree ("created_at");

--- a/apps/api/src/db/migrations/meta/0028_snapshot.json
+++ b/apps/api/src/db/migrations/meta/0028_snapshot.json
@@ -1,0 +1,3381 @@
+{
+  "id": "b33fadad-8fc5-41ec-abbf-b46d8e7708e4",
+  "prevId": "a0e11bdb-449e-45b2-95c9-59b5541db429",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accommodations": {
+      "name": "accommodations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "check_in": {
+          "name": "check_in",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_out": {
+          "name": "check_out",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "links": {
+          "name": "links",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accommodations_trip_id_idx": {
+          "name": "accommodations_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_created_by_idx": {
+          "name": "accommodations_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_check_in_idx": {
+          "name": "accommodations_check_in_idx",
+          "columns": [
+            {
+              "expression": "check_in",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_deleted_at_idx": {
+          "name": "accommodations_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_trip_id_deleted_at_idx": {
+          "name": "accommodations_trip_id_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_trip_id_not_deleted_idx": {
+          "name": "accommodations_trip_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accommodations\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accommodations_trip_id_trips_id_fk": {
+          "name": "accommodations_trip_id_trips_id_fk",
+          "tableFrom": "accommodations",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accommodations_created_by_users_id_fk": {
+          "name": "accommodations_created_by_users_id_fk",
+          "tableFrom": "accommodations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "accommodations_deleted_by_users_id_fk": {
+          "name": "accommodations_deleted_by_users_id_fk",
+          "tableFrom": "accommodations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.affiliate_dismissals": {
+      "name": "affiliate_dismissals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestion_type": {
+          "name": "suggestion_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestion_key": {
+          "name": "suggestion_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "affiliate_dismissals_user_trip_idx": {
+          "name": "affiliate_dismissals_user_trip_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "affiliate_dismissals_unique_idx": {
+          "name": "affiliate_dismissals_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "suggestion_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "suggestion_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "affiliate_dismissals_user_id_users_id_fk": {
+          "name": "affiliate_dismissals_user_id_users_id_fk",
+          "tableFrom": "affiliate_dismissals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "affiliate_dismissals_trip_id_trips_id_fk": {
+          "name": "affiliate_dismissals_trip_id_trips_id_fk",
+          "tableFrom": "affiliate_dismissals",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.affiliate_events": {
+      "name": "affiliate_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_slug": {
+          "name": "partner_slug",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestion_type": {
+          "name": "suggestion_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "affiliate_events_user_trip_idx": {
+          "name": "affiliate_events_user_trip_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "affiliate_events_created_at_idx": {
+          "name": "affiliate_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "affiliate_events_user_id_users_id_fk": {
+          "name": "affiliate_events_user_id_users_id_fk",
+          "tableFrom": "affiliate_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "affiliate_events_trip_id_trips_id_fk": {
+          "name": "affiliate_events_trip_id_trips_id_fk",
+          "tableFrom": "affiliate_events",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_attempts": {
+      "name": "auth_attempts",
+      "schema": "",
+      "columns": {
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_failed_at": {
+          "name": "last_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blacklisted_tokens": {
+      "name": "blacklisted_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "jti": {
+          "name": "jti",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blacklisted_tokens_expires_at_idx": {
+          "name": "blacklisted_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blacklisted_tokens_user_id_users_id_fk": {
+          "name": "blacklisted_tokens_user_id_users_id_fk",
+          "tableFrom": "blacklisted_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "blacklisted_tokens_jti_unique": {
+          "name": "blacklisted_tokens_jti_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "jti"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meetup_location": {
+          "name": "meetup_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meetup_time": {
+          "name": "meetup_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_day": {
+          "name": "all_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_optional": {
+          "name": "is_optional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "links": {
+          "name": "links",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_trip_id_idx": {
+          "name": "events_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_created_by_idx": {
+          "name": "events_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_start_time_idx": {
+          "name": "events_start_time_idx",
+          "columns": [
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_deleted_at_idx": {
+          "name": "events_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_trip_id_deleted_at_idx": {
+          "name": "events_trip_id_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_trip_id_not_deleted_idx": {
+          "name": "events_trip_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_trip_id_trips_id_fk": {
+          "name": "events_trip_id_trips_id_fk",
+          "tableFrom": "events",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_created_by_users_id_fk": {
+          "name": "events_created_by_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_deleted_by_users_id_fk": {
+          "name": "events_deleted_by_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flight_cache": {
+      "name": "flight_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "flight_number": {
+          "name": "flight_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "flight_cache_flight_number_date_unique": {
+          "name": "flight_cache_flight_number_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "flight_number",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_phone": {
+          "name": "invitee_phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitations_trip_id_idx": {
+          "name": "invitations_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_invitee_phone_idx": {
+          "name": "invitations_invitee_phone_idx",
+          "columns": [
+            {
+              "expression": "invitee_phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_trip_id_trips_id_fk": {
+          "name": "invitations_trip_id_trips_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_id_users_id_fk": {
+          "name": "invitations_inviter_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitations_trip_phone_unique": {
+          "name": "invitations_trip_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trip_id",
+            "invitee_phone"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member_travel": {
+      "name": "member_travel",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "travel_type": {
+          "name": "travel_type",
+          "type": "member_travel_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flight_number": {
+          "name": "flight_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_travel_trip_id_idx": {
+          "name": "member_travel_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_member_id_idx": {
+          "name": "member_travel_member_id_idx",
+          "columns": [
+            {
+              "expression": "member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_time_idx": {
+          "name": "member_travel_time_idx",
+          "columns": [
+            {
+              "expression": "time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_deleted_at_idx": {
+          "name": "member_travel_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_member_id_deleted_at_idx": {
+          "name": "member_travel_member_id_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_trip_id_deleted_at_idx": {
+          "name": "member_travel_trip_id_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_trip_id_not_deleted_idx": {
+          "name": "member_travel_trip_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"member_travel\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_travel_trip_id_trips_id_fk": {
+          "name": "member_travel_trip_id_trips_id_fk",
+          "tableFrom": "member_travel",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_travel_member_id_members_id_fk": {
+          "name": "member_travel_member_id_members_id_fk",
+          "tableFrom": "member_travel",
+          "tableTo": "members",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_travel_deleted_by_users_id_fk": {
+          "name": "member_travel_deleted_by_users_id_fk",
+          "tableFrom": "member_travel",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "rsvp_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'no_response'"
+        },
+        "is_organizer": {
+          "name": "is_organizer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "share_phone": {
+          "name": "share_phone",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "calendar_excluded": {
+          "name": "calendar_excluded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "members_trip_id_idx": {
+          "name": "members_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "members_user_id_idx": {
+          "name": "members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "members_trip_id_is_organizer_idx": {
+          "name": "members_trip_id_is_organizer_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_organizer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "members_trip_id_trips_id_fk": {
+          "name": "members_trip_id_trips_id_fk",
+          "tableFrom": "members",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "members_user_id_users_id_fk": {
+          "name": "members_user_id_users_id_fk",
+          "tableFrom": "members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "members_trip_user_unique": {
+          "name": "members_trip_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trip_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_reactions": {
+      "name": "message_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_reactions_message_id_idx": {
+          "name": "message_reactions_message_id_idx",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_reactions_user_id_idx": {
+          "name": "message_reactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_reactions_message_id_messages_id_fk": {
+          "name": "message_reactions_message_id_messages_id_fk",
+          "tableFrom": "message_reactions",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_reactions_user_id_users_id_fk": {
+          "name": "message_reactions_user_id_users_id_fk",
+          "tableFrom": "message_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "message_reactions_message_user_emoji_unique": {
+          "name": "message_reactions_message_user_emoji_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id",
+            "user_id",
+            "emoji"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_trip_id_created_at_idx": {
+          "name": "messages_trip_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_parent_id_idx": {
+          "name": "messages_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_author_id_idx": {
+          "name": "messages_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_trip_toplevel_idx": {
+          "name": "messages_trip_toplevel_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"messages\".\"parent_id\" IS NULL AND \"messages\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_trip_id_not_deleted_idx": {
+          "name": "messages_trip_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"messages\".\"deleted_at\" IS NULL AND \"messages\".\"parent_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_trip_id_trips_id_fk": {
+          "name": "messages_trip_id_trips_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_author_id_users_id_fk": {
+          "name": "messages_author_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_parent_id_messages_id_fk": {
+          "name": "messages_parent_id_messages_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_deleted_by_users_id_fk": {
+          "name": "messages_deleted_by_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.muted_members": {
+      "name": "muted_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted_by": {
+          "name": "muted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "muted_members_trip_id_trips_id_fk": {
+          "name": "muted_members_trip_id_trips_id_fk",
+          "tableFrom": "muted_members",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "muted_members_user_id_users_id_fk": {
+          "name": "muted_members_user_id_users_id_fk",
+          "tableFrom": "muted_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "muted_members_muted_by_users_id_fk": {
+          "name": "muted_members_muted_by_users_id_fk",
+          "tableFrom": "muted_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "muted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "muted_members_trip_user_unique": {
+          "name": "muted_members_trip_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trip_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daily_itinerary": {
+          "name": "daily_itinerary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "trip_messages": {
+          "name": "trip_messages",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_user_id_users_id_fk": {
+          "name": "notification_preferences_user_id_users_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_preferences_trip_id_trips_id_fk": {
+          "name": "notification_preferences_trip_id_trips_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_preferences_user_trip_unique": {
+          "name": "notification_preferences_user_trip_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "trip_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_created_at_idx": {
+          "name": "notifications_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_id_created_at_desc_idx": {
+          "name": "notifications_user_id_created_at_desc_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notifications\".\"read_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_trip_user_created_at_idx": {
+          "name": "notifications_trip_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_trip_id_trips_id_fk": {
+          "name": "notifications_trip_id_trips_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_participants": {
+      "name": "payment_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_amount": {
+          "name": "share_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_participants_payment_id_idx": {
+          "name": "payment_participants_payment_id_idx",
+          "columns": [
+            {
+              "expression": "payment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_participants_user_id_idx": {
+          "name": "payment_participants_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_participants_guest_id_idx": {
+          "name": "payment_participants_guest_id_idx",
+          "columns": [
+            {
+              "expression": "guest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_participants_payment_id_payments_id_fk": {
+          "name": "payment_participants_payment_id_payments_id_fk",
+          "tableFrom": "payment_participants",
+          "tableTo": "payments",
+          "columnsFrom": [
+            "payment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_participants_user_id_users_id_fk": {
+          "name": "payment_participants_user_id_users_id_fk",
+          "tableFrom": "payment_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_participants_guest_id_trip_guests_id_fk": {
+          "name": "payment_participants_guest_id_trip_guests_id_fk",
+          "tableFrom": "payment_participants",
+          "tableTo": "trip_guests",
+          "columnsFrom": [
+            "guest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payments_trip_id_not_deleted_idx": {
+          "name": "payments_trip_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"payments\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_user_id_idx": {
+          "name": "payments_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_guest_id_idx": {
+          "name": "payments_guest_id_idx",
+          "columns": [
+            {
+              "expression": "guest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_trip_id_trips_id_fk": {
+          "name": "payments_trip_id_trips_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payments_user_id_users_id_fk": {
+          "name": "payments_user_id_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payments_guest_id_trip_guests_id_fk": {
+          "name": "payments_guest_id_trip_guests_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "trip_guests",
+          "columnsFrom": [
+            "guest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payments_created_by_users_id_fk": {
+          "name": "payments_created_by_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_subscriptions_user_id_idx": {
+          "name": "push_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_id_users_id_fk": {
+          "name": "push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_subscriptions_endpoint_unique": {
+          "name": "push_subscriptions_endpoint_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "endpoint"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_entries": {
+      "name": "rate_limit_entries",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rate_limit_entries_expires_at_idx": {
+          "name": "rate_limit_entries_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sent_reminders": {
+      "name": "sent_reminders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sent_reminders_type_ref_idx": {
+          "name": "sent_reminders_type_ref_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sent_reminders_user_id_users_id_fk": {
+          "name": "sent_reminders_user_id_users_id_fk",
+          "tableFrom": "sent_reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sent_reminders_type_ref_user_unique": {
+          "name": "sent_reminders_type_ref_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "type",
+            "reference_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trip_guests": {
+      "name": "trip_guests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trip_guests_trip_id_idx": {
+          "name": "trip_guests_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trip_guests_trip_id_trips_id_fk": {
+          "name": "trip_guests_trip_id_trips_id_fk",
+          "tableFrom": "trip_guests",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_guests_created_by_users_id_fk": {
+          "name": "trip_guests_created_by_users_id_fk",
+          "tableFrom": "trip_guests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trip_photos": {
+      "name": "trip_photos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "photo_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trip_photos_trip_id_idx": {
+          "name": "trip_photos_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trip_photos_uploaded_by_idx": {
+          "name": "trip_photos_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trip_photos_trip_id_trips_id_fk": {
+          "name": "trip_photos_trip_id_trips_id_fk",
+          "tableFrom": "trip_photos",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_photos_uploaded_by_users_id_fk": {
+          "name": "trip_photos_uploaded_by_users_id_fk",
+          "tableFrom": "trip_photos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trips": {
+      "name": "trips",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_lat": {
+          "name": "destination_lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_lon": {
+          "name": "destination_lon",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_display_name": {
+          "name": "destination_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_timezone": {
+          "name": "preferred_timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_id": {
+          "name": "theme_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_font": {
+          "name": "theme_font",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allow_members_to_add_events": {
+          "name": "allow_members_to_add_events",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_all_members": {
+          "name": "show_all_members",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancelled": {
+          "name": "cancelled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trips_created_by_idx": {
+          "name": "trips_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trips_created_by_users_id_fk": {
+          "name": "trips_created_by_users_id_fk",
+          "tableFrom": "trips",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_photo_url": {
+          "name": "profile_photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handles": {
+          "name": "handles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature_unit": {
+          "name": "temperature_unit",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'celsius'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "calendar_token": {
+          "name": "calendar_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_at": {
+          "name": "sms_consent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_version": {
+          "name": "sms_consent_version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_phone_number_idx": {
+          "name": "users_phone_number_idx",
+          "columns": [
+            {
+              "expression": "phone_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_phone_number_unique": {
+          "name": "users_phone_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone_number"
+          ]
+        },
+        "users_calendar_token_unique": {
+          "name": "users_calendar_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "calendar_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weather_cache": {
+      "name": "weather_cache",
+      "schema": "",
+      "columns": {
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "weather_cache_trip_id_trips_id_fk": {
+          "name": "weather_cache_trip_id_trips_id_fk",
+          "tableFrom": "weather_cache",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.event_type": {
+      "name": "event_type",
+      "schema": "public",
+      "values": [
+        "travel",
+        "meal",
+        "activity"
+      ]
+    },
+    "public.invitation_status": {
+      "name": "invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "declined",
+        "failed"
+      ]
+    },
+    "public.member_travel_type": {
+      "name": "member_travel_type",
+      "schema": "public",
+      "values": [
+        "arrival",
+        "departure"
+      ]
+    },
+    "public.photo_status": {
+      "name": "photo_status",
+      "schema": "public",
+      "values": [
+        "processing",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.rsvp_status": {
+      "name": "rsvp_status",
+      "schema": "public",
+      "values": [
+        "going",
+        "not_going",
+        "maybe",
+        "no_response"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1774744683800,
       "tag": "0027_dusty_namora",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1774922028104,
+      "tag": "0028_faithful_gateway",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -7,6 +7,7 @@ import {
   text,
   timestamp,
   index,
+  uniqueIndex,
   date,
   boolean,
   pgEnum,
@@ -755,3 +756,62 @@ export const paymentParticipants = pgTable(
 
 export type PaymentParticipant = typeof paymentParticipants.$inferSelect;
 export type NewPaymentParticipant = typeof paymentParticipants.$inferInsert;
+
+// Affiliate Events (click/impression tracking)
+export const affiliateEvents = pgTable(
+  "affiliate_events",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id),
+    tripId: uuid("trip_id")
+      .notNull()
+      .references(() => trips.id, { onDelete: "cascade" }),
+    partnerSlug: varchar("partner_slug", { length: 50 }).notNull(),
+    suggestionType: varchar("suggestion_type", { length: 50 }).notNull(),
+    eventType: varchar("event_type", { length: 20 }).notNull(),
+    metadata: jsonb("metadata"),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("affiliate_events_user_trip_idx").on(table.userId, table.tripId),
+    index("affiliate_events_created_at_idx").on(table.createdAt),
+  ],
+);
+
+export type AffiliateEvent = typeof affiliateEvents.$inferSelect;
+export type NewAffiliateEvent = typeof affiliateEvents.$inferInsert;
+
+// Affiliate Dismissals (persistent per-user suggestion dismissals)
+export const affiliateDismissals = pgTable(
+  "affiliate_dismissals",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id),
+    tripId: uuid("trip_id")
+      .notNull()
+      .references(() => trips.id, { onDelete: "cascade" }),
+    suggestionType: varchar("suggestion_type", { length: 50 }).notNull(),
+    suggestionKey: varchar("suggestion_key", { length: 100 }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("affiliate_dismissals_user_trip_idx").on(table.userId, table.tripId),
+    uniqueIndex("affiliate_dismissals_unique_idx").on(
+      table.userId,
+      table.tripId,
+      table.suggestionType,
+      table.suggestionKey,
+    ),
+  ],
+);
+
+export type AffiliateDismissal = typeof affiliateDismissals.$inferSelect;
+export type NewAffiliateDismissal = typeof affiliateDismissals.$inferInsert;

--- a/apps/api/src/db/schema/relations.ts
+++ b/apps/api/src/db/schema/relations.ts
@@ -20,6 +20,8 @@ import {
   tripGuests,
   payments,
   paymentParticipants,
+  affiliateEvents,
+  affiliateDismissals,
 } from "./index.js";
 
 export const usersRelations = relations(users, ({ many }) => ({
@@ -39,6 +41,8 @@ export const usersRelations = relations(users, ({ many }) => ({
   payments: many(payments, { relationName: "paymentPayer" }),
   createdPayments: many(payments, { relationName: "paymentCreator" }),
   paymentParticipations: many(paymentParticipants),
+  affiliateEvents: many(affiliateEvents),
+  affiliateDismissals: many(affiliateDismissals),
 }));
 
 export const tripsRelations = relations(trips, ({ one, many }) => ({
@@ -56,6 +60,8 @@ export const tripsRelations = relations(trips, ({ one, many }) => ({
   photos: many(tripPhotos),
   guests: many(tripGuests),
   payments: many(payments),
+  affiliateEvents: many(affiliateEvents),
+  affiliateDismissals: many(affiliateDismissals),
 }));
 
 export const membersRelations = relations(members, ({ one, many }) => ({
@@ -264,6 +270,34 @@ export const paymentParticipantsRelations = relations(
     guest: one(tripGuests, {
       fields: [paymentParticipants.guestId],
       references: [tripGuests.id],
+    }),
+  }),
+);
+
+export const affiliateEventsRelations = relations(
+  affiliateEvents,
+  ({ one }) => ({
+    user: one(users, {
+      fields: [affiliateEvents.userId],
+      references: [users.id],
+    }),
+    trip: one(trips, {
+      fields: [affiliateEvents.tripId],
+      references: [trips.id],
+    }),
+  }),
+);
+
+export const affiliateDismissalsRelations = relations(
+  affiliateDismissals,
+  ({ one }) => ({
+    user: one(users, {
+      fields: [affiliateDismissals.userId],
+      references: [users.id],
+    }),
+    trip: one(trips, {
+      fields: [affiliateDismissals.tripId],
+      references: [trips.id],
     }),
   }),
 );

--- a/apps/api/src/db/seed.ts
+++ b/apps/api/src/db/seed.ts
@@ -379,6 +379,137 @@ async function main() {
     },
   ]);
 
+  // --- Affiliate Suggestions Test Trip ---
+  // Designed to trigger all 4 gap detection rules:
+  //   missing_travel: Alice is "going" but has no memberTravel
+  //   no_accommodation: zero accommodations
+  //   empty_day: days 3 and 4 have no events
+  //   missing_meal: day 2 has activities but no meals
+  const [lisbon] = await db
+    .insert(schema.trips)
+    .values({
+      name: "Lisbon Getaway",
+      destination: "Lisbon, Portugal",
+      destinationLat: 38.7223,
+      destinationLon: -9.1393,
+      startDate: toDateStr(daysFromNow(7)),
+      endDate: toDateStr(daysFromNow(13)),
+      preferredTimezone: "Europe/Lisbon",
+      description: "A week in Lisbon — affiliate suggestions test trip.",
+      createdBy: alice.id,
+    })
+    .returning();
+
+  const lisbonMembers = await db
+    .insert(schema.members)
+    .values([
+      {
+        tripId: lisbon!.id,
+        userId: alice.id,
+        status: "going" as const,
+        isOrganizer: true,
+      },
+      { tripId: lisbon!.id, userId: bob.id, status: "going" as const },
+      { tripId: lisbon!.id, userId: carol.id, status: "maybe" as const },
+    ])
+    .returning();
+
+  // Only Bob has travel — Alice (going) has none → triggers missing_travel
+  const bobMember = lisbonMembers.find((m) => m.userId === bob.id)!;
+  await db.insert(schema.memberTravel).values([
+    {
+      tripId: lisbon!.id,
+      memberId: bobMember.id,
+      travelType: "arrival",
+      time: daysFromNow(7, 10),
+      location: "Lisbon Airport",
+      details: "Flight from LHR",
+    },
+    {
+      tripId: lisbon!.id,
+      memberId: bobMember.id,
+      travelType: "departure",
+      time: daysFromNow(13, 16),
+      location: "Lisbon Airport",
+    },
+  ]);
+
+  // No accommodations → triggers no_accommodation
+
+  // Events: only on days 1, 2, 5 — days 3 & 4 empty → triggers empty_day
+  // Day 2 has only activities (no meals) → triggers missing_meal
+  await db.insert(schema.events).values([
+    // Day 1 (startDay+7): has meals + activities — no gap
+    {
+      tripId: lisbon!.id,
+      createdBy: alice.id,
+      name: "Welcome Dinner",
+      eventType: "meal",
+      location: "Time Out Market",
+      startTime: daysFromNow(7, 19),
+      endTime: daysFromNow(7, 21),
+    },
+    {
+      tripId: lisbon!.id,
+      createdBy: bob.id,
+      name: "Evening Walk in Alfama",
+      eventType: "activity",
+      location: "Alfama District",
+      startTime: daysFromNow(7, 16),
+      endTime: daysFromNow(7, 18),
+    },
+    // Day 2 (startDay+8): activities only, no meals → triggers missing_meal
+    {
+      tripId: lisbon!.id,
+      createdBy: alice.id,
+      name: "Belém Tower Visit",
+      eventType: "activity",
+      location: "Belém Tower",
+      startTime: daysFromNow(8, 10),
+      endTime: daysFromNow(8, 12),
+    },
+    {
+      tripId: lisbon!.id,
+      createdBy: alice.id,
+      name: "Jerónimos Monastery",
+      eventType: "activity",
+      location: "Jerónimos Monastery",
+      startTime: daysFromNow(8, 14),
+      endTime: daysFromNow(8, 16),
+    },
+    // Days 3 & 4 (startDay+9, startDay+10): no events → triggers empty_day
+    // Day 5 (startDay+11): has meals + activities — no gap
+    {
+      tripId: lisbon!.id,
+      createdBy: bob.id,
+      name: "Sintra Day Trip",
+      eventType: "activity",
+      location: "Sintra",
+      startTime: daysFromNow(11, 9),
+      endTime: daysFromNow(11, 17),
+    },
+    {
+      tripId: lisbon!.id,
+      createdBy: alice.id,
+      name: "Seafood Dinner",
+      eventType: "meal",
+      location: "Cervejaria Ramiro",
+      startTime: daysFromNow(11, 19),
+      endTime: daysFromNow(11, 21),
+    },
+  ]);
+
+  await db.insert(schema.messages).values({
+    tripId: lisbon!.id,
+    authorId: alice.id,
+    content:
+      "This trip is set up for testing affiliate suggestions — has gaps for all 4 rules!",
+  });
+
+  console.log(
+    "\n  🧪 Affiliate test trip: 'Lisbon Getaway' (login as Alice to see suggestions)\n",
+  );
+
   // Print login info
   console.log("\nSeed complete! Login with any phone number + code 000000:\n");
   console.log("  Phone Number     Name");

--- a/apps/api/src/plugins/affiliate-service.ts
+++ b/apps/api/src/plugins/affiliate-service.ts
@@ -1,0 +1,18 @@
+import fp from "fastify-plugin";
+import type { FastifyInstance } from "fastify";
+import { AffiliateService } from "@/services/affiliate.service.js";
+
+export default fp(
+  async function affiliateServicePlugin(fastify: FastifyInstance) {
+    const affiliateService = new AffiliateService(
+      fastify.db,
+      fastify.permissionsService,
+    );
+    fastify.decorate("affiliateService", affiliateService);
+  },
+  {
+    name: "affiliate-service",
+    fastify: "5.x",
+    dependencies: ["database", "permissions-service"],
+  },
+);

--- a/apps/api/src/routes/affiliate.routes.ts
+++ b/apps/api/src/routes/affiliate.routes.ts
@@ -12,8 +12,14 @@ import {
 import {
   suggestionsResponseSchema,
   dismissSuggestionSchema,
+  trackClickSchema,
+  trackImpressionsSchema,
 } from "@journiful/shared/schemas";
-import type { DismissSuggestionInput } from "@journiful/shared/schemas";
+import type {
+  DismissSuggestionInput,
+  TrackClickInput,
+  TrackImpressionsInput,
+} from "@journiful/shared/schemas";
 
 const tripIdParamsSchema = z.object({
   tripId: z.string().uuid({ message: "Invalid trip ID format" }),
@@ -54,5 +60,39 @@ export async function affiliateRoutes(fastify: FastifyInstance) {
       ],
     },
     affiliateController.dismissSuggestion,
+  );
+
+  /**
+   * POST /affiliate/click
+   * Track a click on an affiliate suggestion and return the redirect URL
+   */
+  fastify.post<{ Body: TrackClickInput }>(
+    "/affiliate/click",
+    {
+      schema: {
+        body: trackClickSchema,
+      },
+      preHandler: [fastify.rateLimit(writeRateLimitConfig), authenticate],
+    },
+    affiliateController.trackClick,
+  );
+
+  /**
+   * POST /trips/:tripId/suggestions/impressions
+   * Batch track impressions for displayed suggestions
+   */
+  fastify.post<{
+    Params: { tripId: string };
+    Body: TrackImpressionsInput;
+  }>(
+    "/trips/:tripId/suggestions/impressions",
+    {
+      schema: {
+        params: tripIdParamsSchema,
+        body: trackImpressionsSchema,
+      },
+      preHandler: [fastify.rateLimit(writeRateLimitConfig), authenticate],
+    },
+    affiliateController.trackImpressions,
   );
 }

--- a/apps/api/src/routes/affiliate.routes.ts
+++ b/apps/api/src/routes/affiliate.routes.ts
@@ -1,0 +1,58 @@
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { affiliateController } from "@/controllers/affiliate.controller.js";
+import {
+  authenticate,
+  requireCompleteProfile,
+} from "@/middleware/auth.middleware.js";
+import {
+  defaultRateLimitConfig,
+  writeRateLimitConfig,
+} from "@/middleware/rate-limit.middleware.js";
+import {
+  suggestionsResponseSchema,
+  dismissSuggestionSchema,
+} from "@journiful/shared/schemas";
+import type { DismissSuggestionInput } from "@journiful/shared/schemas";
+
+const tripIdParamsSchema = z.object({
+  tripId: z.string().uuid({ message: "Invalid trip ID format" }),
+});
+
+export async function affiliateRoutes(fastify: FastifyInstance) {
+  /**
+   * GET /trips/:tripId/suggestions
+   * Get contextual affiliate suggestions for a trip
+   */
+  fastify.get<{ Params: { tripId: string } }>(
+    "/trips/:tripId/suggestions",
+    {
+      schema: {
+        params: tripIdParamsSchema,
+        response: { 200: suggestionsResponseSchema },
+      },
+      preHandler: [fastify.rateLimit(defaultRateLimitConfig), authenticate],
+    },
+    affiliateController.getSuggestions,
+  );
+
+  /**
+   * POST /trips/:tripId/suggestions/dismiss
+   * Dismiss a suggestion so it doesn't reappear
+   */
+  fastify.post<{ Params: { tripId: string }; Body: DismissSuggestionInput }>(
+    "/trips/:tripId/suggestions/dismiss",
+    {
+      schema: {
+        params: tripIdParamsSchema,
+        body: dismissSuggestionSchema,
+      },
+      preHandler: [
+        fastify.rateLimit(writeRateLimitConfig),
+        authenticate,
+        requireCompleteProfile,
+      ],
+    },
+    affiliateController.dismissSuggestion,
+  );
+}

--- a/apps/api/src/services/affiliate.service.ts
+++ b/apps/api/src/services/affiliate.service.ts
@@ -244,20 +244,47 @@ function detectGaps(
   // Rule 3 & 4: Per-day gaps (only if trip has date range)
   if (trip.startDate && trip.endDate) {
     const days = getDateRange(trip.startDate, trip.endDate);
+    const firstDay = days[0];
+    const lastDay = days[days.length - 1];
+
     for (const day of days) {
       const dayEvents = eventRows.filter((e) => isEventOnDay(e, day));
+
+      // Count travel events on this day (arrivals + departures)
+      const travelEventsOnDay = memberTravelRows.filter((t) => {
+        const travelDate = t.time.toISOString().slice(0, 10);
+        return travelDate === day;
+      });
+      const isTravelHeavy = travelEventsOnDay.length >= 2;
+      const isArrivalOrDepartureDay = day === firstDay || day === lastDay;
+
       if (dayEvents.length === 0) {
-        gaps.push({ type: "empty_day", priority: 3, day });
+        // Don't suggest activities on travel-heavy days
+        if (!isTravelHeavy) {
+          gaps.push({ type: "empty_day", priority: 3, day });
+        }
       } else {
         const hasMeal = dayEvents.some((e) => e.eventType === "meal");
-        if (!hasMeal) {
+        // Don't suggest meals on arrival/departure days
+        if (!hasMeal && !isArrivalOrDepartureDay) {
           gaps.push({ type: "missing_meal", priority: 4, day });
         }
       }
     }
   }
 
-  return gaps;
+  // Cap to 1 day-level suggestion per day (highest priority wins)
+  const seenDays = new Set<string>();
+  const dedupedGaps: GapSignal[] = [];
+  for (const gap of gaps) {
+    if (gap.day) {
+      if (seenDays.has(gap.day)) continue;
+      seenDays.add(gap.day);
+    }
+    dedupedGaps.push(gap);
+  }
+
+  return dedupedGaps;
 }
 
 function buildSuggestions(

--- a/apps/api/src/services/affiliate.service.ts
+++ b/apps/api/src/services/affiliate.service.ts
@@ -1,0 +1,280 @@
+import { eq, and, isNull } from "drizzle-orm";
+import { randomUUID } from "node:crypto";
+import {
+  trips,
+  events,
+  accommodations,
+  memberTravel,
+  members,
+  affiliateDismissals,
+} from "@/db/schema/index.js";
+import type { AppDatabase } from "@/types/index.js";
+import type { IPermissionsService } from "@/services/permissions.service.js";
+import type { SuggestionCard, GapType, SuggestionType } from "@journiful/shared/types";
+import {
+  BOOKING_DEEP_LINKS,
+  SUGGESTION_TEMPLATES,
+  BOOKING_PARTNER,
+  MAX_SUGGESTIONS,
+  type TripContext,
+} from "@/config/affiliates.js";
+import { env } from "@/config/env.js";
+
+interface GapSignal {
+  type: GapType;
+  priority: number;
+  day?: string;
+}
+
+export interface IAffiliateService {
+  getSuggestions(userId: string, tripId: string): Promise<SuggestionCard[]>;
+  dismissSuggestion(
+    userId: string,
+    tripId: string,
+    suggestionType: string,
+    suggestionKey: string,
+  ): Promise<void>;
+}
+
+export class AffiliateService implements IAffiliateService {
+  constructor(
+    private db: AppDatabase,
+    private permissionsService: IPermissionsService,
+  ) {}
+
+  async getSuggestions(
+    userId: string,
+    tripId: string,
+  ): Promise<SuggestionCard[]> {
+    // No suggestions if affiliate ID not configured
+    if (!env.BOOKING_AFFILIATE_ID) {
+      return [];
+    }
+
+    // Check trip access
+    const canView = await this.permissionsService.canViewFullTrip(
+      userId,
+      tripId,
+    );
+    if (!canView) {
+      return [];
+    }
+
+    // Load trip data in parallel
+    const [tripRows, eventRows, accommodationRows, memberTravelRows, memberRows, dismissalRows] =
+      await Promise.all([
+        this.db
+          .select()
+          .from(trips)
+          .where(eq(trips.id, tripId))
+          .limit(1),
+        this.db
+          .select()
+          .from(events)
+          .where(and(eq(events.tripId, tripId), isNull(events.deletedAt))),
+        this.db
+          .select()
+          .from(accommodations)
+          .where(
+            and(
+              eq(accommodations.tripId, tripId),
+              isNull(accommodations.deletedAt),
+            ),
+          ),
+        this.db
+          .select()
+          .from(memberTravel)
+          .where(
+            and(
+              eq(memberTravel.tripId, tripId),
+              isNull(memberTravel.deletedAt),
+            ),
+          ),
+        this.db
+          .select()
+          .from(members)
+          .where(eq(members.tripId, tripId)),
+        this.db
+          .select()
+          .from(affiliateDismissals)
+          .where(
+            and(
+              eq(affiliateDismissals.userId, userId),
+              eq(affiliateDismissals.tripId, tripId),
+            ),
+          ),
+      ]);
+
+    const trip = tripRows[0];
+    if (!trip) {
+      return [];
+    }
+
+    // Don't show suggestions for cancelled trips
+    if (trip.cancelled) {
+      return [];
+    }
+
+    // Detect gaps
+    const gaps = detectGaps(
+      trip,
+      eventRows,
+      accommodationRows,
+      memberTravelRows,
+      memberRows,
+      userId,
+    );
+
+    // Filter out dismissed suggestions
+    const dismissedKeys = new Set(
+      dismissalRows.map((d) => `${d.suggestionType}:${d.suggestionKey}`),
+    );
+
+    const filteredGaps = gaps.filter((gap) => {
+      const key = gap.day
+        ? `${gap.type}:${gap.day}`
+        : `${gap.type}:trip`;
+      return !dismissedKeys.has(key);
+    });
+
+    // Sort by priority and cap
+    filteredGaps.sort((a, b) => a.priority - b.priority);
+    const topGaps = filteredGaps.slice(0, MAX_SUGGESTIONS);
+
+    // Build suggestion cards
+    const tripContext: TripContext = {
+      destination: trip.destination,
+      lat: trip.destinationLat,
+      lon: trip.destinationLon,
+      startDate: trip.startDate,
+      endDate: trip.endDate,
+    };
+
+    return buildSuggestions(topGaps, tripContext);
+  }
+
+  async dismissSuggestion(
+    userId: string,
+    tripId: string,
+    suggestionType: string,
+    suggestionKey: string,
+  ): Promise<void> {
+    await this.db
+      .insert(affiliateDismissals)
+      .values({
+        userId,
+        tripId,
+        suggestionType,
+        suggestionKey,
+      })
+      .onConflictDoNothing();
+  }
+}
+
+function detectGaps(
+  trip: typeof trips.$inferSelect,
+  eventRows: (typeof events.$inferSelect)[],
+  accommodationRows: (typeof accommodations.$inferSelect)[],
+  memberTravelRows: (typeof memberTravel.$inferSelect)[],
+  memberRows: (typeof members.$inferSelect)[],
+  currentUserId: string,
+): GapSignal[] {
+  const gaps: GapSignal[] = [];
+
+  // Rule 1: Current user is "going" but has no travel entries
+  const currentMember = memberRows.find((m) => m.userId === currentUserId);
+  if (currentMember?.status === "going") {
+    const hasTravel = memberTravelRows.some(
+      (t) => t.memberId === currentMember.id,
+    );
+    if (!hasTravel) {
+      gaps.push({ type: "missing_travel", priority: 1 });
+    }
+  }
+
+  // Rule 2: No accommodations
+  if (accommodationRows.length === 0 && trip.startDate) {
+    gaps.push({ type: "no_accommodation", priority: 2 });
+  }
+
+  // Rule 3 & 4: Per-day gaps (only if trip has date range)
+  if (trip.startDate && trip.endDate) {
+    const days = getDateRange(trip.startDate, trip.endDate);
+    for (const day of days) {
+      const dayEvents = eventRows.filter((e) => isEventOnDay(e, day));
+      if (dayEvents.length === 0) {
+        gaps.push({ type: "empty_day", priority: 3, day });
+      } else {
+        const hasMeal = dayEvents.some((e) => e.eventType === "meal");
+        if (!hasMeal) {
+          gaps.push({ type: "missing_meal", priority: 4, day });
+        }
+      }
+    }
+  }
+
+  return gaps;
+}
+
+function buildSuggestions(
+  gaps: GapSignal[],
+  tripContext: TripContext,
+): SuggestionCard[] {
+  return gaps.map((gap) => {
+    const template = SUGGESTION_TEMPLATES[gap.type];
+    const ctx: TripContext = { ...tripContext };
+    if (gap.day) {
+      ctx.dayDate = gap.day;
+    }
+
+    const destination = tripContext.destination || "your destination";
+    const dayFormatted = gap.day
+      ? new Date(gap.day + "T00:00:00").toLocaleDateString("en-US", {
+          weekday: "short",
+          month: "short",
+          day: "numeric",
+        })
+      : "";
+
+    const title = template.title;
+    const description = template.description
+      .replace("{destination}", destination)
+      .replace("{day}", dayFormatted);
+
+    const affiliateUrl = BOOKING_DEEP_LINKS[template.linkType](ctx);
+    const dismissKey = gap.day ? gap.day : "trip";
+    const suggestionType: SuggestionType = template.linkType;
+
+    return {
+      id: randomUUID(),
+      gapType: gap.type,
+      suggestionType,
+      title,
+      description,
+      affiliateUrl,
+      partner: { ...BOOKING_PARTNER },
+      dismissKey,
+      day: gap.day ?? null,
+      priority: gap.priority,
+    };
+  });
+}
+
+export function getDateRange(start: string, end: string): string[] {
+  const days: string[] = [];
+  const current = new Date(start + "T00:00:00Z");
+  const last = new Date(end + "T00:00:00Z");
+  while (current <= last) {
+    days.push(current.toISOString().slice(0, 10));
+    current.setUTCDate(current.getUTCDate() + 1);
+  }
+  return days;
+}
+
+export function isEventOnDay(
+  event: typeof events.$inferSelect,
+  day: string,
+): boolean {
+  const eventDate = event.startTime.toISOString().slice(0, 10);
+  return eventDate === day;
+}

--- a/apps/api/src/services/affiliate.service.ts
+++ b/apps/api/src/services/affiliate.service.ts
@@ -7,6 +7,7 @@ import {
   memberTravel,
   members,
   affiliateDismissals,
+  affiliateEvents,
 } from "@/db/schema/index.js";
 import type { AppDatabase } from "@/types/index.js";
 import type { IPermissionsService } from "@/services/permissions.service.js";
@@ -33,6 +34,17 @@ export interface IAffiliateService {
     tripId: string,
     suggestionType: string,
     suggestionKey: string,
+  ): Promise<void>;
+  trackClick(
+    userId: string,
+    tripId: string,
+    partnerSlug: string,
+    suggestionType: string,
+  ): Promise<void>;
+  trackImpressions(
+    userId: string,
+    tripId: string,
+    impressions: Array<{ partnerSlug: string; suggestionType: string }>,
   ): Promise<void>;
 }
 
@@ -168,6 +180,38 @@ export class AffiliateService implements IAffiliateService {
         suggestionKey,
       })
       .onConflictDoNothing();
+  }
+
+  async trackClick(
+    userId: string,
+    tripId: string,
+    partnerSlug: string,
+    suggestionType: string,
+  ): Promise<void> {
+    await this.db.insert(affiliateEvents).values({
+      userId,
+      tripId,
+      partnerSlug,
+      suggestionType,
+      eventType: "click",
+    });
+  }
+
+  async trackImpressions(
+    userId: string,
+    tripId: string,
+    impressions: Array<{ partnerSlug: string; suggestionType: string }>,
+  ): Promise<void> {
+    if (impressions.length === 0) return;
+    await this.db.insert(affiliateEvents).values(
+      impressions.map((imp) => ({
+        userId,
+        tripId,
+        partnerSlug: imp.partnerSlug,
+        suggestionType: imp.suggestionType,
+        eventType: "impression" as const,
+      })),
+    );
   }
 }
 

--- a/apps/api/src/types/index.ts
+++ b/apps/api/src/types/index.ts
@@ -29,6 +29,7 @@ import type { IPushService } from "@/services/push.service.js";
 import type { IGuestService } from "@/services/guest.service.js";
 import type { IPaymentService } from "@/services/payment.service.js";
 import type { IBalanceService } from "@/services/balance.service.js";
+import type { IAffiliateService } from "@/services/affiliate.service.js";
 
 export type FullSchema = typeof schema & typeof relations;
 export type AppDatabase = NodePgDatabase<FullSchema>;
@@ -87,6 +88,7 @@ declare module "fastify" {
     guestService: IGuestService;
     paymentService: IPaymentService;
     balanceService: IBalanceService;
+    affiliateService: IAffiliateService;
     healthService: { getStatus(): Promise<HealthCheckResponse> };
   }
 }

--- a/apps/api/tests/integration/affiliate.routes.test.ts
+++ b/apps/api/tests/integration/affiliate.routes.test.ts
@@ -1,0 +1,385 @@
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import type { FastifyInstance } from "fastify";
+import { buildApp } from "../helpers.js";
+import { db } from "@/config/database.js";
+import {
+  users,
+  trips,
+  members,
+  affiliateEvents,
+  affiliateDismissals,
+} from "@/db/schema/index.js";
+import { eq, and } from "drizzle-orm";
+import { generateUniquePhone } from "../test-utils.js";
+
+describe("Affiliate Routes", () => {
+  let app: FastifyInstance;
+
+  beforeEach(() => {
+    process.env.BOOKING_AFFILIATE_ID = "test-affiliate-123";
+  });
+
+  afterEach(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  // Helper to create a user, trip, and member for tests
+  async function createTestTripWithMember(opts?: {
+    memberStatus?: string;
+    startDate?: string;
+    endDate?: string;
+    destination?: string;
+  }) {
+    const [testUser] = await db
+      .insert(users)
+      .values({
+        phoneNumber: generateUniquePhone(),
+        displayName: "Test User",
+        timezone: "UTC",
+      })
+      .returning();
+
+    const [trip] = await db
+      .insert(trips)
+      .values({
+        name: "Test Trip",
+        destination: opts?.destination ?? "Paris",
+        preferredTimezone: "Europe/Paris",
+        createdBy: testUser.id,
+        startDate: opts?.startDate ?? "2026-07-01",
+        endDate: opts?.endDate ?? "2026-07-03",
+      })
+      .returning();
+
+    await db.insert(members).values({
+      tripId: trip.id,
+      userId: testUser.id,
+      status: opts?.memberStatus ?? "going",
+    });
+
+    return { testUser, trip };
+  }
+
+  describe("GET /api/trips/:tripId/suggestions", () => {
+    it("should return 401 without auth token", async () => {
+      app = await buildApp();
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/trips/550e8400-e29b-41d4-a716-446655440000/suggestions",
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+
+    it("should return suggestions for a trip with gaps", async () => {
+      app = await buildApp();
+      const { testUser, trip } = await createTestTripWithMember();
+
+      const token = app.jwt.sign({
+        sub: testUser.id,
+        name: testUser.displayName,
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/trips/${trip.id}/suggestions`,
+        cookies: { auth_token: token },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.success).toBe(true);
+      expect(Array.isArray(body.suggestions)).toBe(true);
+      // Trip with no accommodations and member "going" with no travel should have suggestions
+      expect(body.suggestions.length).toBeGreaterThan(0);
+
+      // Each suggestion should have the expected shape
+      for (const suggestion of body.suggestions) {
+        expect(suggestion).toHaveProperty("id");
+        expect(suggestion).toHaveProperty("gapType");
+        expect(suggestion).toHaveProperty("suggestionType");
+        expect(suggestion).toHaveProperty("title");
+        expect(suggestion).toHaveProperty("description");
+        expect(suggestion).toHaveProperty("affiliateUrl");
+        expect(suggestion).toHaveProperty("partner");
+        expect(suggestion.partner).toHaveProperty("slug");
+        expect(suggestion.partner).toHaveProperty("name");
+        expect(suggestion).toHaveProperty("dismissKey");
+      }
+    });
+
+    it("should return empty suggestions for non-member of the trip", async () => {
+      app = await buildApp();
+      const { trip } = await createTestTripWithMember();
+
+      // Create a separate user who is NOT a member
+      const [outsider] = await db
+        .insert(users)
+        .values({
+          phoneNumber: generateUniquePhone(),
+          displayName: "Outsider",
+          timezone: "UTC",
+        })
+        .returning();
+
+      const token = app.jwt.sign({
+        sub: outsider.id,
+        name: outsider.displayName,
+      });
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/api/trips/${trip.id}/suggestions`,
+        cookies: { auth_token: token },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.success).toBe(true);
+      expect(body.suggestions).toHaveLength(0);
+    });
+
+    it("should respect dismissals", async () => {
+      app = await buildApp();
+      const { testUser, trip } = await createTestTripWithMember();
+
+      const token = app.jwt.sign({
+        sub: testUser.id,
+        name: testUser.displayName,
+      });
+
+      // Get initial suggestions
+      const initialResponse = await app.inject({
+        method: "GET",
+        url: `/api/trips/${trip.id}/suggestions`,
+        cookies: { auth_token: token },
+      });
+
+      const initialBody = JSON.parse(initialResponse.body);
+      expect(initialBody.suggestions.length).toBeGreaterThan(0);
+
+      const firstSuggestion = initialBody.suggestions[0];
+
+      // Dismiss the first suggestion (use gapType, not suggestionType)
+      await app.inject({
+        method: "POST",
+        url: `/api/trips/${trip.id}/suggestions/dismiss`,
+        cookies: { auth_token: token },
+        payload: {
+          suggestionType: firstSuggestion.gapType,
+          suggestionKey: firstSuggestion.dismissKey,
+        },
+      });
+
+      // Get suggestions again - dismissed one should be gone
+      const afterResponse = await app.inject({
+        method: "GET",
+        url: `/api/trips/${trip.id}/suggestions`,
+        cookies: { auth_token: token },
+      });
+
+      const afterBody = JSON.parse(afterResponse.body);
+      const dismissedStillPresent = afterBody.suggestions.some(
+        (s: { gapType: string; dismissKey: string }) =>
+          s.gapType === firstSuggestion.gapType &&
+          s.dismissKey === firstSuggestion.dismissKey,
+      );
+      expect(dismissedStillPresent).toBe(false);
+    });
+  });
+
+  describe("POST /api/trips/:tripId/suggestions/dismiss", () => {
+    it("should return 204 on successful dismiss", async () => {
+      app = await buildApp();
+      const { testUser, trip } = await createTestTripWithMember();
+
+      const token = app.jwt.sign({
+        sub: testUser.id,
+        name: testUser.displayName,
+      });
+
+      const response = await app.inject({
+        method: "POST",
+        url: `/api/trips/${trip.id}/suggestions/dismiss`,
+        cookies: { auth_token: token },
+        payload: {
+          suggestionType: "hotels",
+          suggestionKey: "trip",
+        },
+      });
+
+      expect(response.statusCode).toBe(204);
+    });
+
+    it("should be idempotent (dismissing same suggestion twice does not error)", async () => {
+      app = await buildApp();
+      const { testUser, trip } = await createTestTripWithMember();
+
+      const token = app.jwt.sign({
+        sub: testUser.id,
+        name: testUser.displayName,
+      });
+
+      const payload = {
+        suggestionType: "hotels",
+        suggestionKey: "trip",
+      };
+
+      const first = await app.inject({
+        method: "POST",
+        url: `/api/trips/${trip.id}/suggestions/dismiss`,
+        cookies: { auth_token: token },
+        payload,
+      });
+      expect(first.statusCode).toBe(204);
+
+      const second = await app.inject({
+        method: "POST",
+        url: `/api/trips/${trip.id}/suggestions/dismiss`,
+        cookies: { auth_token: token },
+        payload,
+      });
+      expect(second.statusCode).toBe(204);
+    });
+
+    it("should return 401 without auth", async () => {
+      app = await buildApp();
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/trips/550e8400-e29b-41d4-a716-446655440000/suggestions/dismiss",
+        payload: {
+          suggestionType: "hotels",
+          suggestionKey: "trip",
+        },
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+  });
+
+  describe("POST /api/affiliate/click", () => {
+    it("should log a click event and return success", async () => {
+      app = await buildApp();
+      const { testUser, trip } = await createTestTripWithMember();
+
+      const token = app.jwt.sign({
+        sub: testUser.id,
+        name: testUser.displayName,
+      });
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/affiliate/click",
+        cookies: { auth_token: token },
+        payload: {
+          partnerSlug: "booking-com",
+          tripId: trip.id,
+          suggestionType: "hotels",
+          affiliateUrl: "https://www.booking.com/searchresults.html?aid=test",
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body).toHaveProperty("redirectUrl");
+      expect(body.redirectUrl).toBe(
+        "https://www.booking.com/searchresults.html?aid=test",
+      );
+
+      // Verify the click was recorded in the database
+      const events = await db
+        .select()
+        .from(affiliateEvents)
+        .where(
+          and(
+            eq(affiliateEvents.userId, testUser.id),
+            eq(affiliateEvents.tripId, trip.id),
+            eq(affiliateEvents.eventType, "click"),
+          ),
+        );
+      expect(events).toHaveLength(1);
+      expect(events[0].partnerSlug).toBe("booking-com");
+      expect(events[0].suggestionType).toBe("hotels");
+    });
+
+    it("should return 401 without auth", async () => {
+      app = await buildApp();
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/affiliate/click",
+        payload: {
+          partnerSlug: "booking-com",
+          tripId: "550e8400-e29b-41d4-a716-446655440000",
+          suggestionType: "hotels",
+          affiliateUrl: "https://www.booking.com/searchresults.html?aid=test",
+        },
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+  });
+
+  describe("POST /api/trips/:tripId/suggestions/impressions", () => {
+    it("should batch log impression events and return success", async () => {
+      app = await buildApp();
+      const { testUser, trip } = await createTestTripWithMember();
+
+      const token = app.jwt.sign({
+        sub: testUser.id,
+        name: testUser.displayName,
+      });
+
+      const response = await app.inject({
+        method: "POST",
+        url: `/api/trips/${trip.id}/suggestions/impressions`,
+        cookies: { auth_token: token },
+        payload: {
+          impressions: [
+            { partnerSlug: "booking-com", suggestionType: "hotels" },
+            { partnerSlug: "booking-com", suggestionType: "flights" },
+          ],
+        },
+      });
+
+      expect(response.statusCode).toBe(204);
+
+      // Verify impression records in the database
+      const events = await db
+        .select()
+        .from(affiliateEvents)
+        .where(
+          and(
+            eq(affiliateEvents.userId, testUser.id),
+            eq(affiliateEvents.tripId, trip.id),
+            eq(affiliateEvents.eventType, "impression"),
+          ),
+        );
+      expect(events).toHaveLength(2);
+      expect(events.map((e) => e.suggestionType).sort()).toEqual([
+        "flights",
+        "hotels",
+      ]);
+    });
+
+    it("should return 401 without auth", async () => {
+      app = await buildApp();
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/trips/550e8400-e29b-41d4-a716-446655440000/suggestions/impressions",
+        payload: {
+          impressions: [
+            { partnerSlug: "booking-com", suggestionType: "hotels" },
+          ],
+        },
+      });
+
+      expect(response.statusCode).toBe(401);
+    });
+  });
+});

--- a/apps/api/tests/integration/affiliate.routes.test.ts
+++ b/apps/api/tests/integration/affiliate.routes.test.ts
@@ -10,19 +10,27 @@ import {
   affiliateDismissals,
 } from "@/db/schema/index.js";
 import { eq, and } from "drizzle-orm";
+import { env } from "@/config/env.js";
 import { generateUniquePhone } from "../test-utils.js";
+
+const ORIGINAL_AFFILIATE_ID = env.BOOKING_AFFILIATE_ID;
 
 describe("Affiliate Routes", () => {
   let app: FastifyInstance;
 
   beforeEach(() => {
-    process.env.BOOKING_AFFILIATE_ID = "test-affiliate-123";
+    // Mutate the parsed env singleton directly — setting process.env has no
+    // effect because env is computed once at module load via Zod parse.
+    (env as { BOOKING_AFFILIATE_ID: string }).BOOKING_AFFILIATE_ID =
+      "test-affiliate-123";
   });
 
   afterEach(async () => {
     if (app) {
       await app.close();
     }
+    (env as { BOOKING_AFFILIATE_ID: string }).BOOKING_AFFILIATE_ID =
+      ORIGINAL_AFFILIATE_ID;
   });
 
   // Helper to create a user, trip, and member for tests

--- a/apps/api/tests/integration/affiliate.routes.test.ts
+++ b/apps/api/tests/integration/affiliate.routes.test.ts
@@ -7,7 +7,6 @@ import {
   trips,
   members,
   affiliateEvents,
-  affiliateDismissals,
 } from "@/db/schema/index.js";
 import { eq, and } from "drizzle-orm";
 import { env } from "@/config/env.js";

--- a/apps/api/tests/unit/affiliate.service.test.ts
+++ b/apps/api/tests/unit/affiliate.service.test.ts
@@ -1,0 +1,545 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { db } from "@/config/database.js";
+import {
+  users,
+  trips,
+  members,
+  events,
+  accommodations,
+  memberTravel,
+  affiliateDismissals,
+  affiliateEvents,
+} from "@/db/schema/index.js";
+import { eq, or } from "drizzle-orm";
+import {
+  AffiliateService,
+  getDateRange,
+  isEventOnDay,
+} from "@/services/affiliate.service.js";
+import { PermissionsService } from "@/services/permissions.service.js";
+import { BOOKING_DEEP_LINKS } from "@/config/affiliates.js";
+import { generateUniquePhone } from "../test-utils.js";
+
+// Mock env to control BOOKING_AFFILIATE_ID
+vi.mock("@/config/env.js", () => ({
+  env: {
+    BOOKING_AFFILIATE_ID: "test-affiliate-123",
+    // Add other env values the code may reference
+    NODE_ENV: "test",
+    PORT: 8000,
+    HOST: "0.0.0.0",
+    DATABASE_URL: process.env.DATABASE_URL,
+    JWT_SECRET: process.env.JWT_SECRET,
+    FRONTEND_URL: "http://localhost:3000",
+    TRUST_PROXY: false,
+    COOKIE_SECURE: false,
+    EXPOSE_ERROR_DETAILS: true,
+    ENABLE_FIXED_VERIFICATION_CODE: true,
+    LOG_LEVEL: "info",
+    TWILIO_ACCOUNT_SID: "",
+    TWILIO_AUTH_TOKEN: "",
+    TWILIO_VERIFY_SERVICE_SID: "",
+    STORAGE_PROVIDER: "local",
+    AWS_ENDPOINT_URL: "",
+    AWS_S3_BUCKET_NAME: "",
+    AWS_ACCESS_KEY_ID: "",
+    AWS_SECRET_ACCESS_KEY: "",
+    AWS_DEFAULT_REGION: "us-east-1",
+    UPLOAD_DIR: "uploads",
+    MAX_FILE_SIZE: 5242880,
+    VAPID_PUBLIC_KEY: "",
+    VAPID_PRIVATE_KEY: "",
+    VAPID_SUBJECT: "mailto:hello@journiful.app",
+    AERODATABOX_API_KEY: "",
+    ALLOWED_MIME_TYPES: ["image/jpeg", "image/png", "image/webp"],
+    COOKIE_DOMAIN: undefined,
+  },
+}));
+
+// Get a reference to the mocked env so we can modify it per-test
+import { env } from "@/config/env.js";
+
+const permissionsService = new PermissionsService(db);
+const affiliateService = new AffiliateService(db, permissionsService);
+
+describe("affiliate.service", () => {
+  // --- Helper function tests (no DB needed) ---
+
+  describe("getDateRange", () => {
+    it("should return 4 dates for a 3-night range", () => {
+      const result = getDateRange("2026-04-10", "2026-04-13");
+      expect(result).toEqual([
+        "2026-04-10",
+        "2026-04-11",
+        "2026-04-12",
+        "2026-04-13",
+      ]);
+    });
+
+    it("should return 1 date when start equals end", () => {
+      const result = getDateRange("2026-04-10", "2026-04-10");
+      expect(result).toEqual(["2026-04-10"]);
+    });
+  });
+
+  describe("isEventOnDay", () => {
+    it("should match event by startTime date", () => {
+      const event = {
+        startTime: new Date("2026-04-10T14:00:00Z"),
+      } as typeof events.$inferSelect;
+
+      expect(isEventOnDay(event, "2026-04-10")).toBe(true);
+      expect(isEventOnDay(event, "2026-04-11")).toBe(false);
+    });
+  });
+
+  // --- Deep link URL tests ---
+
+  describe("BOOKING_DEEP_LINKS", () => {
+    it("flights URL includes destination, dates, affiliate ID", () => {
+      const url = BOOKING_DEEP_LINKS.flights({
+        destination: "Paris",
+        lat: null,
+        lon: null,
+        startDate: "2026-06-01",
+        endDate: "2026-06-10",
+      });
+      expect(url).toContain("to=Paris");
+      expect(url).toContain("depart=2026-06-01");
+      expect(url).toContain("return=2026-06-10");
+      expect(url).toContain("aid=test-affiliate-123");
+    });
+
+    it("hotels URL includes lat/lon and dates", () => {
+      const url = BOOKING_DEEP_LINKS.hotels({
+        destination: "Paris",
+        lat: 48.8566,
+        lon: 2.3522,
+        startDate: "2026-06-01",
+        endDate: "2026-06-10",
+      });
+      expect(url).toContain("latitude=48.8566");
+      expect(url).toContain("longitude=2.3522");
+      expect(url).toContain("checkin=2026-06-01");
+      expect(url).toContain("checkout=2026-06-10");
+      expect(url).toContain("aid=test-affiliate-123");
+    });
+
+    it("attractions URL includes destination", () => {
+      const url = BOOKING_DEEP_LINKS.attractions({
+        destination: "Paris",
+        lat: null,
+        lon: null,
+        startDate: null,
+        endDate: null,
+      });
+      expect(url).toContain("Paris");
+      expect(url).toContain("aid=test-affiliate-123");
+    });
+
+    it("hotels URL handles missing lat/lon gracefully", () => {
+      const url = BOOKING_DEEP_LINKS.hotels({
+        destination: "Paris",
+        lat: null,
+        lon: null,
+        startDate: "2026-06-01",
+        endDate: "2026-06-10",
+      });
+      expect(url).not.toContain("latitude");
+      expect(url).not.toContain("longitude");
+      expect(url).toContain("checkin=2026-06-01");
+    });
+
+    it("flights URL handles missing dates gracefully", () => {
+      const url = BOOKING_DEEP_LINKS.flights({
+        destination: "Paris",
+        lat: null,
+        lon: null,
+        startDate: null,
+        endDate: null,
+      });
+      expect(url).not.toContain("depart");
+      expect(url).not.toContain("return");
+      expect(url).toContain("aid=test-affiliate-123");
+    });
+  });
+
+  // --- Gap detection tests via getSuggestions ---
+
+  describe("getSuggestions", () => {
+    let testUserPhone: string;
+    let testUserId: string;
+    let testTripId: string;
+    let testMemberId: string;
+
+    const cleanup = async () => {
+      if (testTripId) {
+        await db
+          .delete(affiliateDismissals)
+          .where(eq(affiliateDismissals.tripId, testTripId));
+        await db
+          .delete(affiliateEvents)
+          .where(eq(affiliateEvents.tripId, testTripId));
+        await db.delete(events).where(eq(events.tripId, testTripId));
+        await db
+          .delete(memberTravel)
+          .where(eq(memberTravel.tripId, testTripId));
+        await db.delete(members).where(eq(members.tripId, testTripId));
+        await db
+          .delete(accommodations)
+          .where(eq(accommodations.tripId, testTripId));
+        await db.delete(trips).where(eq(trips.id, testTripId));
+      }
+      if (testUserPhone) {
+        await db
+          .delete(users)
+          .where(eq(users.phoneNumber, testUserPhone));
+      }
+    };
+
+    beforeEach(async () => {
+      testUserPhone = generateUniquePhone();
+      await cleanup();
+
+      // Create test user
+      const userResult = await db
+        .insert(users)
+        .values({
+          phoneNumber: testUserPhone,
+          displayName: "Affiliate Test User",
+          timezone: "UTC",
+        })
+        .returning();
+      testUserId = userResult[0].id;
+
+      // Create test trip (4-day trip: Apr 10-13)
+      const tripResult = await db
+        .insert(trips)
+        .values({
+          name: "Affiliate Test Trip",
+          destination: "Paris",
+          destinationLat: 48.8566,
+          destinationLon: 2.3522,
+          startDate: "2026-04-10",
+          endDate: "2026-04-13",
+          preferredTimezone: "UTC",
+          createdBy: testUserId,
+        })
+        .returning();
+      testTripId = tripResult[0].id;
+
+      // Add user as member with status "going"
+      const memberResult = await db
+        .insert(members)
+        .values({
+          tripId: testTripId,
+          userId: testUserId,
+          status: "going",
+        })
+        .returning();
+      testMemberId = memberResult[0].id;
+    });
+
+    afterEach(cleanup);
+
+    it("missing_travel: user going, no travel → gets suggestion", async () => {
+      const suggestions = await affiliateService.getSuggestions(
+        testUserId,
+        testTripId,
+      );
+      const travelSuggestion = suggestions.find(
+        (s) => s.gapType === "missing_travel",
+      );
+      expect(travelSuggestion).toBeDefined();
+      expect(travelSuggestion!.suggestionType).toBe("flights");
+    });
+
+    it("no_accommodation: zero accommodations → gets suggestion", async () => {
+      const suggestions = await affiliateService.getSuggestions(
+        testUserId,
+        testTripId,
+      );
+      const accommodationSuggestion = suggestions.find(
+        (s) => s.gapType === "no_accommodation",
+      );
+      expect(accommodationSuggestion).toBeDefined();
+      expect(accommodationSuggestion!.suggestionType).toBe("hotels");
+    });
+
+    it("empty_day: day with zero events → gets suggestion", async () => {
+      // Add accommodation so no_accommodation doesn't appear
+      await db.insert(accommodations).values({
+        tripId: testTripId,
+        createdBy: testUserId,
+        name: "Test Hotel",
+        checkIn: new Date("2026-04-10T14:00:00Z"),
+        checkOut: new Date("2026-04-13T11:00:00Z"),
+      });
+      // Add travel so missing_travel doesn't appear
+      await db.insert(memberTravel).values({
+        tripId: testTripId,
+        memberId: testMemberId,
+        travelType: "arrival",
+        time: new Date("2026-04-10T10:00:00Z"),
+      });
+
+      const suggestions = await affiliateService.getSuggestions(
+        testUserId,
+        testTripId,
+      );
+      const emptyDaySuggestion = suggestions.find(
+        (s) => s.gapType === "empty_day",
+      );
+      expect(emptyDaySuggestion).toBeDefined();
+      expect(emptyDaySuggestion!.suggestionType).toBe("attractions");
+    });
+
+    it("missing_meal: day with activity but no meal → gets suggestion", async () => {
+      // Add accommodation and travel to suppress those suggestions
+      await db.insert(accommodations).values({
+        tripId: testTripId,
+        createdBy: testUserId,
+        name: "Test Hotel",
+        checkIn: new Date("2026-04-10T14:00:00Z"),
+        checkOut: new Date("2026-04-13T11:00:00Z"),
+      });
+      await db.insert(memberTravel).values({
+        tripId: testTripId,
+        memberId: testMemberId,
+        travelType: "arrival",
+        time: new Date("2026-04-10T10:00:00Z"),
+      });
+
+      // Add meal events on all other days so they don't generate gaps
+      await db.insert(events).values([
+        {
+          tripId: testTripId,
+          createdBy: testUserId,
+          name: "Breakfast",
+          eventType: "meal",
+          startTime: new Date("2026-04-10T09:00:00Z"),
+        },
+        {
+          tripId: testTripId,
+          createdBy: testUserId,
+          name: "Lunch",
+          eventType: "meal",
+          startTime: new Date("2026-04-12T12:00:00Z"),
+        },
+        {
+          tripId: testTripId,
+          createdBy: testUserId,
+          name: "Dinner",
+          eventType: "meal",
+          startTime: new Date("2026-04-13T19:00:00Z"),
+        },
+      ]);
+
+      // Add an activity event on Apr 11 (middle day, not first/last) — no meal
+      await db.insert(events).values({
+        tripId: testTripId,
+        createdBy: testUserId,
+        name: "Sightseeing",
+        eventType: "activity",
+        startTime: new Date("2026-04-11T10:00:00Z"),
+      });
+
+      const suggestions = await affiliateService.getSuggestions(
+        testUserId,
+        testTripId,
+      );
+      const mealSuggestion = suggestions.find(
+        (s) => s.gapType === "missing_meal",
+      );
+      expect(mealSuggestion).toBeDefined();
+      expect(mealSuggestion!.day).toBe("2026-04-11");
+    });
+
+    // --- Edge cases ---
+
+    it("should not suggest meals on first/last day of trip", async () => {
+      // Add accommodation and travel
+      await db.insert(accommodations).values({
+        tripId: testTripId,
+        createdBy: testUserId,
+        name: "Test Hotel",
+        checkIn: new Date("2026-04-10T14:00:00Z"),
+        checkOut: new Date("2026-04-13T11:00:00Z"),
+      });
+      await db.insert(memberTravel).values({
+        tripId: testTripId,
+        memberId: testMemberId,
+        travelType: "arrival",
+        time: new Date("2026-04-10T10:00:00Z"),
+      });
+
+      // Add activity events on first and last day (no meals)
+      await db.insert(events).values([
+        {
+          tripId: testTripId,
+          createdBy: testUserId,
+          name: "Arrival Activity",
+          eventType: "activity",
+          startTime: new Date("2026-04-10T15:00:00Z"),
+        },
+        {
+          tripId: testTripId,
+          createdBy: testUserId,
+          name: "Departure Activity",
+          eventType: "activity",
+          startTime: new Date("2026-04-13T09:00:00Z"),
+        },
+      ]);
+
+      const suggestions = await affiliateService.getSuggestions(
+        testUserId,
+        testTripId,
+      );
+      const mealSuggestions = suggestions.filter(
+        (s) => s.gapType === "missing_meal",
+      );
+      // No meal suggestions for first (Apr 10) or last (Apr 13) day
+      for (const s of mealSuggestions) {
+        expect(s.day).not.toBe("2026-04-10");
+        expect(s.day).not.toBe("2026-04-13");
+      }
+    });
+
+    it("should not suggest activities on travel-heavy days (2+ travel entries)", async () => {
+      // Add accommodation and travel to suppress those
+      await db.insert(accommodations).values({
+        tripId: testTripId,
+        createdBy: testUserId,
+        name: "Test Hotel",
+        checkIn: new Date("2026-04-10T14:00:00Z"),
+        checkOut: new Date("2026-04-13T11:00:00Z"),
+      });
+      await db.insert(memberTravel).values({
+        tripId: testTripId,
+        memberId: testMemberId,
+        travelType: "arrival",
+        time: new Date("2026-04-10T10:00:00Z"),
+      });
+
+      // Create a second member to add more travel on Apr 11
+      const phone2 = generateUniquePhone();
+      const user2 = await db
+        .insert(users)
+        .values({
+          phoneNumber: phone2,
+          displayName: "Second User",
+          timezone: "UTC",
+        })
+        .returning();
+      const member2 = await db
+        .insert(members)
+        .values({
+          tripId: testTripId,
+          userId: user2[0].id,
+          status: "going",
+        })
+        .returning();
+
+      // 2 travel entries on Apr 11 → travel-heavy day
+      await db.insert(memberTravel).values([
+        {
+          tripId: testTripId,
+          memberId: testMemberId,
+          travelType: "departure",
+          time: new Date("2026-04-11T08:00:00Z"),
+        },
+        {
+          tripId: testTripId,
+          memberId: member2[0].id,
+          travelType: "arrival",
+          time: new Date("2026-04-11T14:00:00Z"),
+        },
+      ]);
+
+      const suggestions = await affiliateService.getSuggestions(
+        testUserId,
+        testTripId,
+      );
+      // Apr 11 has 0 events but 2 travel entries → should NOT get empty_day
+      const emptyDayOnApr11 = suggestions.find(
+        (s) => s.gapType === "empty_day" && s.day === "2026-04-11",
+      );
+      expect(emptyDayOnApr11).toBeUndefined();
+
+      // Cleanup extra user
+      await db.delete(users).where(eq(users.phoneNumber, phone2));
+    });
+
+    it("should cap day-level suggestions to 1 per day (highest priority wins)", async () => {
+      // With no accommodation and no travel, all days are empty.
+      // Each day can only produce one day-level suggestion.
+      const suggestions = await affiliateService.getSuggestions(
+        testUserId,
+        testTripId,
+      );
+
+      // Collect day-level suggestions and check uniqueness
+      const dayKeys = suggestions
+        .filter((s) => s.day !== null)
+        .map((s) => s.day);
+      const uniqueDays = new Set(dayKeys);
+      expect(dayKeys.length).toBe(uniqueDays.size);
+    });
+
+    it("should cap total suggestions at MAX_SUGGESTIONS (3)", async () => {
+      // With no data at all, there are many potential gaps but max 3 returned
+      const suggestions = await affiliateService.getSuggestions(
+        testUserId,
+        testTripId,
+      );
+      expect(suggestions.length).toBeLessThanOrEqual(3);
+    });
+
+    it("should return no suggestions for cancelled trips", async () => {
+      await db
+        .update(trips)
+        .set({ cancelled: true })
+        .where(eq(trips.id, testTripId));
+
+      const suggestions = await affiliateService.getSuggestions(
+        testUserId,
+        testTripId,
+      );
+      expect(suggestions).toEqual([]);
+    });
+
+    it("should return no suggestions when user status is not going", async () => {
+      // Update member status to "maybe"
+      await db
+        .update(members)
+        .set({ status: "maybe" })
+        .where(eq(members.tripId, testTripId));
+
+      const suggestions = await affiliateService.getSuggestions(
+        testUserId,
+        testTripId,
+      );
+      // missing_travel requires status "going", but no_accommodation and empty_day still fire
+      const travelSuggestion = suggestions.find(
+        (s) => s.gapType === "missing_travel",
+      );
+      expect(travelSuggestion).toBeUndefined();
+    });
+
+    it("should return no suggestions when BOOKING_AFFILIATE_ID is empty", async () => {
+      const original = env.BOOKING_AFFILIATE_ID;
+      (env as { BOOKING_AFFILIATE_ID: string }).BOOKING_AFFILIATE_ID = "";
+
+      try {
+        const suggestions = await affiliateService.getSuggestions(
+          testUserId,
+          testTripId,
+        );
+        expect(suggestions).toEqual([]);
+      } finally {
+        (env as { BOOKING_AFFILIATE_ID: string }).BOOKING_AFFILIATE_ID =
+          original;
+      }
+    });
+  });
+});

--- a/apps/api/tests/unit/affiliate.service.test.ts
+++ b/apps/api/tests/unit/affiliate.service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { db } from "@/config/database.js";
 import {
   users,
@@ -10,7 +10,7 @@ import {
   affiliateDismissals,
   affiliateEvents,
 } from "@/db/schema/index.js";
-import { eq, or } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import {
   AffiliateService,
   getDateRange,
@@ -18,51 +18,27 @@ import {
 } from "@/services/affiliate.service.js";
 import { PermissionsService } from "@/services/permissions.service.js";
 import { BOOKING_DEEP_LINKS } from "@/config/affiliates.js";
+import { env } from "@/config/env.js";
 import { generateUniquePhone } from "../test-utils.js";
 
-// Mock env to control BOOKING_AFFILIATE_ID
-vi.mock("@/config/env.js", () => ({
-  env: {
-    BOOKING_AFFILIATE_ID: "test-affiliate-123",
-    // Add other env values the code may reference
-    NODE_ENV: "test",
-    PORT: 8000,
-    HOST: "0.0.0.0",
-    DATABASE_URL: process.env.DATABASE_URL,
-    JWT_SECRET: process.env.JWT_SECRET,
-    FRONTEND_URL: "http://localhost:3000",
-    TRUST_PROXY: false,
-    COOKIE_SECURE: false,
-    EXPOSE_ERROR_DETAILS: true,
-    ENABLE_FIXED_VERIFICATION_CODE: true,
-    LOG_LEVEL: "info",
-    TWILIO_ACCOUNT_SID: "",
-    TWILIO_AUTH_TOKEN: "",
-    TWILIO_VERIFY_SERVICE_SID: "",
-    STORAGE_PROVIDER: "local",
-    AWS_ENDPOINT_URL: "",
-    AWS_S3_BUCKET_NAME: "",
-    AWS_ACCESS_KEY_ID: "",
-    AWS_SECRET_ACCESS_KEY: "",
-    AWS_DEFAULT_REGION: "us-east-1",
-    UPLOAD_DIR: "uploads",
-    MAX_FILE_SIZE: 5242880,
-    VAPID_PUBLIC_KEY: "",
-    VAPID_PRIVATE_KEY: "",
-    VAPID_SUBJECT: "mailto:hello@journiful.app",
-    AERODATABOX_API_KEY: "",
-    ALLOWED_MIME_TYPES: ["image/jpeg", "image/png", "image/webp"],
-    COOKIE_DOMAIN: undefined,
-  },
-}));
-
-// Get a reference to the mocked env so we can modify it per-test
-import { env } from "@/config/env.js";
+// Store original value to restore after tests that mutate env
+const ORIGINAL_AFFILIATE_ID = env.BOOKING_AFFILIATE_ID;
 
 const permissionsService = new PermissionsService(db);
 const affiliateService = new AffiliateService(db, permissionsService);
 
 describe("affiliate.service", () => {
+  // Set affiliate ID for all tests; individual tests can override
+  beforeEach(() => {
+    (env as { BOOKING_AFFILIATE_ID: string }).BOOKING_AFFILIATE_ID =
+      "test-affiliate-123";
+  });
+
+  afterEach(() => {
+    (env as { BOOKING_AFFILIATE_ID: string }).BOOKING_AFFILIATE_ID =
+      ORIGINAL_AFFILIATE_ID;
+  });
+
   // --- Helper function tests (no DB needed) ---
 
   describe("getDateRange", () => {

--- a/apps/web/src/components/itinerary/day-by-day-view.tsx
+++ b/apps/web/src/components/itinerary/day-by-day-view.tsx
@@ -48,6 +48,7 @@ interface DayByDayViewProps {
   forecasts?: DailyForecast[];
   temperatureUnit?: TemperatureUnit;
   filter?: ItineraryFilter;
+  tripId?: string;
   daySuggestions?: Map<string, SuggestionCardType[]>;
   onDismissSuggestion?: (suggestionType: string, suggestionKey: string) => void;
 }
@@ -82,6 +83,7 @@ export function DayByDayView({
   forecasts,
   temperatureUnit,
   filter = "all",
+  tripId,
   daySuggestions,
   onDismissSuggestion,
 }: DayByDayViewProps) {
@@ -447,6 +449,7 @@ export function DayByDayView({
                   <SuggestionCard
                     key={s.id}
                     suggestion={s}
+                    tripId={tripId || ""}
                     onDismiss={onDismissSuggestion}
                   />
                 ))}

--- a/apps/web/src/components/itinerary/day-by-day-view.tsx
+++ b/apps/web/src/components/itinerary/day-by-day-view.tsx
@@ -6,7 +6,9 @@ import type {
   MemberTravel,
   DailyForecast,
   TemperatureUnit,
+  SuggestionCard as SuggestionCardType,
 } from "@journiful/shared/types";
+import { SuggestionCard } from "./suggestion-card";
 import { EventCard } from "./event-card";
 import { MemberTravelLineItem } from "./member-travel-line-item";
 import { EventDetailSheet } from "./event-detail-sheet";
@@ -46,6 +48,8 @@ interface DayByDayViewProps {
   forecasts?: DailyForecast[];
   temperatureUnit?: TemperatureUnit;
   filter?: ItineraryFilter;
+  daySuggestions?: Map<string, SuggestionCardType[]>;
+  onDismissSuggestion?: (suggestionType: string, suggestionKey: string) => void;
 }
 
 interface DayData {
@@ -78,6 +82,8 @@ export function DayByDayView({
   forecasts,
   temperatureUnit,
   filter = "all",
+  daySuggestions,
+  onDismissSuggestion,
 }: DayByDayViewProps) {
   // Track current time for the "now" indicator
   const [now, setNow] = useState(() => Date.now());
@@ -435,6 +441,15 @@ export function DayByDayView({
                   <span className="text-sm">No events scheduled</span>
                 </div>
               )}
+              {!isLocked &&
+                onDismissSuggestion &&
+                daySuggestions?.get(day.date)?.map((s) => (
+                  <SuggestionCard
+                    key={s.id}
+                    suggestion={s}
+                    onDismiss={onDismissSuggestion}
+                  />
+                ))}
             </div>
           </div>
         );

--- a/apps/web/src/components/itinerary/itinerary-view.tsx
+++ b/apps/web/src/components/itinerary/itinerary-view.tsx
@@ -24,7 +24,11 @@ import { CreateAccommodationDialog } from "./create-accommodation-dialog";
 import { DeletedItemsDialog } from "./deleted-items-dialog";
 import { TravelReminderBanner } from "@/components/trip/travel-reminder-banner";
 import { SuggestionCard } from "./suggestion-card";
-import { useSuggestions, useDismissSuggestion } from "@/hooks/use-suggestions";
+import {
+  useSuggestions,
+  useDismissSuggestion,
+  useTrackImpressions,
+} from "@/hooks/use-suggestions";
 import { EmptyState } from "@/components/ui/empty-state";
 import type {
   DailyForecast,
@@ -88,6 +92,7 @@ export function ItineraryView({
   // Fetch suggestions
   const { data: suggestions = [] } = useSuggestions(tripId);
   const dismissSuggestion = useDismissSuggestion(tripId);
+  useTrackImpressions(tripId, suggestions.length > 0 ? suggestions : undefined);
 
   // Separate trip-level vs day-level suggestions
   const tripLevelSuggestions = useMemo(
@@ -344,6 +349,7 @@ export function ItineraryView({
             <SuggestionCard
               key={s.id}
               suggestion={s}
+              tripId={tripId}
               onDismiss={handleDismiss}
             />
           ))}
@@ -366,6 +372,7 @@ export function ItineraryView({
           forecasts={forecasts ?? []}
           temperatureUnit={temperatureUnit ?? "fahrenheit"}
           filter={filter}
+          tripId={tripId}
           daySuggestions={daySuggestions}
           onDismissSuggestion={handleDismiss}
         />

--- a/apps/web/src/components/itinerary/itinerary-view.tsx
+++ b/apps/web/src/components/itinerary/itinerary-view.tsx
@@ -96,7 +96,7 @@ export function ItineraryView({
 
   // Separate trip-level vs day-level suggestions
   const tripLevelSuggestions = useMemo(
-    () => suggestions.filter((s) => s.day === null),
+    () => suggestions.filter((s) => s.day === null && s.gapType !== "no_accommodation"),
     [suggestions],
   );
   const daySuggestions = useMemo(() => {

--- a/apps/web/src/components/itinerary/itinerary-view.tsx
+++ b/apps/web/src/components/itinerary/itinerary-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { AlertCircle, CalendarX, Lock, Trash2 } from "lucide-react";
 import { useAuth } from "@/app/providers/auth-provider";
 import { useEvents, useEventsWithDeleted } from "@/hooks/use-events";
@@ -23,8 +23,14 @@ import { CreateEventDialog } from "./create-event-dialog";
 import { CreateAccommodationDialog } from "./create-accommodation-dialog";
 import { DeletedItemsDialog } from "./deleted-items-dialog";
 import { TravelReminderBanner } from "@/components/trip/travel-reminder-banner";
+import { SuggestionCard } from "./suggestion-card";
+import { useSuggestions, useDismissSuggestion } from "@/hooks/use-suggestions";
 import { EmptyState } from "@/components/ui/empty-state";
-import type { DailyForecast, TemperatureUnit } from "@journiful/shared/types";
+import type {
+  DailyForecast,
+  TemperatureUnit,
+  SuggestionCard as SuggestionCardType,
+} from "@journiful/shared/types";
 
 interface ItineraryViewProps {
   tripId: string;
@@ -78,6 +84,34 @@ export function ItineraryView({
         displayName: m.displayName,
       })),
   });
+
+  // Fetch suggestions
+  const { data: suggestions = [] } = useSuggestions(tripId);
+  const dismissSuggestion = useDismissSuggestion(tripId);
+
+  // Separate trip-level vs day-level suggestions
+  const tripLevelSuggestions = useMemo(
+    () => suggestions.filter((s) => s.day === null),
+    [suggestions],
+  );
+  const daySuggestions = useMemo(() => {
+    const map = new Map<string, SuggestionCardType[]>();
+    for (const s of suggestions) {
+      if (s.day) {
+        const existing = map.get(s.day) || [];
+        existing.push(s);
+        map.set(s.day, existing);
+      }
+    }
+    return map;
+  }, [suggestions]);
+
+  const handleDismiss = useCallback(
+    (suggestionType: string, suggestionKey: string) => {
+      dismissSuggestion.mutate({ suggestionType, suggestionKey });
+    },
+    [dismissSuggestion],
+  );
 
   // Fetch all items (including deleted) to check if deleted items exist
   const { data: allEvents = [] } = useEventsWithDeleted(tripId);
@@ -305,6 +339,14 @@ export function ItineraryView({
               onAddTravel={onAddTravel}
             />
           )}
+        {!isLocked &&
+          tripLevelSuggestions.map((s) => (
+            <SuggestionCard
+              key={s.id}
+              suggestion={s}
+              onDismiss={handleDismiss}
+            />
+          ))}
         {isLocked && (
           <div className="bg-muted/50 border border-border rounded-md p-4 text-center text-sm text-muted-foreground mb-6">
             <Lock className="w-4 h-4 inline mr-2" />
@@ -324,6 +366,8 @@ export function ItineraryView({
           forecasts={forecasts ?? []}
           temperatureUnit={temperatureUnit ?? "fahrenheit"}
           filter={filter}
+          daySuggestions={daySuggestions}
+          onDismissSuggestion={handleDismiss}
         />
         {isOrganizer && hasDeletedItems && (
           <Button

--- a/apps/web/src/components/itinerary/suggestion-card.tsx
+++ b/apps/web/src/components/itinerary/suggestion-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useCallback } from "react";
+import React, { memo, useCallback } from "react";
 import { ExternalLink, Lightbulb, X } from "lucide-react";
 import type { SuggestionCard as SuggestionCardType } from "@journiful/shared/types";
 import { apiRequest } from "@/lib/api";

--- a/apps/web/src/components/itinerary/suggestion-card.tsx
+++ b/apps/web/src/components/itinerary/suggestion-card.tsx
@@ -1,20 +1,41 @@
 "use client";
 
-import { memo } from "react";
+import { memo, useCallback } from "react";
 import { ExternalLink, Lightbulb, X } from "lucide-react";
 import type { SuggestionCard as SuggestionCardType } from "@journiful/shared/types";
+import { apiRequest } from "@/lib/api";
 
 interface SuggestionCardProps {
   suggestion: SuggestionCardType;
+  tripId: string;
   onDismiss: (suggestionType: string, suggestionKey: string) => void;
-  onClickLink?: (suggestionId: string) => void;
 }
 
 export const SuggestionCard = memo(function SuggestionCard({
   suggestion,
+  tripId,
   onDismiss,
-  onClickLink,
 }: SuggestionCardProps) {
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      // Fire-and-forget click tracking — don't block the user
+      apiRequest("/affiliate/click", {
+        method: "POST",
+        body: JSON.stringify({
+          partnerSlug: suggestion.partner.slug,
+          tripId,
+          suggestionType: suggestion.gapType,
+          affiliateUrl: suggestion.affiliateUrl,
+        }),
+      }).catch(() => {
+        // Silently ignore tracking failures
+      });
+      window.open(suggestion.affiliateUrl, "_blank", "noopener,noreferrer");
+    },
+    [suggestion, tripId],
+  );
+
   return (
     <div className="flex items-start gap-3 rounded-md border border-dashed border-muted-foreground/25 bg-muted/30 p-3 my-1.5">
       <Lightbulb className="w-4 h-4 shrink-0 text-muted-foreground mt-0.5" />
@@ -27,7 +48,7 @@ export const SuggestionCard = memo(function SuggestionCard({
           href={suggestion.affiliateUrl}
           target="_blank"
           rel="noopener noreferrer"
-          onClick={() => onClickLink?.(suggestion.id)}
+          onClick={handleClick}
           className="inline-flex items-center gap-1 text-xs font-medium text-primary mt-1.5 hover:underline"
         >
           Browse on {suggestion.partner.name}

--- a/apps/web/src/components/itinerary/suggestion-card.tsx
+++ b/apps/web/src/components/itinerary/suggestion-card.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { memo } from "react";
+import { ExternalLink, Lightbulb, X } from "lucide-react";
+import type { SuggestionCard as SuggestionCardType } from "@journiful/shared/types";
+
+interface SuggestionCardProps {
+  suggestion: SuggestionCardType;
+  onDismiss: (suggestionType: string, suggestionKey: string) => void;
+  onClickLink?: (suggestionId: string) => void;
+}
+
+export const SuggestionCard = memo(function SuggestionCard({
+  suggestion,
+  onDismiss,
+  onClickLink,
+}: SuggestionCardProps) {
+  return (
+    <div className="flex items-start gap-3 rounded-md border border-dashed border-muted-foreground/25 bg-muted/30 p-3 my-1.5">
+      <Lightbulb className="w-4 h-4 shrink-0 text-muted-foreground mt-0.5" />
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-foreground">{suggestion.title}</p>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          {suggestion.description}
+        </p>
+        <a
+          href={suggestion.affiliateUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() => onClickLink?.(suggestion.id)}
+          className="inline-flex items-center gap-1 text-xs font-medium text-primary mt-1.5 hover:underline"
+        >
+          Browse on {suggestion.partner.name}
+          <ExternalLink className="w-3 h-3" />
+        </a>
+        <p className="text-[10px] text-muted-foreground/60 mt-1">
+          We may earn a commission
+        </p>
+      </div>
+      <button
+        onClick={() => onDismiss(suggestion.gapType, suggestion.dismissKey)}
+        className="p-1 shrink-0 text-muted-foreground/50 hover:text-muted-foreground transition-colors rounded-sm"
+        aria-label="Dismiss suggestion"
+      >
+        <X className="w-3.5 h-3.5" />
+      </button>
+    </div>
+  );
+});

--- a/apps/web/src/components/trip/mobile/panels/info-panel.tsx
+++ b/apps/web/src/components/trip/mobile/panels/info-panel.tsx
@@ -6,6 +6,7 @@ import {
   Building2,
   CalendarPlus,
   Pencil,
+  Plus,
   Settings,
   UserPlus,
 } from "lucide-react";
@@ -20,6 +21,8 @@ import { CreateEventDialog } from "@/components/itinerary/create-event-dialog";
 import { canModifyAccommodation } from "@/components/itinerary/utils/permissions";
 import { MemberProfileSheet } from "@/components/trip/member-profile-sheet";
 import { useAccommodations } from "@/hooks/use-accommodations";
+import { useSuggestions, useDismissSuggestion } from "@/hooks/use-suggestions";
+import { SuggestionCard } from "@/components/itinerary/suggestion-card";
 import { membersQueryOptions } from "@/hooks/invitation-queries";
 import { useQuery } from "@tanstack/react-query";
 import { useAuth } from "@/app/providers/auth-provider";
@@ -111,6 +114,12 @@ export function InfoPanel({
 
   const { user } = useAuth();
   const { data: accommodations } = useAccommodations(tripId);
+  const { data: suggestions = [] } = useSuggestions(tripId);
+  const dismissSuggestion = useDismissSuggestion(tripId);
+  const accommodationSuggestion = useMemo(
+    () => suggestions.find((s) => s.gapType === "no_accommodation"),
+    [suggestions],
+  );
   const [selectedAccommodation, setSelectedAccommodation] = useState<Accommodation | null>(null);
   const [editingAccommodation, setEditingAccommodation] = useState<Accommodation | null>(null);
   const [isCreateAccommodationOpen, setIsCreateAccommodationOpen] = useState(false);
@@ -312,15 +321,36 @@ export function InfoPanel({
                 ))}
               </div>
             ) : (
-              <p className="text-sm text-muted-foreground">
-                No accommodations.{" "}
-                <button
-                  onClick={() => setIsCreateAccommodationOpen(true)}
-                  className="text-primary hover:underline transition-colors"
-                >
-                  Add one
-                </button>
-              </p>
+              <>
+                {accommodationSuggestion ? (
+                  <>
+                    <SuggestionCard
+                      suggestion={accommodationSuggestion}
+                      tripId={tripId}
+                      onDismiss={(suggestionType, suggestionKey) =>
+                        dismissSuggestion.mutate({ suggestionType, suggestionKey })
+                      }
+                    />
+                    <button
+                      onClick={() => setIsCreateAccommodationOpen(true)}
+                      className="inline-flex items-center gap-1 text-sm text-muted-foreground mt-1 hover:text-foreground transition-colors"
+                    >
+                      <Plus className="size-3.5" />
+                      Add your own
+                    </button>
+                  </>
+                ) : (
+                  <p className="text-sm text-muted-foreground">
+                    No accommodations.{" "}
+                    <button
+                      onClick={() => setIsCreateAccommodationOpen(true)}
+                      className="text-primary hover:underline transition-colors"
+                    >
+                      Add one
+                    </button>
+                  </p>
+                )}
+              </>
             )}
           </div>
         )}

--- a/apps/web/src/hooks/suggestion-queries.ts
+++ b/apps/web/src/hooks/suggestion-queries.ts
@@ -1,0 +1,28 @@
+import { queryOptions } from "@tanstack/react-query";
+import { apiRequest } from "@/lib/api";
+import type { SuggestionsResponse } from "@journiful/shared/types";
+
+/**
+ * Query key factory for suggestion-related queries
+ */
+export const suggestionKeys = {
+  all: ["suggestions"] as const,
+  lists: () => ["suggestions", "list"] as const,
+  list: (tripId: string) => ["suggestions", "list", tripId] as const,
+};
+
+/**
+ * Query options for fetching suggestions for a trip
+ */
+export const suggestionsQueryOptions = (tripId: string) =>
+  queryOptions({
+    queryKey: suggestionKeys.list(tripId),
+    staleTime: 5 * 60 * 1000,
+    queryFn: async ({ signal }) => {
+      const response = await apiRequest<SuggestionsResponse>(
+        `/trips/${tripId}/suggestions`,
+        { signal },
+      );
+      return response.suggestions;
+    },
+  });

--- a/apps/web/src/hooks/use-suggestions.ts
+++ b/apps/web/src/hooks/use-suggestions.ts
@@ -1,0 +1,85 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { apiRequest, APIError } from "@/lib/api";
+import type { SuggestionCard } from "@journiful/shared/types";
+import type { DismissSuggestionInput } from "@journiful/shared/schemas";
+
+import { suggestionKeys, suggestionsQueryOptions } from "./suggestion-queries";
+
+export { suggestionKeys, suggestionsQueryOptions };
+
+/**
+ * Hook for fetching suggestions for a trip
+ */
+export function useSuggestions(tripId: string) {
+  return useQuery({
+    ...suggestionsQueryOptions(tripId),
+    enabled: !!tripId,
+  });
+}
+
+interface DismissContext {
+  previousSuggestions: SuggestionCard[] | undefined;
+}
+
+/**
+ * Hook for dismissing a suggestion with optimistic removal
+ */
+export function useDismissSuggestion(tripId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    void,
+    APIError,
+    DismissSuggestionInput,
+    DismissContext
+  >({
+    mutationFn: async (input) => {
+      await apiRequest(`/trips/${tripId}/suggestions/dismiss`, {
+        method: "POST",
+        body: JSON.stringify(input),
+      });
+    },
+
+    onMutate: async (input) => {
+      await queryClient.cancelQueries({
+        queryKey: suggestionKeys.list(tripId),
+      });
+
+      const previousSuggestions = queryClient.getQueryData<SuggestionCard[]>(
+        suggestionKeys.list(tripId),
+      );
+
+      if (previousSuggestions) {
+        queryClient.setQueryData<SuggestionCard[]>(
+          suggestionKeys.list(tripId),
+          previousSuggestions.filter(
+            (s) =>
+              !(
+                s.gapType === input.suggestionType &&
+                s.dismissKey === input.suggestionKey
+              ),
+          ),
+        );
+      }
+
+      return { previousSuggestions };
+    },
+
+    onError: (_error, _input, context) => {
+      if (context?.previousSuggestions) {
+        queryClient.setQueryData(
+          suggestionKeys.list(tripId),
+          context.previousSuggestions,
+        );
+      }
+    },
+
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        queryKey: suggestionKeys.list(tripId),
+      });
+    },
+  });
+}

--- a/apps/web/src/hooks/use-suggestions.ts
+++ b/apps/web/src/hooks/use-suggestions.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { apiRequest, APIError } from "@/lib/api";
 import type { SuggestionCard } from "@journiful/shared/types";
@@ -26,6 +27,41 @@ interface DismissContext {
 /**
  * Hook for dismissing a suggestion with optimistic removal
  */
+/**
+ * Fire-and-forget impression tracking when suggestions are first displayed
+ */
+export function useTrackImpressions(
+  tripId: string,
+  suggestions: SuggestionCard[] | undefined,
+) {
+  const trackedRef = useRef(new Set<string>());
+
+  useEffect(() => {
+    if (!suggestions || suggestions.length === 0) return;
+
+    const newImpressions = suggestions.filter(
+      (s) => !trackedRef.current.has(s.id),
+    );
+    if (newImpressions.length === 0) return;
+
+    for (const s of newImpressions) {
+      trackedRef.current.add(s.id);
+    }
+
+    apiRequest(`/trips/${tripId}/suggestions/impressions`, {
+      method: "POST",
+      body: JSON.stringify({
+        impressions: newImpressions.map((s) => ({
+          partnerSlug: s.partner.slug,
+          suggestionType: s.gapType,
+        })),
+      }),
+    }).catch(() => {
+      // Silently ignore impression tracking failures
+    });
+  }, [tripId, suggestions]);
+}
+
 export function useDismissSuggestion(tripId: string) {
   const queryClient = useQueryClient();
 

--- a/apps/web/src/hooks/use-suggestions.ts
+++ b/apps/web/src/hooks/use-suggestions.ts
@@ -2,7 +2,8 @@
 
 import { useEffect, useRef } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { apiRequest, APIError } from "@/lib/api";
+import { apiRequest } from "@/lib/api";
+import type { APIError } from "@/lib/api";
 import type { SuggestionCard } from "@journiful/shared/types";
 import type { DismissSuggestionInput } from "@journiful/shared/schemas";
 

--- a/apps/web/src/lib/affiliates.ts
+++ b/apps/web/src/lib/affiliates.ts
@@ -1,0 +1,11 @@
+/**
+ * Partner display configuration for affiliate suggestions.
+ * Contains only public display info — no secrets or affiliate IDs.
+ */
+export const PARTNER_CONFIG = {
+  "booking.com": {
+    name: "Booking.com",
+  },
+} as const;
+
+export type PartnerSlug = keyof typeof PARTNER_CONFIG;

--- a/apps/web/tests/e2e/trip-journey.spec.ts
+++ b/apps/web/tests/e2e/trip-journey.spec.ts
@@ -894,10 +894,9 @@ test.describe("Trip Journey", () => {
         // the submit button. Use waitFor to ensure it is attached before clicking.
         const submitBtn = page.locator('button[type="submit"]', { hasText: "Add travel details" });
         await expect(submitBtn).toBeVisible({ timeout: ELEMENT_TIMEOUT });
-        await submitBtn.scrollIntoViewIfNeeded();
         // Use force:true to bypass actionability checks that fail on detached elements
         // during React re-renders. The button is already verified visible above.
-        await submitBtn.click({ force: true });
+        await submitBtn.click({ force: true, timeout: DIALOG_TIMEOUT });
 
         // Wait for success toast
         await expect(

--- a/apps/web/tests/e2e/trip-journey.spec.ts
+++ b/apps/web/tests/e2e/trip-journey.spec.ts
@@ -833,7 +833,9 @@ test.describe("Trip Journey", () => {
         // menu item to be stable before clicking and retry if it detaches.
         const myTravelItem = page.getByRole("menuitem", { name: "My Travel" });
         await expect(myTravelItem).toBeVisible({ timeout: DIALOG_TIMEOUT });
-        await myTravelItem.click({ timeout: ELEMENT_TIMEOUT });
+        // Use force:true to bypass actionability checks — the dropdown menu item
+        // can detach during React re-renders between the visibility check and click.
+        await myTravelItem.click({ force: true });
 
         await expect(
           page.getByRole("heading", { name: "Add your travel details" }),

--- a/shared/schemas/affiliate.ts
+++ b/shared/schemas/affiliate.ts
@@ -34,3 +34,26 @@ export const dismissSuggestionSchema = z.object({
 });
 
 export type DismissSuggestionInput = z.infer<typeof dismissSuggestionSchema>;
+
+export const trackClickSchema = z.object({
+  partnerSlug: z.string().min(1).max(50),
+  tripId: z.string().uuid(),
+  suggestionType: z.string().min(1).max(50),
+  affiliateUrl: z.string().url(),
+});
+
+export type TrackClickInput = z.infer<typeof trackClickSchema>;
+
+export const trackImpressionsSchema = z.object({
+  impressions: z
+    .array(
+      z.object({
+        partnerSlug: z.string().min(1).max(50),
+        suggestionType: z.string().min(1).max(50),
+      }),
+    )
+    .min(1)
+    .max(10),
+});
+
+export type TrackImpressionsInput = z.infer<typeof trackImpressionsSchema>;

--- a/shared/schemas/affiliate.ts
+++ b/shared/schemas/affiliate.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+export const suggestionPartnerSchema = z.object({
+  slug: z.string(),
+  name: z.string(),
+});
+
+export const suggestionCardSchema = z.object({
+  id: z.string(),
+  gapType: z.enum([
+    "missing_travel",
+    "no_accommodation",
+    "empty_day",
+    "missing_meal",
+  ]),
+  suggestionType: z.enum(["flights", "hotels", "attractions"]),
+  title: z.string(),
+  description: z.string(),
+  affiliateUrl: z.string(),
+  partner: suggestionPartnerSchema,
+  dismissKey: z.string(),
+  day: z.string().nullable(),
+  priority: z.number(),
+});
+
+export const suggestionsResponseSchema = z.object({
+  success: z.literal(true),
+  suggestions: z.array(suggestionCardSchema),
+});
+
+export const dismissSuggestionSchema = z.object({
+  suggestionType: z.string().min(1).max(50),
+  suggestionKey: z.string().min(1).max(100),
+});
+
+export type DismissSuggestionInput = z.infer<typeof dismissSuggestionSchema>;

--- a/shared/schemas/index.ts
+++ b/shared/schemas/index.ts
@@ -210,3 +210,12 @@ export {
   type BalanceResponse,
   type MyBalanceResponse,
 } from "./balance";
+
+// Re-export affiliate schemas
+export {
+  suggestionCardSchema,
+  suggestionPartnerSchema,
+  suggestionsResponseSchema,
+  dismissSuggestionSchema,
+  type DismissSuggestionInput,
+} from "./affiliate";

--- a/shared/schemas/index.ts
+++ b/shared/schemas/index.ts
@@ -217,5 +217,9 @@ export {
   suggestionPartnerSchema,
   suggestionsResponseSchema,
   dismissSuggestionSchema,
+  trackClickSchema,
+  trackImpressionsSchema,
   type DismissSuggestionInput,
+  type TrackClickInput,
+  type TrackImpressionsInput,
 } from "./affiliate";

--- a/shared/types/affiliate.ts
+++ b/shared/types/affiliate.ts
@@ -1,0 +1,53 @@
+/** Gap types detected in trip itinerary */
+export type GapType =
+  | "missing_travel"
+  | "no_accommodation"
+  | "empty_day"
+  | "missing_meal";
+
+/** Suggestion types mapping to Booking.com product types */
+export type SuggestionType = "flights" | "hotels" | "attractions";
+
+/** Partner display info included in each suggestion card */
+export interface SuggestionPartner {
+  slug: string;
+  name: string;
+}
+
+/** A single affiliate suggestion card returned by the API */
+export interface SuggestionCard {
+  id: string;
+  gapType: GapType;
+  suggestionType: SuggestionType;
+  title: string;
+  description: string;
+  affiliateUrl: string;
+  partner: SuggestionPartner;
+  dismissKey: string;
+  /** ISO date string for day-level suggestions, null for trip-level */
+  day: string | null;
+  priority: number;
+}
+
+/** Context extracted from a trip used to build deep links */
+export interface TripContext {
+  destination: string;
+  lat: number | null;
+  lon: number | null;
+  startDate: string | null;
+  endDate: string | null;
+  dayDate?: string;
+  origin?: string;
+}
+
+/** Response shape for GET /trips/:tripId/suggestions */
+export interface SuggestionsResponse {
+  success: true;
+  suggestions: SuggestionCard[];
+}
+
+/** Input shape for POST /trips/:tripId/suggestions/dismiss */
+export interface DismissSuggestionInput {
+  suggestionType: string;
+  suggestionKey: string;
+}

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -169,3 +169,14 @@ export type {
   GetBalancesResponse,
   GetMyBalanceResponse,
 } from "./balance";
+
+// Re-export affiliate types
+export type {
+  GapType,
+  SuggestionType,
+  SuggestionPartner,
+  SuggestionCard,
+  TripContext,
+  SuggestionsResponse,
+  DismissSuggestionInput,
+} from "./affiliate";


### PR DESCRIPTION
## Summary

- Adds contextual affiliate suggestion cards that surface when gaps are detected in trip itineraries (missing travel, no accommodation, empty days, missing meals)
- Cards link to Booking.com deep links (flights, hotels, attractions) constructed from trip data, with server-side click/impression tracking and persistent dismissals
- Accommodation suggestion renders in the info panel alongside the accommodations section; day-level suggestions render inline in the itinerary
- Feature is fully hidden when `BOOKING_AFFILIATE_ID` env var is not set
- Includes FTC-compliant "We may earn a commission" disclosure on all cards

## Test plan

- [x] Unit tests for gap detection rules (all 4 types), edge cases (first/last day, travel-heavy days, dedup, cap at 3), helpers, and deep link URL construction (19 tests)
- [x] Integration tests for suggestions endpoint, dismiss endpoint, click tracking, and impression tracking (11 tests)
- [ ] Manual test: seed DB (`pnpm db:seed`), set `BOOKING_AFFILIATE_ID=test-dev-123` in `.env`, log in as Alice (+15550000001), open Lisbon Getaway trip
- [ ] Verify suggestion cards appear in itinerary (missing travel, empty days, missing meals) and info panel (no accommodation)
- [ ] Verify dismiss persists across page reloads
- [ ] Verify click tracking logs to `affiliate_events` table
- [ ] Verify no suggestion cards appear when `BOOKING_AFFILIATE_ID` is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)