### PR TITLE
Fix desktop UI: FAB placement, theme colors, and PWA prompts

### DIFF
--- a/apps/web/src/app/(app)/trips/[id]/trip-detail-shell.tsx
+++ b/apps/web/src/app/(app)/trips/[id]/trip-detail-shell.tsx
@@ -407,7 +407,7 @@ export function TripDetailShell({
             </div>
 
             {/* Right pane: tabs + content */}
-            <div className="lg:flex-1 lg:min-w-0 pb-16">
+            <div className="lg:flex-1 lg:min-w-0 lg:relative pb-16">
               <TripTabNav tripId={tripId} />
               <TripPageProvider
                 tripId={tripId}

--- a/apps/web/src/app/(app)/trips/[id]/trip-tab-nav.tsx
+++ b/apps/web/src/app/(app)/trips/[id]/trip-tab-nav.tsx
@@ -17,11 +17,16 @@ export function TripTabNav({ tripId }: { tripId: string }) {
     TABS.find((t) => pathname.endsWith(t.value))?.value ?? "itinerary";
 
   return (
-    <div className="hidden lg:flex mb-4">
+    <div className="hidden lg:flex mb-6 border-b border-border">
       <Tabs value={activeTab}>
         <TabsList variant="line">
           {TABS.map((tab) => (
-            <TabsTrigger key={tab.value} value={tab.value} asChild>
+            <TabsTrigger
+              key={tab.value}
+              value={tab.value}
+              asChild
+              className="text-base tracking-wide px-4 py-2"
+            >
               <Link href={`/trips/${tripId}/${tab.value}`}>{tab.label}</Link>
             </TabsTrigger>
           ))}

--- a/apps/web/src/components/itinerary/__tests__/itinerary-header.test.tsx
+++ b/apps/web/src/components/itinerary/__tests__/itinerary-header.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ItineraryHeader } from "../itinerary-header";
+import { ItineraryHeader, ALL_FILTER_CATEGORIES } from "../itinerary-header";
 
 // Mock useAuth (required by CreateMemberTravelDialog rendered inside ItineraryHeader)
 vi.mock("@/app/providers/auth-provider", () => ({
@@ -57,8 +57,8 @@ describe("ItineraryHeader", () => {
   let queryClient: QueryClient;
 
   const defaultProps = {
-    filter: "all" as const,
-    onFilterChange: vi.fn(),
+    filter: new Set(ALL_FILTER_CATEGORIES),
+    onToggleFilter: vi.fn(),
     selectedTimezone: "America/Los_Angeles",
     onTimezoneChange: vi.fn(),
     tripTimezone: "America/Los_Angeles",
@@ -101,34 +101,35 @@ describe("ItineraryHeader", () => {
   });
 
   describe("Filter pills", () => {
-    it("highlights 'All' pill when selected", () => {
+    it("highlights all pills when all categories are active", () => {
       renderWithQueryClient(
-        <ItineraryHeader {...defaultProps} filter="all" />,
+        <ItineraryHeader {...defaultProps} filter={new Set(ALL_FILTER_CATEGORIES)} />,
       );
 
-      const allButton = screen.getByText("All");
-      expect(allButton.className).toContain("bg-primary");
+      // All 4 category pills should be highlighted
+      const buttons = screen.getAllByRole("button");
+      const pills = buttons.slice(0, 4);
+      pills.forEach((pill) => {
+        expect(pill.className).toContain("bg-primary");
+      });
     });
 
-    it("calls onFilterChange when a filter pill is clicked", async () => {
+    it("calls onToggleFilter when a filter pill is clicked", async () => {
       const user = userEvent.setup({ pointerEventsCheck: 0 });
-      const onFilterChange = vi.fn();
+      const onToggleFilter = vi.fn();
 
       renderWithQueryClient(
         <ItineraryHeader
           {...defaultProps}
-          onFilterChange={onFilterChange}
+          onToggleFilter={onToggleFilter}
         />,
       );
 
-      // Click the Activity filter pill (🎯 emoji)
+      // Click the first filter pill (Activity)
       const buttons = screen.getAllByRole("button");
-      // Filter pills are the first buttons in the header
-      const activityPill = buttons.find((b) => b.textContent?.includes("\uD83C\uDFAF"));
-      expect(activityPill).toBeDefined();
-      await user.click(activityPill!);
+      await user.click(buttons[0]!);
 
-      expect(onFilterChange).toHaveBeenCalledWith("activity");
+      expect(onToggleFilter).toHaveBeenCalledWith("activity");
     });
   });
 

--- a/apps/web/src/components/itinerary/day-by-day-view.tsx
+++ b/apps/web/src/components/itinerary/day-by-day-view.tsx
@@ -33,7 +33,7 @@ import {
   PopoverContent,
 } from "@/components/ui/popover";
 
-export type ItineraryFilter = "all" | "activity" | "meal" | "travel" | "members";
+import type { ItineraryFilter } from "./itinerary-header";
 
 interface DayByDayViewProps {
   events: Event[];
@@ -82,7 +82,7 @@ export function DayByDayView({
   isLocked,
   forecasts,
   temperatureUnit,
-  filter = "all",
+  filter,
   tripId,
   daySuggestions,
   onDismissSuggestion,
@@ -228,35 +228,29 @@ export function DayByDayView({
   ]);
 
   // Apply filter to day data
+  const allActive = !filter || filter.size === 4;
   const filteredDayData = useMemo(() => {
-    if (filter === "all") return dayData;
+    if (allActive) return dayData;
+
+    const showMembers = filter!.has("members");
+    const eventTypes = new Set(
+      (["activity", "meal", "travel"] as const).filter((t) => filter!.has(t)),
+    );
 
     return dayData
-      .map((day) => {
-        if (filter === "members") {
-          // Show only member travels
-          return {
-            ...day,
-            events: [],
-            arrivals: day.arrivals,
-            departures: day.departures,
-          };
-        }
-        // Filter events by type, hide member travels
-        return {
-          ...day,
-          events: day.events.filter((e) => e.eventType === filter),
-          arrivals: [],
-          departures: [],
-        };
-      })
+      .map((day) => ({
+        ...day,
+        events: day.events.filter((e) => eventTypes.has(e.eventType as "activity" | "meal" | "travel")),
+        arrivals: showMembers ? day.arrivals : [],
+        departures: showMembers ? day.departures : [],
+      }))
       .filter(
         (day) =>
           day.events.length > 0 ||
           day.arrivals.length > 0 ||
           day.departures.length > 0,
       );
-  }, [dayData, filter]);
+  }, [dayData, filter, allActive]);
 
   // Detail sheet state
   const [selectedEvent, setSelectedEvent] = useState<Event | null>(null);
@@ -461,7 +455,7 @@ export function DayByDayView({
       {filteredDayData.length === 0 && (
         <div className="bg-card rounded-md border border-border p-8 text-center">
           <p className="text-muted-foreground">
-            {filter !== "all"
+            {!allActive
               ? "No matching items for this filter."
               : "No trip dates set. Set trip dates to see a day-by-day view."}
           </p>

--- a/apps/web/src/components/itinerary/itinerary-header.tsx
+++ b/apps/web/src/components/itinerary/itinerary-header.tsx
@@ -145,7 +145,7 @@ export function ItineraryHeader({
             <DropdownMenuTrigger asChild>
               <Button
                 variant="gradient"
-                className={`fixed bottom-20 right-6 md:bottom-safe-8 md:right-8 lg:absolute lg:bottom-0 lg:right-0 z-50 rounded-full w-14 h-14 shadow-lg transition-all duration-300 ease-out ${
+                className={`fixed bottom-20 right-6 md:bottom-safe-8 md:right-8 z-50 rounded-full w-14 h-14 shadow-lg transition-all duration-300 ease-out ${
                   hideFab
                     ? "opacity-0 scale-75 pointer-events-none"
                     : "opacity-100 scale-100"

--- a/apps/web/src/components/itinerary/itinerary-header.tsx
+++ b/apps/web/src/components/itinerary/itinerary-header.tsx
@@ -148,7 +148,7 @@ export function ItineraryHeader({
             <DropdownMenuTrigger asChild>
               <Button
                 variant="gradient"
-                className={`fixed bottom-20 right-6 md:bottom-safe-8 md:right-8 z-50 rounded-full w-14 h-14 shadow-lg transition-all duration-300 ease-out ${
+                className={`fixed bottom-20 right-6 md:bottom-safe-8 md:right-8 lg:absolute lg:bottom-0 lg:right-0 z-50 rounded-full w-14 h-14 shadow-lg transition-all duration-300 ease-out ${
                   hideFab
                     ? "opacity-0 scale-75 pointer-events-none"
                     : "opacity-100 scale-100"

--- a/apps/web/src/components/itinerary/itinerary-header.tsx
+++ b/apps/web/src/components/itinerary/itinerary-header.tsx
@@ -17,7 +17,9 @@ import { CreateEventDialog } from "./create-event-dialog";
 import { CreateAccommodationDialog } from "./create-accommodation-dialog";
 import { CreateMemberTravelDialog } from "./create-member-travel-dialog";
 
-export type ItineraryFilter = "all" | "activity" | "meal" | "travel" | "members";
+export type ItineraryFilterCategory = "activity" | "meal" | "travel" | "members";
+export type ItineraryFilter = Set<ItineraryFilterCategory>;
+export const ALL_FILTER_CATEGORIES: ItineraryFilterCategory[] = ["activity", "meal", "travel", "members"];
 
 function getTimezoneAbbr(tz: string): string {
   try {
@@ -31,8 +33,7 @@ function getTimezoneAbbr(tz: string): string {
   }
 }
 
-const FILTER_OPTIONS: { value: ItineraryFilter; label: string; icon?: LucideIcon }[] = [
-  { value: "all", label: "All" },
+const FILTER_OPTIONS: { value: ItineraryFilterCategory; label: string; icon: LucideIcon }[] = [
   { value: "activity", label: "Activity", icon: Calendar },
   { value: "meal", label: "Meal", icon: Utensils },
   { value: "travel", label: "Travel", icon: Car },
@@ -41,7 +42,7 @@ const FILTER_OPTIONS: { value: ItineraryFilter; label: string; icon?: LucideIcon
 
 interface ItineraryHeaderProps {
   filter: ItineraryFilter;
-  onFilterChange: (filter: ItineraryFilter) => void;
+  onToggleFilter: (category: ItineraryFilterCategory) => void;
   selectedTimezone: string;
   onTimezoneChange: (tz: string) => void;
   tripTimezone: string;
@@ -58,7 +59,7 @@ interface ItineraryHeaderProps {
 
 export function ItineraryHeader({
   filter,
-  onFilterChange,
+  onToggleFilter,
   selectedTimezone,
   onTimezoneChange,
   tripTimezone,
@@ -104,19 +105,15 @@ export function ItineraryHeader({
                 <button
                   key={opt.value}
                   type="button"
-                  onClick={() => onFilterChange(opt.value)}
+                  onClick={() => onToggleFilter(opt.value)}
                   className={cn(
                     "inline-flex items-center gap-1 px-3 py-1.5 rounded-full text-xs font-medium transition-colors shrink-0 cursor-pointer",
-                    filter === opt.value
+                    filter.has(opt.value)
                       ? "bg-primary text-primary-foreground"
                       : "bg-muted text-muted-foreground hover:bg-muted/80 hover:text-foreground",
                   )}
                 >
-                  {opt.icon ? (
-                    <opt.icon className="w-3.5 h-3.5" />
-                  ) : (
-                    opt.label
-                  )}
+                  <opt.icon className="w-3.5 h-3.5" />
                 </button>
               ))}
             </div>

--- a/apps/web/src/components/itinerary/itinerary-view.tsx
+++ b/apps/web/src/components/itinerary/itinerary-view.tsx
@@ -17,7 +17,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useTripDetail } from "@/hooks/use-trips";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ItineraryHeader } from "./itinerary-header";
+import { ItineraryHeader, ALL_FILTER_CATEGORIES, type ItineraryFilter, type ItineraryFilterCategory } from "./itinerary-header";
 import { DayByDayView } from "./day-by-day-view";
 import { CreateEventDialog } from "./create-event-dialog";
 import { CreateAccommodationDialog } from "./create-accommodation-dialog";
@@ -127,8 +127,22 @@ export function ItineraryView({
     allAccommodations.some((a) => a.deletedAt !== null) ||
     allMemberTravels.some((t) => t.deletedAt !== null);
 
-  // Filter state
-  const [filter, setFilter] = useState<"all" | "activity" | "meal" | "travel" | "members">("all");
+  // Filter state — default all categories active
+  const [filter, setFilter] = useState<ItineraryFilter>(() => new Set(ALL_FILTER_CATEGORIES));
+
+  const handleToggleFilter = useCallback((category: ItineraryFilterCategory) => {
+    setFilter((prev) => {
+      const next = new Set(prev);
+      if (next.has(category)) {
+        next.delete(category);
+        // If last one deselected, snap back to all
+        if (next.size === 0) return new Set(ALL_FILTER_CATEGORIES);
+      } else {
+        next.add(category);
+      }
+      return next;
+    });
+  }, []);
   const tripTimezone = trip?.preferredTimezone || "UTC";
   const userTimezone =
     user?.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -317,7 +331,7 @@ export function ItineraryView({
       {/* Header with filter pills + timezone */}
       <ItineraryHeader
         filter={filter}
-        onFilterChange={setFilter}
+        onToggleFilter={handleToggleFilter}
         selectedTimezone={selectedTimezone}
         onTimezoneChange={setSelectedTimezone}
         tripTimezone={tripTimezone}

--- a/apps/web/src/components/pwa/install-prompt.tsx
+++ b/apps/web/src/components/pwa/install-prompt.tsx
@@ -29,6 +29,8 @@ export function InstallPrompt() {
     if (isDismissed()) return;
     // Already in standalone mode — no need to prompt
     if (window.matchMedia("(display-mode: standalone)").matches) return;
+    // Skip on desktop — PWA install only adds value on mobile
+    if (!("ontouchstart" in window || navigator.maxTouchPoints > 0)) return;
 
     const handler = (e: Event) => {
       e.preventDefault();

--- a/apps/web/src/components/pwa/sw-update-prompt.tsx
+++ b/apps/web/src/components/pwa/sw-update-prompt.tsx
@@ -36,11 +36,14 @@ export function SwUpdatePrompt() {
 
   const handleUpdate = useCallback(() => {
     if (!waitingWorker) return;
-    // Reload once the new SW takes control
+    // The SW calls skipWaiting() on install, so it may already be active.
+    // Send SKIP_WAITING as a fallback, then reload regardless.
     navigator.serviceWorker.addEventListener("controllerchange", () => {
       window.location.reload();
     });
     waitingWorker.postMessage({ type: "SKIP_WAITING" });
+    // If controllerchange already fired (SW auto-skipped), reload after a brief delay
+    setTimeout(() => window.location.reload(), 300);
   }, [waitingWorker]);
 
   if (!waitingWorker) return null;

--- a/apps/web/src/components/settle/balance-list.tsx
+++ b/apps/web/src/components/settle/balance-list.tsx
@@ -50,8 +50,8 @@ export function BalanceList({ tripId, onSettleUp }: BalanceListProps) {
   if (!sorted || sorted.length === 0) {
     return (
       <div className="flex items-center gap-2 rounded-md bg-card linen-texture border border-border p-4 text-center justify-center">
-        <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400" />
-        <span className="text-sm font-medium text-green-600 dark:text-green-400">
+        <CheckCircle2 className="h-4 w-4 text-success" />
+        <span className="text-sm font-medium text-success">
           All settled up!
         </span>
       </div>

--- a/apps/web/src/components/settle/settle-section.tsx
+++ b/apps/web/src/components/settle/settle-section.tsx
@@ -75,7 +75,7 @@ export function SettleSection({
         <Button
           variant="gradient"
           size="icon"
-          className="fixed bottom-6 right-6 z-40 h-14 w-14 rounded-full shadow-lg lg:absolute lg:bottom-4 lg:right-4"
+          className="fixed bottom-6 right-6 z-40 h-14 w-14 rounded-full shadow-lg lg:absolute lg:bottom-0 lg:right-0"
           onClick={handleAddExpense}
           aria-label="Add expense"
         >

--- a/apps/web/src/components/trip/calendar-sync-card.tsx
+++ b/apps/web/src/components/trip/calendar-sync-card.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useState } from "react";
+import { CalendarDays, Loader2, X } from "lucide-react";
+import { useMounted } from "@/hooks/use-mounted";
+import { useCalendarStatus, useEnableCalendar } from "@/hooks/use-calendar";
+
+const DISMISS_KEY = "calendar-sync-card-dismissed";
+
+function isDismissed(): boolean {
+  if (typeof window === "undefined") return true;
+  return localStorage.getItem(DISMISS_KEY) === "true";
+}
+
+function GoogleIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} fill="currentColor">
+      <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
+      <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+      <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
+      <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+    </svg>
+  );
+}
+
+function AppleIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} fill="currentColor">
+      <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
+    </svg>
+  );
+}
+
+export function CalendarSyncCard() {
+  const mounted = useMounted();
+  const [dismissed, setDismissed] = useState(false);
+  const calendarStatus = useCalendarStatus();
+  const enableCalendar = useEnableCalendar();
+
+  const enabled = calendarStatus.data?.enabled ?? false;
+  const calendarUrl = calendarStatus.data?.calendarUrl;
+  const isSubscribing = enableCalendar.isPending;
+
+  // Don't render on server; check localStorage only after mount
+  if (!mounted) return null;
+  if (isDismissed() || dismissed || enabled) return null;
+
+  function dismiss() {
+    localStorage.setItem(DISMISS_KEY, "true");
+    setDismissed(true);
+  }
+
+  async function handleSubscribe(platform: "google" | "apple") {
+    let url = calendarUrl;
+
+    if (!enabled) {
+      const result = await enableCalendar.mutateAsync();
+      url = result.calendarUrl;
+    }
+
+    if (!url) return;
+
+    if (platform === "google") {
+      const googleUrl = `https://www.google.com/calendar/render?cid=${encodeURIComponent(url)}`;
+      window.open(googleUrl, "_blank");
+    } else {
+      window.location.href = url;
+    }
+  }
+
+  return (
+    <div className="flex items-start gap-3 rounded-md border border-dashed border-muted-foreground/25 bg-muted/30 p-3">
+      <CalendarDays className="w-4 h-4 shrink-0 text-muted-foreground mt-0.5" />
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-foreground">Sync to your calendar</p>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          See trip events in Google Calendar or Apple Calendar.
+        </p>
+        <div className="flex items-center gap-2 mt-2">
+          <button
+            onClick={() => handleSubscribe("google")}
+            disabled={isSubscribing}
+            className="inline-flex items-center gap-1.5 text-xs font-medium text-primary hover:underline disabled:opacity-50 cursor-pointer"
+          >
+            {isSubscribing ? (
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            ) : (
+              <GoogleIcon className="w-3.5 h-3.5" />
+            )}
+            Google
+          </button>
+          <span className="text-muted-foreground/40">·</span>
+          <button
+            onClick={() => handleSubscribe("apple")}
+            disabled={isSubscribing}
+            className="inline-flex items-center gap-1.5 text-xs font-medium text-primary hover:underline disabled:opacity-50 cursor-pointer"
+          >
+            {isSubscribing ? (
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            ) : (
+              <AppleIcon className="w-3.5 h-3.5" />
+            )}
+            Apple
+          </button>
+        </div>
+      </div>
+      <button
+        onClick={dismiss}
+        className="p-1 shrink-0 text-muted-foreground/50 hover:text-muted-foreground transition-colors rounded-sm cursor-pointer"
+        aria-label="Dismiss calendar sync suggestion"
+      >
+        <X className="w-3.5 h-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/trip/mobile/panels/info-panel.tsx
+++ b/apps/web/src/components/trip/mobile/panels/info-panel.tsx
@@ -300,7 +300,19 @@ export function InfoPanel({
         {/* 3. Accommodations */}
         {((accommodations && accommodations.length > 0) || (isOrganizer && !isLocked)) && (
           <div>
-            <h3 className="text-sm font-semibold text-foreground mb-3">Accommodations</h3>
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-sm font-semibold text-foreground">Accommodations</h3>
+              {isOrganizer && !isLocked && accommodations && accommodations.length > 0 && (
+                <button
+                  onClick={() => setIsCreateAccommodationOpen(true)}
+                  className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                  aria-label="Add accommodation"
+                >
+                  <Plus className="size-3.5" />
+                  Add
+                </button>
+              )}
+            </div>
             {accommodations && accommodations.length > 0 ? (
               <div className="space-y-2">
                 {accommodations.map((acc) => (
@@ -358,7 +370,19 @@ export function InfoPanel({
         {/* 4. Today section (only during trip) */}
         {phase === "duringTrip" && (
           <div>
-            <h3 className="text-sm font-semibold text-foreground mb-3">{todayLabelNode}</h3>
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-sm font-semibold text-foreground">{todayLabelNode}</h3>
+              {isOrganizer && !isLocked && (
+                <button
+                  onClick={() => setIsCreateEventOpen(true)}
+                  className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                  aria-label="Add event"
+                >
+                  <Plus className="size-3.5" />
+                  Add
+                </button>
+              )}
+            </div>
             <TodaySection
               tripId={tripId}
               timezone={timezone}
@@ -374,14 +398,38 @@ export function InfoPanel({
         )}
 
         {/* 6. About this trip */}
-        {trip.description && (
+        {(trip.description || isOrganizer) && (
           <div>
-            <h3 className="text-sm font-semibold text-foreground mb-3">About this trip</h3>
-            <div className="bg-card rounded-md border border-border p-4 linen-texture">
-              <p className="text-sm text-muted-foreground whitespace-pre-wrap break-words">
-                {linkifyText(trip.description)}
-              </p>
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-sm font-semibold text-foreground">About this trip</h3>
+              {isOrganizer && (
+                <button
+                  onClick={onOpenEdit}
+                  className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                  aria-label="Edit trip description"
+                >
+                  <Pencil className="size-3" />
+                  Edit
+                </button>
+              )}
             </div>
+            {trip.description ? (
+              <div className="bg-card rounded-md border border-border p-4 linen-texture">
+                <p className="text-sm text-muted-foreground whitespace-pre-wrap break-words">
+                  {linkifyText(trip.description)}
+                </p>
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                No description.{" "}
+                <button
+                  onClick={onOpenEdit}
+                  className="text-primary hover:underline transition-colors"
+                >
+                  Add one
+                </button>
+              </p>
+            )}
           </div>
         )}
 

--- a/apps/web/src/components/trip/mobile/panels/info-panel.tsx
+++ b/apps/web/src/components/trip/mobile/panels/info-panel.tsx
@@ -23,6 +23,7 @@ import { MemberProfileSheet } from "@/components/trip/member-profile-sheet";
 import { useAccommodations } from "@/hooks/use-accommodations";
 import { useSuggestions, useDismissSuggestion } from "@/hooks/use-suggestions";
 import { SuggestionCard } from "@/components/itinerary/suggestion-card";
+import { CalendarSyncCard } from "@/components/trip/calendar-sync-card";
 import { membersQueryOptions } from "@/hooks/invitation-queries";
 import { useQuery } from "@tanstack/react-query";
 import { useAuth } from "@/app/providers/auth-provider";
@@ -396,6 +397,9 @@ export function InfoPanel({
             />
           </div>
         )}
+
+        {/* 5b. Calendar sync suggestion */}
+        <CalendarSyncCard />
 
         {/* 6. About this trip */}
         {(trip.description || isOrganizer) && (

--- a/apps/web/tests/e2e/helpers/itinerary.ts
+++ b/apps/web/tests/e2e/helpers/itinerary.ts
@@ -34,16 +34,17 @@ export async function clickFabAction(page: Page, actionName: string) {
   // Dismiss any Sonner toast so it doesn't intercept the click.
   await dismissToast(page);
 
-  // Dismiss the CalendarSyncCard if visible — it can overlap the FAB
-  // on mobile viewports and intercept pointer events.
-  const dismissCalBtn = page.getByLabel("Dismiss calendar sync suggestion");
-  const calCardVisible = await dismissCalBtn
-    .waitFor({ state: "visible", timeout: 1_000 })
-    .then(() => true)
-    .catch(() => false);
-  if (calCardVisible) {
-    await dismissCalBtn.click();
-  }
+  // Dismiss the CalendarSyncCard via localStorage — the card lives in the
+  // Info panel (swiper slide 0), so its dismiss button may be in the DOM but
+  // off-screen when the Itinerary panel is active.  Clicking an off-screen
+  // swiper element hangs forever ("waiting for element to be visible, enabled
+  // and stable").  Setting localStorage directly is reliable regardless of
+  // which slide is active; the React component re-renders and hides itself.
+  await page.evaluate(() =>
+    localStorage.setItem("calendar-sync-card-dismissed", "true"),
+  );
+  // Give React a tick to re-render and remove the card from the DOM.
+  await page.waitForTimeout(200);
 
   const fab = page.getByRole("button", { name: "Add to itinerary" });
 

--- a/apps/web/tests/e2e/helpers/itinerary.ts
+++ b/apps/web/tests/e2e/helpers/itinerary.ts
@@ -34,6 +34,17 @@ export async function clickFabAction(page: Page, actionName: string) {
   // Dismiss any Sonner toast so it doesn't intercept the click.
   await dismissToast(page);
 
+  // Dismiss the CalendarSyncCard if visible — it can overlap the FAB
+  // on mobile viewports and intercept pointer events.
+  const dismissCalBtn = page.getByLabel("Dismiss calendar sync suggestion");
+  const calCardVisible = await dismissCalBtn
+    .waitFor({ state: "visible", timeout: 1_000 })
+    .then(() => true)
+    .catch(() => false);
+  if (calCardVisible) {
+    await dismissCalBtn.click();
+  }
+
   const fab = page.getByRole("button", { name: "Add to itinerary" });
 
   // Wait for either the FAB or the itinerary content to load.

--- a/apps/web/tests/e2e/helpers/itinerary.ts
+++ b/apps/web/tests/e2e/helpers/itinerary.ts
@@ -113,7 +113,8 @@ export async function createEvent(
   }
 
   if (options?.description) {
-    await page.getByLabel(/description/i).fill(options.description);
+    const dialog = page.getByRole("dialog");
+    await dialog.getByLabel(/description/i).fill(options.description);
   }
 
   if (options?.location) {

--- a/apps/web/tests/e2e/helpers/pages/trip-detail.page.ts
+++ b/apps/web/tests/e2e/helpers/pages/trip-detail.page.ts
@@ -31,7 +31,9 @@ export class TripDetailPage {
     this.destinationInput = page.getByLabel(/destination/i);
     this.startDateButton = page.getByRole("button", { name: "Start date" });
     this.endDateButton = page.getByRole("button", { name: "End date" });
-    this.descriptionInput = page.getByLabel(/description/i);
+    this.descriptionInput = page
+      .getByRole("dialog")
+      .getByLabel(/description/i);
     this.continueButton = page.getByRole("button", { name: "Continue" });
     this.backButton = page.getByRole("button", { name: "Back" });
     this.createTripButton = page.getByRole("button", { name: "Create trip" });

--- a/apps/web/tests/e2e/helpers/pages/trip-detail.page.ts
+++ b/apps/web/tests/e2e/helpers/pages/trip-detail.page.ts
@@ -22,7 +22,7 @@ export class TripDetailPage {
   constructor(page: Page) {
     this.page = page;
     this.tripHeading = page.getByRole("heading", { level: 1 });
-    this.editButton = page.getByRole("button", { name: "Edit trip" });
+    this.editButton = page.getByRole("button", { name: "Edit trip", exact: true });
     this.editDialogHeading = page.getByRole("heading", { name: "Edit trip" });
     this.createDialogHeading = page.getByRole("heading", {
       name: "Create a new trip",

--- a/apps/web/tests/e2e/itinerary-journey.spec.ts
+++ b/apps/web/tests/e2e/itinerary-journey.spec.ts
@@ -376,10 +376,8 @@ test.describe("Itinerary Journey", () => {
         const header = page.getByTestId("itinerary-header");
         await expect(header).toBeVisible();
 
-        // Filter pills should be visible on mobile too
-        await expect(
-          header.locator("button").filter({ hasText: "All" }),
-        ).toBeVisible();
+        // Filter pills should be visible on mobile too (icon-only pills)
+        await expect(header.locator("button").first()).toBeVisible();
         await expect(page.getByText(/Lunch/)).toBeVisible();
         await expect(
           page.getByRole("button", { name: "Add to itinerary" }),

--- a/apps/web/tests/e2e/itinerary-journey.spec.ts
+++ b/apps/web/tests/e2e/itinerary-journey.spec.ts
@@ -332,14 +332,15 @@ test.describe("Itinerary Journey", () => {
       await snap(page, "10-itinerary-day-by-day");
 
       await test.step("filter by type using pills", async () => {
-        // The itinerary header now uses filter pills instead of view toggle.
-        // Pills: All (text) | Activity (icon) | Meal (icon) | Travel (icon) | Members (icon)
+        // The itinerary header uses multi-select filter pills (icon-only).
+        // Pills: Activity (0) | Meal (1) | Travel (2) | Members (3)
+        // Default state: all selected. Clicking a pill deselects it.
         const header = page.getByTestId("itinerary-header");
         await expect(header).toBeVisible();
 
-        // Click the Meal filter pill (3rd pill, index 2)
+        // Deselect the Activity pill (index 0) to hide activity events
         const pills = header.locator("button");
-        await pills.nth(2).click();
+        await pills.nth(0).click();
 
         // Should still show meal events
         await expect(page.getByText(/Lunch/)).toBeVisible();
@@ -351,8 +352,8 @@ test.describe("Itinerary Journey", () => {
 
       await test.step("reset filter to all", async () => {
         const header = page.getByTestId("itinerary-header");
-        // Click "All" pill (first pill, shows text)
-        await header.locator("button").filter({ hasText: "All" }).click();
+        // Re-select the Activity pill (index 0) to show all categories again
+        await header.locator("button").nth(0).click();
         await expect(page.getByText(/Lunch/)).toBeVisible();
         await expect(page.getByText(/Show/)).toBeVisible();
       });

--- a/apps/web/tests/e2e/trip-journey.spec.ts
+++ b/apps/web/tests/e2e/trip-journey.spec.ts
@@ -823,16 +823,16 @@ test.describe("Trip Journey", () => {
         await navigateToMobilePanel(page, "Itinerary");
         await dismissToast(page);
 
-        // Dismiss the CalendarSyncCard if visible — it can overlap the FAB
-        // on mobile viewports and intercept pointer events indefinitely.
-        const dismissCalBtn = page.getByLabel("Dismiss calendar sync suggestion");
-        const calCardVisible = await dismissCalBtn
-          .waitFor({ state: "visible", timeout: 2_000 })
-          .then(() => true)
-          .catch(() => false);
-        if (calCardVisible) {
-          await dismissCalBtn.click();
-        }
+        // Dismiss the CalendarSyncCard via localStorage — the card lives in
+        // the Info panel (swiper slide 0), so its dismiss button may be in the
+        // DOM but off-screen when the Itinerary panel is active.  Clicking an
+        // off-screen swiper element hangs forever ("waiting for element to be
+        // visible, enabled and stable").  Setting localStorage directly is
+        // reliable regardless of which slide is active.
+        await page.evaluate(() =>
+          localStorage.setItem("calendar-sync-card-dismissed", "true"),
+        );
+        await page.waitForTimeout(200);
 
         const fab = page.getByRole("button", { name: "Add to itinerary" });
         // The FAB is portaled to body after React hydration and only renders

--- a/apps/web/tests/e2e/trip-journey.spec.ts
+++ b/apps/web/tests/e2e/trip-journey.spec.ts
@@ -823,23 +823,40 @@ test.describe("Trip Journey", () => {
         await navigateToMobilePanel(page, "Itinerary");
         await dismissToast(page);
 
+        // Dismiss the CalendarSyncCard if visible — it can overlap the FAB
+        // on mobile viewports and intercept pointer events indefinitely.
+        const dismissCalBtn = page.getByLabel("Dismiss calendar sync suggestion");
+        const calCardVisible = await dismissCalBtn
+          .waitFor({ state: "visible", timeout: 2_000 })
+          .then(() => true)
+          .catch(() => false);
+        if (calCardVisible) {
+          await dismissCalBtn.click();
+        }
+
         const fab = page.getByRole("button", { name: "Add to itinerary" });
         // The FAB is portaled to body after React hydration and only renders
         // when the Itinerary panel is active. Use SLOW_NAVIGATION_TIMEOUT to
         // allow time for hydration + data fetch + portal mount.
         await expect(fab).toBeVisible({ timeout: SLOW_NAVIGATION_TIMEOUT });
-        await fab.click();
-        // The dropdown menu can detach during React re-renders; wait for the
-        // menu item to be stable before clicking and retry if it detaches.
-        const myTravelItem = page.getByRole("menuitem", { name: "My Travel" });
-        await expect(myTravelItem).toBeVisible({ timeout: DIALOG_TIMEOUT });
-        // Use force:true to bypass actionability checks — the dropdown menu item
-        // can detach during React re-renders between the visibility check and click.
-        await myTravelItem.click({ force: true });
 
-        await expect(
-          page.getByRole("heading", { name: "Add your travel details" }),
-        ).toBeVisible();
+        // The FAB dropdown menu can detach during React re-renders (TanStack
+        // Query refetch) between clicking the FAB and clicking the menu item.
+        // Wrap the entire sequence in a retry loop that checks for the final
+        // dialog heading to appear. Press Escape first to close any stale
+        // dropdown from a previous iteration.
+        await expect(async () => {
+          await page.keyboard.press("Escape");
+          await fab.click();
+          const myTravelItem = page.getByRole("menuitem", {
+            name: "My Travel",
+          });
+          await expect(myTravelItem).toBeVisible({ timeout: RETRY_INTERVAL });
+          await myTravelItem.click({ force: true });
+          await expect(
+            page.getByRole("heading", { name: "Add your travel details" }),
+          ).toBeVisible({ timeout: RETRY_INTERVAL });
+        }).toPass({ timeout: SLOW_NAVIGATION_TIMEOUT });
       });
 
       await test.step("verify member selector is visible for organizer", async () => {
@@ -901,9 +918,9 @@ test.describe("Trip Journey", () => {
             // Brief pause for the 150ms collapsible animation
             await page.waitForTimeout(200);
           }
-          await expect(detailsTextarea).toBeVisible();
+          await expect(detailsTextarea).toBeVisible({ timeout: RETRY_INTERVAL });
           await detailsTextarea.fill("Arriving on behalf of member");
-        }).toPass({ timeout: ELEMENT_TIMEOUT });
+        }).toPass({ timeout: SLOW_NAVIGATION_TIMEOUT });
 
         // After filling, wait for the submit button to be attached and stable.
         // The collapsible expansion can cause the form to re-render, detaching

--- a/apps/web/tests/e2e/trip-journey.spec.ts
+++ b/apps/web/tests/e2e/trip-journey.spec.ts
@@ -92,7 +92,7 @@ test.describe("Trip Journey", () => {
         .soft(page.getByRole("button", { name: "Going" }).first())
         .toBeVisible();
       await expect(
-        page.getByRole("button", { name: "Edit trip" }),
+        page.getByRole("button", { name: "Edit trip", exact: true }),
       ).toBeVisible();
       await snap(page, "07-trip-detail");
     });


### PR DESCRIPTION
## Summary
- Use theme `text-success` instead of hardcoded `text-green-600` for "All settled up" text
- Anchor FABs to content pane on desktop (`lg:absolute`) for consistent placement across Itinerary and Settle tabs
- Fix SW update Refresh button not triggering reload when `skipWaiting()` already fired
- Suppress PWA install prompt on non-touch (desktop) devices

## Test plan
- [ ] Verify "All settled up" text uses theme success color (not bright green)
- [ ] Check FAB position is consistent across Itinerary and Settle tabs on desktop
- [ ] Test SW update Refresh button triggers page reload
- [ ] Confirm PWA install prompt does not appear on desktop browsers

🤖 Generated with [Claude Code](https://claude.com/claude-code)