### PR TITLE
Fix PWA install prompt reappearing after dismissal

### DIFF
--- a/apps/web/src/components/pwa/install-prompt.tsx
+++ b/apps/web/src/components/pwa/install-prompt.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { X } from "lucide-react";
 
 interface BeforeInstallPromptEvent extends Event {
@@ -23,6 +23,7 @@ export function InstallPrompt() {
   const [deferredPrompt, setDeferredPrompt] =
     useState<BeforeInstallPromptEvent | null>(null);
   const [visible, setVisible] = useState(false);
+  const dismissedRef = useRef(false);
 
   useEffect(() => {
     if (isDismissed()) return;
@@ -31,6 +32,7 @@ export function InstallPrompt() {
 
     const handler = (e: Event) => {
       e.preventDefault();
+      if (dismissedRef.current || isDismissed()) return;
       setDeferredPrompt(e as BeforeInstallPromptEvent);
       setVisible(true);
     };
@@ -40,6 +42,7 @@ export function InstallPrompt() {
   }, []);
 
   const dismiss = useCallback(() => {
+    dismissedRef.current = true;
     localStorage.setItem(DISMISS_KEY, String(Date.now()));
     setVisible(false);
     setDeferredPrompt(null);


### PR DESCRIPTION
## Summary
- The `beforeinstallprompt` event handler didn't check whether the user had already dismissed the prompt
- Browser can re-fire this event on navigation or mini-infobar dismissal, causing the banner to reappear
- Added `isDismissed()` check in the event handler and a ref guard for same-session re-shows

## Test plan
- [ ] Dismiss the PWA install prompt via the X button
- [ ] Navigate between pages — prompt should not reappear
- [ ] Refresh the page — prompt should not reappear (within 7-day window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)