### PR TITLE
Remove auto-reload on service worker update

### DIFF
--- a/apps/web/src/components/pwa/sw-update-prompt.tsx
+++ b/apps/web/src/components/pwa/sw-update-prompt.tsx
@@ -11,10 +11,6 @@ export function SwUpdatePrompt() {
     if (typeof window === "undefined" || !("serviceWorker" in navigator))
       return;
 
-    const handleControllerChange = () => {
-      window.location.reload();
-    };
-
     // Check for a waiting SW on load
     navigator.serviceWorker.ready.then((registration) => {
       if (registration.waiting) {
@@ -36,22 +32,14 @@ export function SwUpdatePrompt() {
         });
       });
     });
-
-    navigator.serviceWorker.addEventListener(
-      "controllerchange",
-      handleControllerChange,
-    );
-
-    return () => {
-      navigator.serviceWorker.removeEventListener(
-        "controllerchange",
-        handleControllerChange,
-      );
-    };
   }, []);
 
   const handleUpdate = useCallback(() => {
     if (!waitingWorker) return;
+    // Reload once the new SW takes control
+    navigator.serviceWorker.addEventListener("controllerchange", () => {
+      window.location.reload();
+    });
     waitingWorker.postMessage({ type: "SKIP_WAITING" });
   }, [waitingWorker]);
 


### PR DESCRIPTION
## Summary
- Removed the `controllerchange` listener that auto-reloaded the page when a new service worker activated
- Page now only reloads when the user explicitly clicks the "Refresh" button on the update banner
- Prevents disruptive mid-use page refreshes (e.g. from another tab triggering `SKIP_WAITING`)

## Test plan
- [ ] Deploy a new SW version while the app is open — verify the "new version available" banner appears without auto-reloading
- [ ] Click "Refresh" — verify the page reloads and picks up the new version
- [ ] Open in two tabs, click Refresh in one — verify the other tab does not auto-reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)