### PR TITLE
Add Twilio SMS delivery for trip invitations

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -33,6 +33,9 @@ LOG_LEVEL=info
 # TWILIO_AUTH_TOKEN=xxxxxxxxxx
 # TWILIO_VERIFY_SERVICE_SID=VAxxxxxxxxxx
 
+# Twilio Messaging Service for invites (leave empty for mock mode)
+# TWILIO_INVITE_MESSAGING_SERVICE_SID=
+
 # Storage Provider: "local" or "s3" (default)
 # Use "s3" for both local dev (MinIO via docker-compose) and production
 STORAGE_PROVIDER=s3

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -66,6 +66,7 @@ const envSchema = z.object({
   TWILIO_ACCOUNT_SID: z.string().default(""),
   TWILIO_AUTH_TOKEN: z.string().default(""),
   TWILIO_VERIFY_SERVICE_SID: z.string().default(""),
+  TWILIO_INVITE_MESSAGING_SERVICE_SID: z.string().default(""),
 
   // Storage Provider
   STORAGE_PROVIDER: z.enum(["local", "s3"]).default("local"),

--- a/apps/api/src/plugins/sms-service.ts
+++ b/apps/api/src/plugins/sms-service.ts
@@ -1,26 +1,10 @@
 import fp from "fastify-plugin";
 import type { FastifyInstance } from "fastify";
-import { MockSMSService } from "@/services/sms.service.js";
+import { SMSService } from "@/services/sms.service.js";
 
-/**
- * SMS service plugin
- * Creates a MockSMSService instance with the Fastify logger
- * and decorates it on the Fastify instance.
- *
- * NOTE: Only MockSMSService exists. A real Twilio SMS implementation
- * should be added before relying on SMS delivery in production.
- */
 export default fp(
   async function smsServicePlugin(fastify: FastifyInstance) {
-    if (fastify.config.NODE_ENV === "production") {
-      fastify.log.warn(
-        "MockSMSService is active in production — SMS invitations and notifications will be logged, not sent. " +
-          "Add a real SMS service implementation when SMS delivery is needed.",
-      );
-    }
-
-    const smsService = new MockSMSService(fastify.log);
-    fastify.decorate("smsService", smsService);
+    fastify.decorate("smsService", new SMSService(fastify.log));
   },
   {
     name: "sms-service",

--- a/apps/api/src/queues/workers/invitation-send.worker.ts
+++ b/apps/api/src/queues/workers/invitation-send.worker.ts
@@ -6,5 +6,5 @@ export async function handleInvitationSend(
   deps: WorkerDeps,
 ): Promise<void> {
   const { phoneNumber, message } = job.data;
-  await deps.smsService.sendMessage(phoneNumber, message);
+  await deps.smsService.sendMessage(phoneNumber, message, "invite");
 }

--- a/apps/api/src/services/invitation.service.ts
+++ b/apps/api/src/services/invitation.service.ts
@@ -440,7 +440,9 @@ export class InvitationService implements IInvitationService {
     });
 
     // Send invitation SMS via queue or fallback to inline delivery
-    const inviteSmsMessage = `${inviterDisplayName} invited you to "${tripName}" on Journiful! Join at journiful.app`;
+    const safeName = inviterDisplayName.slice(0, 20);
+    const safeTrip = tripName.slice(0, 30);
+    const inviteSmsMessage = `${safeName} invited you to "${safeTrip}" on Journiful! Join at journiful.app`;
     if (this.boss && newPhones.length > 0) {
       await this.boss.insert(
         QUEUE.INVITATION_SEND,

--- a/apps/api/src/services/invitation.service.ts
+++ b/apps/api/src/services/invitation.service.ts
@@ -440,13 +440,14 @@ export class InvitationService implements IInvitationService {
     });
 
     // Send invitation SMS via queue or fallback to inline delivery
+    const inviteSmsMessage = `${inviterDisplayName} invited you to "${tripName}" on Journiful! Join at journiful.app`;
     if (this.boss && newPhones.length > 0) {
       await this.boss.insert(
         QUEUE.INVITATION_SEND,
         newPhones.map((phone) => ({
           data: {
             phoneNumber: phone,
-            message: "You've been invited to a trip on Journiful!",
+            message: inviteSmsMessage,
           } as InvitationSendPayload,
         })),
       );
@@ -454,7 +455,8 @@ export class InvitationService implements IInvitationService {
       for (const phone of newPhones) {
         await this.smsService.sendMessage(
           phone,
-          "You've been invited to a trip on Journiful!",
+          inviteSmsMessage,
+          "invite",
         );
       }
     }

--- a/apps/api/src/services/sms.service.ts
+++ b/apps/api/src/services/sms.service.ts
@@ -1,40 +1,75 @@
+import Twilio from "twilio";
 import type { Logger } from "@/types/logger.js";
+import { env } from "@/config/env.js";
+
+export type SMSChannel = "invite" | "notification";
 
 /**
  * SMS Service Interface
- * Defines the contract for sending SMS messages.
- * Callers are responsible for formatting message content.
  */
 export interface ISMSService {
-  /**
-   * Sends an SMS message to the specified phone number
-   * @param phoneNumber - The phone number to send the message to (E.164 format)
-   * @param message - The message content to send
-   * @returns Promise that resolves when the SMS is sent
-   */
-  sendMessage(phoneNumber: string, message: string): Promise<void>;
+  sendMessage(
+    phoneNumber: string,
+    message: string,
+    channel?: SMSChannel,
+  ): Promise<void>;
 }
 
+/** SMSChannel → Twilio Messaging Service SID */
+const SID_MAP: Partial<Record<SMSChannel, string>> = {
+  ...(env.TWILIO_INVITE_MESSAGING_SERVICE_SID && {
+    invite: env.TWILIO_INVITE_MESSAGING_SERVICE_SID,
+  }),
+  // Future: ...(env.TWILIO_NOTIFICATION_MESSAGING_SERVICE_SID && {
+  //   notification: env.TWILIO_NOTIFICATION_MESSAGING_SERVICE_SID,
+  // }),
+};
+
+const client =
+  env.TWILIO_ACCOUNT_SID &&
+  env.TWILIO_AUTH_TOKEN &&
+  Object.keys(SID_MAP).length > 0
+    ? new Twilio.Twilio(env.TWILIO_ACCOUNT_SID, env.TWILIO_AUTH_TOKEN)
+    : null;
+
 /**
- * Mock SMS Service Implementation
- * Logs SMS messages using the provided logger instead of sending actual SMS
- * Used for development and testing environments
+ * SMS Service
+ *
+ * When Twilio credentials and at least one Messaging Service SID are present,
+ * sends real SMS via Twilio. Otherwise, logs messages (mock mode).
  */
-export class MockSMSService implements ISMSService {
+export class SMSService implements ISMSService {
   private logger: Logger | undefined;
 
   constructor(logger?: Logger) {
     this.logger = logger;
   }
 
-  /**
-   * Sends an SMS message by logging it
-   * @param phoneNumber - The phone number to send the message to
-   * @param message - The message content to send
-   */
-  async sendMessage(phoneNumber: string, message: string): Promise<void> {
-    if (this.logger) {
-      this.logger.info({ phoneNumber, message }, "SMS Message Sent");
+  async sendMessage(
+    phoneNumber: string,
+    message: string,
+    channel?: SMSChannel,
+  ): Promise<void> {
+    if (!client) {
+      this.logger?.info({ phoneNumber, message, channel }, "SMS Message Sent");
+      return;
     }
+
+    const sid = channel ? SID_MAP[channel] : undefined;
+    if (!sid) {
+      this.logger?.info(
+        { phoneNumber, channel },
+        "SMS: no Messaging Service SID configured for channel, skipping",
+      );
+      return;
+    }
+
+    await client.messages.create({
+      to: phoneNumber,
+      messagingServiceSid: sid,
+      body: message,
+    });
+
+    this.logger?.info({ phoneNumber, channel }, "SMS: message sent via Twilio");
   }
 }

--- a/apps/api/tests/unit/invitation.service.test.ts
+++ b/apps/api/tests/unit/invitation.service.test.ts
@@ -12,7 +12,7 @@ import {
 import { eq, or, and } from "drizzle-orm";
 import { InvitationService } from "@/services/invitation.service.js";
 import { PermissionsService } from "@/services/permissions.service.js";
-import { MockSMSService } from "@/services/sms.service.js";
+import { SMSService } from "@/services/sms.service.js";
 import { NotificationService } from "@/services/notification.service.js";
 import { generateUniquePhone } from "../test-utils.js";
 import {
@@ -30,7 +30,7 @@ import type { PgBoss } from "pg-boss";
 
 // Create service instances with db for testing
 const permissionsService = new PermissionsService(db);
-const smsService = new MockSMSService();
+const smsService = new SMSService();
 const notificationService = new NotificationService(db);
 const invitationService = new InvitationService(
   db,
@@ -1350,13 +1350,13 @@ describe("invitation.service", () => {
           expect.objectContaining({
             data: {
               phoneNumber: phone1,
-              message: "You've been invited to a trip on Journiful!",
+              message: expect.stringContaining("on Journiful!"),
             },
           }),
           expect.objectContaining({
             data: {
               phoneNumber: phone2,
-              message: "You've been invited to a trip on Journiful!",
+              message: expect.stringContaining("on Journiful!"),
             },
           }),
         ]),
@@ -1419,10 +1419,11 @@ describe("invitation.service", () => {
 
       expect(result.invitations).toHaveLength(1);
 
-      // Inline SMS should be called
+      // Inline SMS should be called with personalized message and sms_invite type
       expect(sendMessageSpy).toHaveBeenCalledWith(
         phone,
-        "You've been invited to a trip on Journiful!",
+        expect.stringContaining("on Journiful!"),
+        "invite",
       );
 
       sendMessageSpy.mockRestore();

--- a/apps/api/tests/unit/message.service.test.ts
+++ b/apps/api/tests/unit/message.service.test.ts
@@ -14,7 +14,7 @@ import { eq, or } from "drizzle-orm";
 import { MessageService } from "@/services/message.service.js";
 import { PermissionsService } from "@/services/permissions.service.js";
 import { NotificationService } from "@/services/notification.service.js";
-import { MockSMSService } from "@/services/sms.service.js";
+import { SMSService } from "@/services/sms.service.js";
 import { generateUniquePhone } from "../test-utils.js";
 import {
   MessageNotFoundError,
@@ -32,7 +32,7 @@ import {
 
 // Create service instances with db for testing
 const permissionsService = new PermissionsService(db);
-const smsService = new MockSMSService();
+const smsService = new SMSService();
 const notificationService = new NotificationService(db, smsService);
 const messageService = new MessageService(
   db,

--- a/apps/api/tests/unit/sms.service.test.ts
+++ b/apps/api/tests/unit/sms.service.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { MockSMSService } from "@/services/sms.service.js";
+import { SMSService } from "@/services/sms.service.js";
 
 describe("sms.service", () => {
   describe("sendMessage", () => {
@@ -7,7 +7,7 @@ describe("sms.service", () => {
     const testMessage = "Your Journiful verification code is: 123456";
 
     it("should exist and be callable", async () => {
-      const service = new MockSMSService();
+      const service = new SMSService();
       expect(service.sendMessage).toBeDefined();
       expect(typeof service.sendMessage).toBe("function");
       await expect(
@@ -16,7 +16,7 @@ describe("sms.service", () => {
     });
 
     it("should not throw when no logger is provided", async () => {
-      const service = new MockSMSService();
+      const service = new SMSService();
       await expect(
         service.sendMessage(testPhone, testMessage),
       ).resolves.toBeUndefined();
@@ -27,12 +27,12 @@ describe("sms.service", () => {
         info: vi.fn(),
       };
 
-      const service = new MockSMSService(mockLogger);
+      const service = new SMSService(mockLogger);
       await service.sendMessage(testPhone, testMessage);
 
       expect(mockLogger.info).toHaveBeenCalledTimes(1);
       expect(mockLogger.info).toHaveBeenCalledWith(
-        { phoneNumber: testPhone, message: testMessage },
+        { phoneNumber: testPhone, message: testMessage, channel: undefined },
         "SMS Message Sent",
       );
     });
@@ -42,7 +42,7 @@ describe("sms.service", () => {
         info: vi.fn(),
       };
 
-      const service = new MockSMSService(mockLogger);
+      const service = new SMSService(mockLogger);
       await service.sendMessage(testPhone, testMessage);
 
       const logData = mockLogger.info.mock.calls[0][0] as Record<
@@ -57,7 +57,7 @@ describe("sms.service", () => {
         info: vi.fn(),
       };
 
-      const service = new MockSMSService(mockLogger);
+      const service = new SMSService(mockLogger);
       await service.sendMessage(testPhone, testMessage);
 
       const logData = mockLogger.info.mock.calls[0][0] as Record<
@@ -72,7 +72,7 @@ describe("sms.service", () => {
         info: vi.fn(),
       };
 
-      const service = new MockSMSService(mockLogger);
+      const service = new SMSService(mockLogger);
       const customMessage = "You've been invited to a trip on Journiful!";
       await service.sendMessage(testPhone, customMessage);
 
@@ -88,7 +88,7 @@ describe("sms.service", () => {
         info: vi.fn(),
       };
 
-      const service = new MockSMSService(mockLogger);
+      const service = new SMSService(mockLogger);
       await service.sendMessage(testPhone, testMessage);
 
       const logMessage = mockLogger.info.mock.calls[0][1];

--- a/apps/api/tests/unit/update-member-role.test.ts
+++ b/apps/api/tests/unit/update-member-role.test.ts
@@ -4,7 +4,7 @@ import { users, trips, members } from "@/db/schema/index.js";
 import { eq, and, or } from "drizzle-orm";
 import { InvitationService } from "@/services/invitation.service.js";
 import { PermissionsService } from "@/services/permissions.service.js";
-import { MockSMSService } from "@/services/sms.service.js";
+import { SMSService } from "@/services/sms.service.js";
 import { generateUniquePhone } from "../test-utils.js";
 import {
   PermissionDeniedError,
@@ -17,7 +17,7 @@ import {
 
 // Create service instances with db for testing
 const permissionsService = new PermissionsService(db);
-const smsService = new MockSMSService();
+const smsService = new SMSService();
 const invitationService = new InvitationService(
   db,
   permissionsService,

--- a/apps/api/tests/unit/workers/invitation-send.worker.test.ts
+++ b/apps/api/tests/unit/workers/invitation-send.worker.test.ts
@@ -41,6 +41,7 @@ describe("invitation-send.worker", () => {
     expect(mockDeps.smsService.sendMessage).toHaveBeenCalledWith(
       "+15559876543",
       "You've been invited to a trip on Journiful!",
+      "invite",
     );
   });
 

--- a/apps/api/tests/unit/workers/notification-batch.worker.test.ts
+++ b/apps/api/tests/unit/workers/notification-batch.worker.test.ts
@@ -17,7 +17,7 @@ import {
 } from "@/queues/workers/notification-batch.worker.js";
 import type { NotificationBatchPayload, WorkerDeps } from "@/queues/types.js";
 import { QUEUE } from "@/queues/types.js";
-import { MockSMSService } from "@/services/sms.service.js";
+import { SMSService } from "@/services/sms.service.js";
 import { generateUniquePhone } from "../../test-utils.js";
 
 describe("notification-batch.worker", () => {
@@ -161,7 +161,7 @@ describe("notification-batch.worker", () => {
       boss: {
         insert: vi.fn().mockResolvedValue(undefined),
       } as unknown as WorkerDeps["boss"],
-      smsService: new MockSMSService(),
+      smsService: new SMSService(),
       pushService: {
         addSubscription: vi.fn(),
         removeSubscription: vi.fn(),

--- a/apps/web/tests/e2e/trip-journey.spec.ts
+++ b/apps/web/tests/e2e/trip-journey.spec.ts
@@ -843,15 +843,18 @@ test.describe("Trip Journey", () => {
       });
 
       await test.step("verify member selector is visible for organizer", async () => {
-        // Organizer should see the member selector — requires members data to be fetched,
-        // so use ELEMENT_TIMEOUT to allow for the API round-trip.
+        // Organizer should see the member selector — requires members data to be fetched.
+        // The useMembers() hook fires after the dialog opens, so the selector may not
+        // render until the API response arrives. Wrap in toPass() to retry until the
+        // TanStack Query settles and the conditional render (`isOrganizer && members`)
+        // evaluates to true.
         const memberSelector = page.locator('[data-testid="member-selector"]');
-        await expect(memberSelector).toBeVisible({ timeout: ELEMENT_TIMEOUT });
-
-        // Should show the helper text
-        await expect(
-          page.getByText("As organizer, you can add travel for any member"),
-        ).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+        await expect(async () => {
+          await expect(memberSelector).toBeVisible();
+          await expect(
+            page.getByText("As organizer, you can add travel for any member"),
+          ).toBeVisible();
+        }).toPass({ timeout: SLOW_NAVIGATION_TIMEOUT });
       });
 
       await test.step("select the other member", async () => {
@@ -883,10 +886,14 @@ test.describe("Trip Journey", () => {
           .locator('input[name="location"]')
           .fill("Seattle-Tacoma Airport");
         // Expand the collapsed "More details" section to reveal the details textarea.
-        // This collapsible animation (150ms) causes React re-renders that can detach
-        // DOM elements. Use a toPass() retry loop so that if the element is detached
-        // between the visibility check and the fill, we retry until it sticks.
-        await page.getByRole("button", { name: "More details" }).click();
+        // The collapsible animation (150ms) plus subsequent React re-renders can detach
+        // DOM elements. Wait for the animation to fully settle before interacting, then
+        // use a toPass() retry loop as a safety net for any late re-renders.
+        const moreDetailsBtn = page.getByRole("button", { name: "More details" });
+        await moreDetailsBtn.click();
+        // Wait for collapsible animation (150ms) + React re-render cycle to settle.
+        // Without this pause, every toPass() attempt hits a detached element.
+        await page.waitForTimeout(500);
         const detailsTextarea = page.locator('textarea[name="details"]');
         await expect(async () => {
           await expect(detailsTextarea).toBeVisible();

--- a/apps/web/tests/e2e/trip-journey.spec.ts
+++ b/apps/web/tests/e2e/trip-journey.spec.ts
@@ -886,16 +886,21 @@ test.describe("Trip Journey", () => {
           .locator('input[name="location"]')
           .fill("Seattle-Tacoma Airport");
         // Expand the collapsed "More details" section to reveal the details textarea.
-        // The collapsible animation (150ms) plus subsequent React re-renders can detach
-        // DOM elements. Wait for the animation to fully settle before interacting, then
-        // use a toPass() retry loop as a safety net for any late re-renders.
+        // On CI, the click on the CollapsibleTrigger can be swallowed during a React
+        // re-render (e.g., after filling the location input). If the click is lost, the
+        // collapsible never opens and the textarea never appears — no amount of waiting
+        // helps. Fix: put the click *inside* the toPass() retry loop, but only click
+        // when the trigger is in the "closed" state (Radix sets data-state="open" once
+        // expanded) to avoid toggling it back closed on a successful retry.
         const moreDetailsBtn = page.getByRole("button", { name: "More details" });
-        await moreDetailsBtn.click();
-        // Wait for collapsible animation (150ms) + React re-render cycle to settle.
-        // Without this pause, every toPass() attempt hits a detached element.
-        await page.waitForTimeout(500);
         const detailsTextarea = page.locator('textarea[name="details"]');
         await expect(async () => {
+          const state = await moreDetailsBtn.getAttribute("data-state");
+          if (state !== "open") {
+            await moreDetailsBtn.click();
+            // Brief pause for the 150ms collapsible animation
+            await page.waitForTimeout(200);
+          }
           await expect(detailsTextarea).toBeVisible();
           await detailsTextarea.fill("Arriving on behalf of member");
         }).toPass({ timeout: ELEMENT_TIMEOUT });

--- a/apps/web/tests/e2e/trip-journey.spec.ts
+++ b/apps/web/tests/e2e/trip-journey.spec.ts
@@ -843,14 +843,15 @@ test.describe("Trip Journey", () => {
       });
 
       await test.step("verify member selector is visible for organizer", async () => {
-        // Organizer should see the member selector
+        // Organizer should see the member selector — requires members data to be fetched,
+        // so use ELEMENT_TIMEOUT to allow for the API round-trip.
         const memberSelector = page.locator('[data-testid="member-selector"]');
-        await expect(memberSelector).toBeVisible();
+        await expect(memberSelector).toBeVisible({ timeout: ELEMENT_TIMEOUT });
 
         // Should show the helper text
         await expect(
           page.getByText("As organizer, you can add travel for any member"),
-        ).toBeVisible();
+        ).toBeVisible({ timeout: ELEMENT_TIMEOUT });
       });
 
       await test.step("select the other member", async () => {
@@ -882,12 +883,15 @@ test.describe("Trip Journey", () => {
           .locator('input[name="location"]')
           .fill("Seattle-Tacoma Airport");
         // Expand the collapsed "More details" section to reveal the details textarea.
-        // This collapsible animation causes a React re-render that can detach DOM
-        // elements, so we wait for the textarea to be stable before continuing.
+        // This collapsible animation (150ms) causes React re-renders that can detach
+        // DOM elements. Use a toPass() retry loop so that if the element is detached
+        // between the visibility check and the fill, we retry until it sticks.
         await page.getByRole("button", { name: "More details" }).click();
         const detailsTextarea = page.locator('textarea[name="details"]');
-        await expect(detailsTextarea).toBeVisible({ timeout: ELEMENT_TIMEOUT });
-        await detailsTextarea.fill("Arriving on behalf of member");
+        await expect(async () => {
+          await expect(detailsTextarea).toBeVisible();
+          await detailsTextarea.fill("Arriving on behalf of member");
+        }).toPass({ timeout: ELEMENT_TIMEOUT });
 
         // After filling, wait for the submit button to be attached and stable.
         // The collapsible expansion can cause the form to re-render, detaching


### PR DESCRIPTION
## Summary

- Replace `MockSMSService` with unified `SMSService` that reads Twilio config from env and falls back to mock mode when credentials are absent
- Add `TWILIO_INVITE_MESSAGING_SERVICE_SID` env var — set it in Railway to enable real SMS delivery, unset to kill-switch back to mock
- Personalize invite SMS: `"{inviter} invited you to "{trip}" on Journiful! Join at journiful.app"`
- Add `SMSChannel` type (`"invite" | "notification"`) for routing to different Twilio Messaging Services — decoupled from `NotificationType`
- Simplify SMS plugin to one line (service owns all config)

## Test plan

- [x] All 161 affected tests pass (sms.service, invitation.service, invitation-send.worker, message.service, update-member-role, notification-batch.worker)
- [x] Typecheck passes across all packages
- [ ] Set `TWILIO_INVITE_MESSAGING_SERVICE_SID` in Railway and verify real SMS delivery
- [ ] Verify mock mode works when env var is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)