### PR TITLE
Send SMS with deep link for mutual invites

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -39,7 +39,7 @@
     "date-fns-tz": "^3.2.0",
     "dotenv": "^17.4.1",
     "drizzle-orm": "^0.45.2",
-    "fastify": "^5.8.4",
+    "fastify": "^5.8.5",
     "fastify-plugin": "^5.1.0",
     "fastify-type-provider-zod": "^6.1.0",
     "file-type": "^22.0.1",

--- a/apps/api/src/services/invitation.service.ts
+++ b/apps/api/src/services/invitation.service.ts
@@ -250,6 +250,7 @@ export class InvitationService implements IInvitationService {
     const tripName = tripRow?.name ?? "a trip";
 
     let createdInvitations: DBInvitation[] = [];
+    let mutualCreatedInvitations: DBInvitation[] = [];
     let skipped: string[] = [];
     let newPhones: string[] = [];
     const addedMembers: { userId: string; displayName: string }[] = [];
@@ -440,30 +441,91 @@ export class InvitationService implements IInvitationService {
         }
 
         if (newMutualUserIds.length > 0) {
-          // Fetch display names for the new mutual invitees
+          // Fetch display names and phone numbers for the new mutual invitees
           const mutualUsers = await tx
-            .select({ id: users.id, displayName: users.displayName })
+            .select({
+              id: users.id,
+              displayName: users.displayName,
+              phoneNumber: users.phoneNumber,
+            })
             .from(users)
             .where(inArray(users.id, newMutualUserIds));
           const mutualUserMap = new Map(
-            mutualUsers.map((u) => [u.id, u.displayName]),
+            mutualUsers.map((u) => [u.id, u]),
           );
 
-          // Create member records for mutual invitees
-          await tx.insert(members).values(
-            newMutualUserIds.map((uid) => ({
-              tripId,
-              userId: uid,
-              status: "no_response" as const,
-              isOrganizer: false,
-            })),
+          // Check for already-invited phones among mutuals (dedup)
+          const mutualPhones = mutualUsers.map((u) => u.phoneNumber);
+          const alreadyInvitedMutualRows = await tx
+            .select({ inviteePhone: invitations.inviteePhone })
+            .from(invitations)
+            .where(
+              and(
+                eq(invitations.tripId, tripId),
+                inArray(invitations.inviteePhone, mutualPhones),
+              ),
+            );
+          const alreadyInvitedMutualPhones = new Set(
+            alreadyInvitedMutualRows.map((r) => r.inviteePhone),
           );
+
+          // Find mutuals whose phones are already invited and add their userId to skipped
+          const phonesToSkipUserIds = new Set<string>();
+          for (const u of mutualUsers) {
+            if (alreadyInvitedMutualPhones.has(u.phoneNumber)) {
+              skipped.push(u.id);
+              phonesToSkipUserIds.add(u.id);
+            }
+          }
+
+          // Filter to mutuals whose phones are NOT already invited
+          const eligibleMutualUserIds = newMutualUserIds.filter(
+            (uid) => !phonesToSkipUserIds.has(uid),
+          );
+
+          // Create invitation records for eligible mutuals
+          if (eligibleMutualUserIds.length > 0) {
+            const mutualInviteValues = eligibleMutualUserIds
+              .map((uid) => {
+                const u = mutualUserMap.get(uid);
+                if (!u) return null;
+                return {
+                  tripId,
+                  inviterId: userId,
+                  inviteePhone: u.phoneNumber,
+                  status: "pending" as const,
+                };
+              })
+              .filter(
+                (v): v is NonNullable<typeof v> => v !== null,
+              );
+
+            if (mutualInviteValues.length > 0) {
+              mutualCreatedInvitations = await tx
+                .insert(invitations)
+                .values(mutualInviteValues)
+                .returning();
+            }
+          }
+
+          // Create member records for mutual invitees (all eligible, not just those with invitations)
+          if (eligibleMutualUserIds.length > 0) {
+            await tx.insert(members).values(
+              eligibleMutualUserIds.map((uid) => ({
+                tripId,
+                userId: uid,
+                status: "no_response" as const,
+                isOrganizer: false,
+              })),
+            );
+          }
 
           // Build addedMembers entries for mutual invitees
-          for (const uid of newMutualUserIds) {
+          for (const uid of eligibleMutualUserIds) {
+            const u = mutualUserMap.get(uid);
             addedMembers.push({
               userId: uid,
-              displayName: mutualUserMap.get(uid) ?? "Unknown",
+              displayName: u?.displayName ?? "Unknown",
             });
           }
         }
@@ -496,6 +558,36 @@ export class InvitationService implements IInvitationService {
         );
       }
     }
+
+    // Send invitation SMS for mutual invites via queue or fallback to inline delivery
+    const mutualPhoneToInvitationId = new Map(
+      mutualCreatedInvitations.map((inv) => [inv.inviteePhone, inv.id]),
+    );
+    const mutualPhonesForSms = mutualCreatedInvitations.map(
+      (inv) => inv.inviteePhone,
+    );
+    if (this.boss && mutualPhonesForSms.length > 0) {
+      await this.boss.insert(
+        QUEUE.INVITATION_SEND,
+        mutualPhonesForSms.map((phone) => ({
+          data: {
+            phoneNumber: phone,
+            message: `${safeName} invited you to "${safeTrip}" on Journiful!\n${this.frontendUrl}/invite/${mutualPhoneToInvitationId.get(phone)}`,
+          } as InvitationSendPayload,
+        })),
+      );
+    } else {
+      for (const phone of mutualPhonesForSms) {
+        await this.smsService.sendMessage(
+          phone,
+          `${safeName} invited you to "${safeTrip}" on Journiful!\n${this.frontendUrl}/invite/${mutualPhoneToInvitationId.get(phone)}`,
+          "invite",
+        );
+      }
+    }
+
+    // Merge mutual invitations into createdInvitations for the return value
+    createdInvitations = [...createdInvitations, ...mutualCreatedInvitations];
 
     // Send sms_invite notifications for existing users auto-added via phone
     for (const autoAddedUserId of phoneAutoAddedUserIds) {

--- a/apps/api/tests/integration/invitation.routes.test.ts
+++ b/apps/api/tests/integration/invitation.routes.test.ts
@@ -2465,7 +2465,7 @@ describe("Invitation Routes", () => {
 
       const body = JSON.parse(response.body);
       expect(body).toHaveProperty("success", true);
-      expect(body.invitations).toHaveLength(0); // no phone invitations
+      expect(body.invitations).toHaveLength(1); // mutual invite now creates invitation record
       expect(body.addedMembers).toHaveLength(1);
       expect(body.addedMembers[0].userId).toBe(mutual.id);
       expect(body.addedMembers[0].displayName).toBe("Mutual Friend");
@@ -2640,7 +2640,7 @@ describe("Invitation Routes", () => {
 
       const body = JSON.parse(response.body);
       expect(body).toHaveProperty("success", true);
-      expect(body.invitations).toHaveLength(1); // phone invitation
+      expect(body.invitations).toHaveLength(2); // phone + mutual invitations
       expect(body.addedMembers).toHaveLength(1); // mutual invite
       expect(body.addedMembers[0].userId).toBe(mutual.id);
       expect(body.skipped).toHaveLength(0);

--- a/apps/api/tests/unit/invitation.service.test.ts
+++ b/apps/api/tests/unit/invitation.service.test.ts
@@ -1493,7 +1493,7 @@ describe("invitation.service", () => {
       }
     });
 
-    it("should create member record and send mutual_invite notification for mutual user", async () => {
+    it("should create member record, invitation record, and send mutual_invite notification for mutual user", async () => {
       const result = await invitationService.createInvitations(
         testOrganizerId,
         testTripId,
@@ -1501,8 +1501,12 @@ describe("invitation.service", () => {
         [mutualUserId],
       );
 
-      // No phone-based invitations created
-      expect(result.invitations).toHaveLength(0);
+      // Mutual invite now creates an invitation record
+      expect(result.invitations).toHaveLength(1);
+      expect(result.invitations[0].inviteePhone).toBe(mutualUserPhone);
+      expect(result.invitations[0].status).toBe("pending");
+      expect(result.invitations[0].tripId).toBe(testTripId);
+      expect(result.invitations[0].inviterId).toBe(testOrganizerId);
       expect(result.skipped).toHaveLength(0);
 
       // addedMembers should include the mutual
@@ -1521,6 +1525,19 @@ describe("invitation.service", () => {
       expect(memberRecords[0].status).toBe("no_response");
       expect(memberRecords[0].isOrganizer).toBe(false);
 
+      // Verify invitation record exists in DB with correct inviteePhone
+      const invitationRecords = await db
+        .select()
+        .from(invitations)
+        .where(
+          and(
+            eq(invitations.tripId, testTripId),
+            eq(invitations.inviteePhone, mutualUserPhone),
+          ),
+        );
+      expect(invitationRecords).toHaveLength(1);
+      expect(invitationRecords[0].status).toBe("pending");
+
       // Verify mutual_invite notification was created
       const notificationRecords = await db
         .select()
@@ -1536,6 +1553,84 @@ describe("invitation.service", () => {
       expect(notificationRecords[0].title).toBe("Trip invitation");
       expect(notificationRecords[0].body).toContain("Test Organizer");
       expect(notificationRecords[0].body).toContain("Test Trip");
+    });
+
+    it("should enqueue SMS with deep link for mutual invite", async () => {
+      const mockBoss = {
+        send: vi.fn().mockResolvedValue(undefined),
+        insert: vi.fn().mockResolvedValue(undefined),
+      } as unknown as PgBoss;
+      const serviceWithBoss = new InvitationService(
+        db,
+        permissionsService,
+        smsService,
+        notificationService,
+        undefined,
+        mockBoss,
+      );
+
+      const result = await serviceWithBoss.createInvitations(
+        testOrganizerId,
+        testTripId,
+        [],
+        [mutualUserId],
+      );
+
+      expect(result.invitations).toHaveLength(1);
+
+      // boss.insert should have been called with the mutual's phone and a deep link
+      expect(mockBoss.insert).toHaveBeenCalledWith(
+        QUEUE.INVITATION_SEND,
+        expect.arrayContaining([
+          expect.objectContaining({
+            data: {
+              phoneNumber: mutualUserPhone,
+              message: expect.stringContaining("/invite/"),
+            },
+          }),
+        ]),
+      );
+    });
+
+    it("should skip invitation and SMS for mutual whose phone is already invited", async () => {
+      // Pre-insert an invitation for the mutual's phone on the same trip
+      await db.insert(invitations).values({
+        tripId: testTripId,
+        inviterId: testOrganizerId,
+        inviteePhone: mutualUserPhone,
+        status: "pending",
+      });
+
+      const result = await invitationService.createInvitations(
+        testOrganizerId,
+        testTripId,
+        [],
+        [mutualUserId],
+      );
+
+      // The mutual's userId should appear in skipped
+      expect(result.skipped).toContain(mutualUserId);
+
+      // No new invitation should be created (the pre-existing one is the only one)
+      const invitationRecords = await db
+        .select()
+        .from(invitations)
+        .where(
+          and(
+            eq(invitations.tripId, testTripId),
+            eq(invitations.inviteePhone, mutualUserPhone),
+          ),
+        );
+      expect(invitationRecords).toHaveLength(1);
+
+      // No new member record should be created (skipped users don't get added)
+      const memberRecords = await db
+        .select()
+        .from(members)
+        .where(
+          and(eq(members.tripId, testTripId), eq(members.userId, mutualUserId)),
+        );
+      expect(memberRecords).toHaveLength(0);
     });
 
     it("should send sms_invite notification for existing user auto-added via phone", async () => {
@@ -1580,8 +1675,8 @@ describe("invitation.service", () => {
         [mutualUserId],
       );
 
-      // Phone-based invitation created for the new phone
-      expect(result.invitations).toHaveLength(1);
+      // 2 invitations: 1 phone-based + 1 mutual-based
+      expect(result.invitations).toHaveLength(2);
 
       // Mutual user added via userId
       expect(result.addedMembers).toHaveLength(1);
@@ -1701,8 +1796,8 @@ describe("invitation.service", () => {
         [mutualUserId],
       );
 
-      // Should have 1 phone invitation (for mutualUser2Phone)
-      expect(result.invitations).toHaveLength(1);
+      // Should have 2 invitations (1 phone for mutualUser2Phone + 1 mutual for mutualUserId)
+      expect(result.invitations).toHaveLength(2);
 
       // Should have 2 addedMembers (one mutual, one phone auto-added)
       expect(result.addedMembers).toHaveLength(2);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,14 +103,14 @@ importers:
         specifier: ^0.45.2
         version: 0.45.2(@types/pg@8.20.0)(pg@8.20.0)
       fastify:
-        specifier: ^5.8.4
-        version: 5.8.4
+        specifier: ^5.8.5
+        version: 5.8.5
       fastify-plugin:
         specifier: ^5.1.0
         version: 5.1.0
       fastify-type-provider-zod:
         specifier: ^6.1.0
-        version: 6.1.0(@fastify/swagger@9.7.0)(fastify@5.8.4)(openapi-types@12.1.3)(zod@4.3.6)
+        version: 6.1.0(@fastify/swagger@9.7.0)(fastify@5.8.5)(openapi-types@12.1.3)(zod@4.3.6)
       file-type:
         specifier: ^22.0.1
         version: 22.0.1
@@ -4398,8 +4398,8 @@ packages:
       openapi-types: ^12.1.3
       zod: '>=4.1.5'
 
-  fastify@5.8.4:
-    resolution: {integrity: sha512-sa42J1xylbBAYUWALSBoyXKPDUvM3OoNOibIefA+Oha57FryXKKCZarA1iDntOCWp3O35voZLuDg2mdODXtPzQ==}
+  fastify@5.8.5:
+    resolution: {integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==}
 
   fastparallel@2.4.1:
     resolution: {integrity: sha512-qUmhxPgNHmvRjZKBFUNI0oZuuH9OlSIOXmJ98lhKPxMZZ7zS/Fi0wRHOihDSz0R1YiIOjxzOY4bq65YTcdBi2Q==}
@@ -11011,15 +11011,15 @@ snapshots:
 
   fastify-plugin@5.1.0: {}
 
-  fastify-type-provider-zod@6.1.0(@fastify/swagger@9.7.0)(fastify@5.8.4)(openapi-types@12.1.3)(zod@4.3.6):
+  fastify-type-provider-zod@6.1.0(@fastify/swagger@9.7.0)(fastify@5.8.5)(openapi-types@12.1.3)(zod@4.3.6):
     dependencies:
       '@fastify/error': 4.2.0
       '@fastify/swagger': 9.7.0
-      fastify: 5.8.4
+      fastify: 5.8.5
       openapi-types: 12.1.3
       zod: 4.3.6
 
-  fastify@5.8.4:
+  fastify@5.8.5:
     dependencies:
       '@fastify/ajv-compiler': 4.0.5
       '@fastify/error': 4.2.0


### PR DESCRIPTION
## Summary
- Mutual (userId-based) invites now create invitation records and send SMS with deep links, matching the existing phone-number invite flow
- Existing push notifications (`mutual_invite`) are kept alongside SMS (belt and suspenders)
- Added dedup logic: if a mutual's phone is already invited to the trip, they're skipped

## Changes
- `apps/api/src/services/invitation.service.ts` — extended mutual invite section to create invitation records, look up phone numbers, dedup against existing invitations, and enqueue SMS via pg-boss
- `apps/api/tests/unit/invitation.service.test.ts` — updated assertions for new invitation records, added tests for SMS enqueueing and dedup behavior

## Test plan
- [ ] Verify mutual invite creates invitation record with correct `inviteePhone`
- [ ] Verify SMS is enqueued via pg-boss with deep link `/invite/:id`
- [ ] Verify dedup: mutual whose phone is already invited is skipped (no duplicate invitation or member)
- [ ] Verify existing phone-number invite flow is unaffected
- [ ] Verify push notification still sent alongside SMS
- [ ] Run full test suite in devcontainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)