### PR TITLE
Auto-populate trip timezone from geocoded destination (#73)

### DIFF
--- a/apps/api/src/services/geocoding.service.ts
+++ b/apps/api/src/services/geocoding.service.ts
@@ -81,12 +81,16 @@ export class NominatimGeocodingService implements IGeocodingService {
 
     try {
       const url = `${OPEN_METEO_GEOCODING_API}?name=${encodeURIComponent(query.trim())}&count=1`;
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 3000);
       const response = await fetch(url, {
         headers: {
           "User-Agent":
             "journiful-app (https://github.com/chris-hendrix/tripful)",
         },
+        signal: controller.signal,
       });
+      clearTimeout(timeout);
 
       if (!response.ok) return null;
 

--- a/apps/api/src/services/geocoding.service.ts
+++ b/apps/api/src/services/geocoding.service.ts
@@ -17,9 +17,17 @@ export interface IGeocodingService {
    * @returns Geocoding result or null if not found / on error
    */
   geocode(query: string): Promise<GeocodingResult | null>;
+
+  /**
+   * Looks up the IANA timezone for a location query string
+   * @param query - The location name to look up (e.g. "Paris, France")
+   * @returns IANA timezone string (e.g. "Europe/Paris") or null if not found / on error
+   */
+  getTimezone(query: string): Promise<string | null>;
 }
 
 const NOMINATIM_API_BASE = "https://nominatim.openstreetmap.org/search";
+const OPEN_METEO_GEOCODING_API = "https://geocoding-api.open-meteo.com/v1/search";
 
 /**
  * Nominatim (OpenStreetMap) Geocoding Service Implementation
@@ -62,6 +70,33 @@ export class NominatimGeocodingService implements IGeocodingService {
       };
     } catch (err) {
       this.logger?.error(err, "Geocoding failed");
+      return null;
+    }
+  }
+
+  async getTimezone(query: string): Promise<string | null> {
+    if (!query?.trim()) return null;
+
+    this.logger?.info({ query }, "Timezone lookup query");
+
+    try {
+      const url = `${OPEN_METEO_GEOCODING_API}?name=${encodeURIComponent(query.trim())}&count=1`;
+      const response = await fetch(url, {
+        headers: {
+          "User-Agent":
+            "journiful-app (https://github.com/chris-hendrix/tripful)",
+        },
+      });
+
+      if (!response.ok) return null;
+
+      const data = (await response.json()) as {
+        results?: Array<{ timezone: string }>;
+      };
+
+      return data.results?.[0]?.timezone ?? null;
+    } catch (err) {
+      this.logger?.error(err, "Timezone lookup failed");
       return null;
     }
   }

--- a/apps/api/src/services/trip.service.ts
+++ b/apps/api/src/services/trip.service.ts
@@ -173,7 +173,7 @@ export interface ITripService {
     tripId: string,
     userId: string,
     data: UpdateTripInput,
-  ): Promise<Trip>;
+  ): Promise<Trip & { timezoneAutoUpdated?: boolean }>;
 
   /**
    * Cancels a trip (soft delete)
@@ -292,21 +292,22 @@ export class TripService implements ITripService {
       coOrganizerUserIds = coOrganizerUsers.map((u) => u.id);
     }
 
-    // Geocode destination if provided (best-effort, failure does not block creation)
+    // Geocode destination and look up timezone if provided (best-effort, failure does not block creation)
     let destinationLat: number | null = null;
     let destinationLon: number | null = null;
     let destinationDisplayName: string | null = null;
+    let geocodedTimezone: string | null = null;
     if (data.destination) {
-      try {
-        const coords = await this.geocodingService.geocode(data.destination);
-        if (coords) {
-          destinationLat = coords.lat;
-          destinationLon = coords.lon;
-          destinationDisplayName = coords.displayName;
-        }
-      } catch {
-        // Geocoding failure is non-blocking
+      const [coords, tz] = await Promise.all([
+        this.geocodingService.geocode(data.destination).catch(() => null),
+        this.geocodingService.getTimezone(data.destination).catch(() => null),
+      ]);
+      if (coords) {
+        destinationLat = coords.lat;
+        destinationLon = coords.lon;
+        destinationDisplayName = coords.displayName;
       }
+      geocodedTimezone = tz;
     }
 
     // Wrap all inserts in a transaction for atomicity
@@ -322,7 +323,7 @@ export class TripService implements ITripService {
           destinationDisplayName,
           startDate: data.startDate || null,
           endDate: data.endDate || null,
-          preferredTimezone: data.timezone,
+          preferredTimezone: geocodedTimezone ?? data.timezone,
           description: data.description || null,
           coverImageUrl:
             data.coverImageUrl === null ? null : data.coverImageUrl || null,
@@ -741,8 +742,10 @@ export class TripService implements ITripService {
       delete updateData.timezone;
     }
 
-    // If destination changed, geocode and update coordinates + delete weather cache
+    // If destination changed, geocode and update coordinates + look up timezone + delete weather cache
     // Only re-geocode if the destination value actually differs from the current one
+    let destinationChanged = false;
+    let geocodedTimezone: string | null = null;
     if (data.destination !== undefined) {
       // Fetch current trip to compare destination
       const [currentTrip] = await this.db
@@ -752,22 +755,28 @@ export class TripService implements ITripService {
         .limit(1);
 
       if (data.destination !== currentTrip?.destination) {
+        destinationChanged = true;
         let newLat: number | null = null;
         let newLon: number | null = null;
         let newDisplayName: string | null = null;
-        try {
-          const coords = await this.geocodingService.geocode(data.destination);
-          if (coords) {
-            newLat = coords.lat;
-            newLon = coords.lon;
-            newDisplayName = coords.displayName;
-          }
-        } catch {
-          // Geocoding failure is non-blocking
+        const [coords, tz] = await Promise.all([
+          this.geocodingService.geocode(data.destination).catch(() => null),
+          this.geocodingService.getTimezone(data.destination).catch(() => null),
+        ]);
+        if (coords) {
+          newLat = coords.lat;
+          newLon = coords.lon;
+          newDisplayName = coords.displayName;
         }
+        geocodedTimezone = tz;
         updateData.destinationLat = newLat;
         updateData.destinationLon = newLon;
         updateData.destinationDisplayName = newDisplayName;
+
+        // Auto-update timezone if geocoding returned one
+        if (geocodedTimezone) {
+          updateData.preferredTimezone = geocodedTimezone;
+        }
 
         // Delete weather cache when destination changes (regardless of geocoding result)
         await this.db
@@ -792,7 +801,11 @@ export class TripService implements ITripService {
       throw new TripNotFoundError();
     }
 
-    return result[0];
+    const updatedTrip: Trip & { timezoneAutoUpdated?: boolean } = {
+      ...result[0],
+      timezoneAutoUpdated: destinationChanged && !!geocodedTimezone,
+    };
+    return updatedTrip;
   }
 
   /**

--- a/apps/api/tests/integration/trip.routes.test.ts
+++ b/apps/api/tests/integration/trip.routes.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 import type { FastifyInstance } from "fastify";
 import { buildApp } from "../helpers.js";
 import { db } from "@/config/database.js";
@@ -2643,6 +2643,283 @@ describe("PUT /api/trips/:id", () => {
       expect(body.success).toBe(false);
       expect(body.error.code).toBe("NOT_FOUND");
       expect(body.error.message).toBe("Trip not found");
+    });
+  });
+});
+
+describe("Timezone auto-population", () => {
+  let app: FastifyInstance;
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (app) {
+      await app.close();
+    }
+  });
+
+  describe("POST /api/trips - timezone from geocoding", () => {
+    it("should use geocoded timezone instead of user-provided browser timezone", async () => {
+      app = await buildApp();
+
+      // Mock geocoding service
+      vi.spyOn(app.geocodingService, "geocode").mockResolvedValueOnce({
+        lat: 48.8566,
+        lon: 2.3522,
+        displayName: "Paris, Île-de-France, France",
+      });
+      vi.spyOn(app.geocodingService, "getTimezone").mockResolvedValueOnce(
+        "Europe/Paris",
+      );
+
+      const [testUser] = await db
+        .insert(users)
+        .values({
+          phoneNumber: generateUniquePhone(),
+          displayName: "Timezone Test User",
+          timezone: "America/New_York",
+        })
+        .returning();
+
+      const token = app.jwt.sign({
+        sub: testUser.id,
+        name: testUser.displayName,
+      });
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/trips",
+        cookies: { auth_token: token },
+        payload: {
+          name: "Paris Trip",
+          destination: "Paris, France",
+          timezone: "America/New_York", // browser default, should be overridden
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+      const body = JSON.parse(response.body);
+      expect(body.trip.preferredTimezone).toBe("Europe/Paris");
+    });
+
+    it("should fall back to user-provided timezone when timezone lookup fails", async () => {
+      app = await buildApp();
+
+      // Mock geocoding service - geocode succeeds, getTimezone fails
+      vi.spyOn(app.geocodingService, "geocode").mockResolvedValueOnce({
+        lat: 48.8566,
+        lon: 2.3522,
+        displayName: "Paris, Île-de-France, France",
+      });
+      vi.spyOn(app.geocodingService, "getTimezone").mockRejectedValueOnce(
+        new Error("API error"),
+      );
+
+      const [testUser] = await db
+        .insert(users)
+        .values({
+          phoneNumber: generateUniquePhone(),
+          displayName: "Timezone Fallback User",
+          timezone: "America/New_York",
+        })
+        .returning();
+
+      const token = app.jwt.sign({
+        sub: testUser.id,
+        name: testUser.displayName,
+      });
+
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/trips",
+        cookies: { auth_token: token },
+        payload: {
+          name: "Fallback Trip",
+          destination: "Paris, France",
+          timezone: "America/New_York",
+        },
+      });
+
+      expect(response.statusCode).toBe(201);
+      const body = JSON.parse(response.body);
+      expect(body.trip.preferredTimezone).toBe("America/New_York");
+    });
+  });
+
+  describe("PUT /api/trips/:id - timezone auto-update on destination change", () => {
+    it("should auto-update timezone when destination changes and geocoding succeeds", async () => {
+      app = await buildApp();
+
+      const [testUser] = await db
+        .insert(users)
+        .values({
+          phoneNumber: generateUniquePhone(),
+          displayName: "Update TZ User",
+          timezone: "America/New_York",
+        })
+        .returning();
+
+      const [trip] = await db
+        .insert(trips)
+        .values({
+          name: "Original Trip",
+          destination: "New York, USA",
+          preferredTimezone: "America/New_York",
+          createdBy: testUser.id,
+        })
+        .returning();
+
+      await db.insert(members).values({
+        userId: testUser.id,
+        tripId: trip.id,
+        status: "going",
+        isOrganizer: true,
+      });
+
+      // Mock geocoding for destination change
+      vi.spyOn(app.geocodingService, "geocode").mockResolvedValueOnce({
+        lat: 35.6762,
+        lon: 139.6503,
+        displayName: "Tokyo, Japan",
+      });
+      vi.spyOn(app.geocodingService, "getTimezone").mockResolvedValueOnce(
+        "Asia/Tokyo",
+      );
+
+      const token = app.jwt.sign({
+        sub: testUser.id,
+        name: testUser.displayName,
+      });
+
+      const response = await app.inject({
+        method: "PUT",
+        url: `/api/trips/${trip.id}`,
+        cookies: { auth_token: token },
+        payload: {
+          destination: "Tokyo, Japan",
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.trip.preferredTimezone).toBe("Asia/Tokyo");
+      expect(body.trip.timezoneAutoUpdated).toBe(true);
+    });
+
+    it("should not change timezone when destination is unchanged", async () => {
+      app = await buildApp();
+
+      const [testUser] = await db
+        .insert(users)
+        .values({
+          phoneNumber: generateUniquePhone(),
+          displayName: "No Change User",
+          timezone: "America/New_York",
+        })
+        .returning();
+
+      const [trip] = await db
+        .insert(trips)
+        .values({
+          name: "Same Dest Trip",
+          destination: "Paris, France",
+          preferredTimezone: "Europe/Paris",
+          createdBy: testUser.id,
+        })
+        .returning();
+
+      await db.insert(members).values({
+        userId: testUser.id,
+        tripId: trip.id,
+        status: "going",
+        isOrganizer: true,
+      });
+
+      const token = app.jwt.sign({
+        sub: testUser.id,
+        name: testUser.displayName,
+      });
+
+      // Spy on geocoding to ensure it's NOT called
+      const geocodeSpy = vi.spyOn(app.geocodingService, "geocode");
+      const getTimezoneSpy = vi.spyOn(app.geocodingService, "getTimezone");
+
+      const response = await app.inject({
+        method: "PUT",
+        url: `/api/trips/${trip.id}`,
+        cookies: { auth_token: token },
+        payload: {
+          destination: "Paris, France", // same as current
+          name: "Renamed Trip",
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      expect(body.trip.preferredTimezone).toBe("Europe/Paris");
+      expect(body.trip.timezoneAutoUpdated).toBe(false);
+      expect(geocodeSpy).not.toHaveBeenCalled();
+      expect(getTimezoneSpy).not.toHaveBeenCalled();
+    });
+
+    it("should keep existing timezone when destination changes but timezone lookup fails", async () => {
+      app = await buildApp();
+
+      const [testUser] = await db
+        .insert(users)
+        .values({
+          phoneNumber: generateUniquePhone(),
+          displayName: "TZ Fail User",
+          timezone: "America/New_York",
+        })
+        .returning();
+
+      const [trip] = await db
+        .insert(trips)
+        .values({
+          name: "Fail TZ Trip",
+          destination: "New York, USA",
+          preferredTimezone: "America/New_York",
+          createdBy: testUser.id,
+        })
+        .returning();
+
+      await db.insert(members).values({
+        userId: testUser.id,
+        tripId: trip.id,
+        status: "going",
+        isOrganizer: true,
+      });
+
+      // Mock geocoding - geocode works but getTimezone fails
+      vi.spyOn(app.geocodingService, "geocode").mockResolvedValueOnce({
+        lat: 35.6762,
+        lon: 139.6503,
+        displayName: "Tokyo, Japan",
+      });
+      vi.spyOn(app.geocodingService, "getTimezone").mockRejectedValueOnce(
+        new Error("Timezone API error"),
+      );
+
+      const token = app.jwt.sign({
+        sub: testUser.id,
+        name: testUser.displayName,
+      });
+
+      const response = await app.inject({
+        method: "PUT",
+        url: `/api/trips/${trip.id}`,
+        cookies: { auth_token: token },
+        payload: {
+          destination: "Tokyo, Japan",
+          timezone: "America/Chicago", // user-provided timezone in update
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const body = JSON.parse(response.body);
+      // Should use the user-provided timezone from the update payload, not the geocoded one
+      expect(body.trip.preferredTimezone).toBe("America/Chicago");
+      expect(body.trip.timezoneAutoUpdated).toBe(false);
     });
   });
 });

--- a/apps/api/tests/unit/geocoding.service.test.ts
+++ b/apps/api/tests/unit/geocoding.service.test.ts
@@ -145,4 +145,115 @@ describe("NominatimGeocodingService", () => {
       expect(typeof result!.lon).toBe("number");
     });
   });
+
+  describe("getTimezone", () => {
+    it("should return IANA timezone string for a valid query", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            results: [{ timezone: "Europe/Paris" }],
+          }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await service.getTimezone("Paris, France");
+      expect(result).toBe("Europe/Paris");
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("geocoding-api.open-meteo.com"),
+        expect.objectContaining({
+          headers: {
+            "User-Agent":
+              "journiful-app (https://github.com/chris-hendrix/tripful)",
+          },
+        }),
+      );
+    });
+
+    it("should return null when results array is empty", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ results: [] }),
+        }),
+      );
+
+      const result = await service.getTimezone("xyznonexistent");
+      expect(result).toBeNull();
+    });
+
+    it("should return null when response has no results key", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({}),
+        }),
+      );
+
+      const result = await service.getTimezone("somewhere");
+      expect(result).toBeNull();
+    });
+
+    it("should return null on network error and log the error", async () => {
+      const networkError = new Error("Network error");
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(networkError));
+
+      const result = await service.getTimezone("Tokyo");
+      expect(result).toBeNull();
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        networkError,
+        "Timezone lookup failed",
+      );
+    });
+
+    it("should return null for empty query", async () => {
+      const mockFetch = vi.fn();
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await service.getTimezone("");
+      expect(result).toBeNull();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("should return null for whitespace-only query", async () => {
+      const mockFetch = vi.fn();
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await service.getTimezone("   ");
+      expect(result).toBeNull();
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("should return null on non-OK response", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 500,
+        }),
+      );
+
+      const result = await service.getTimezone("London");
+      expect(result).toBeNull();
+    });
+
+    it("should encode query parameter properly", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            results: [{ timezone: "America/Costa_Rica" }],
+          }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await service.getTimezone("San José, Costa Rica");
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("San%20Jos%C3%A9%2C%20Costa%20Rica"),
+        expect.anything(),
+      );
+    });
+  });
 });

--- a/apps/api/tests/unit/trip.service.test.ts
+++ b/apps/api/tests/unit/trip.service.test.ts
@@ -18,6 +18,7 @@ import type { CreateTripInput } from "@journiful/shared/schemas";
 // Create mock geocoding service
 const mockGeocodingService: IGeocodingService = {
   geocode: vi.fn().mockResolvedValue({ lat: 32.7157, lon: -117.1611 }),
+  getTimezone: vi.fn().mockResolvedValue("America/Los_Angeles"),
 };
 
 // Create service instances with db for testing

--- a/apps/api/tests/unit/trip.service.test.ts
+++ b/apps/api/tests/unit/trip.service.test.ts
@@ -18,7 +18,7 @@ import type { CreateTripInput } from "@journiful/shared/schemas";
 // Create mock geocoding service
 const mockGeocodingService: IGeocodingService = {
   geocode: vi.fn().mockResolvedValue({ lat: 32.7157, lon: -117.1611 }),
-  getTimezone: vi.fn().mockResolvedValue("America/Los_Angeles"),
+  getTimezone: vi.fn().mockResolvedValue(null),
 };
 
 // Create service instances with db for testing

--- a/apps/web/src/hooks/__tests__/use-trips.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-trips.test.tsx
@@ -10,13 +10,14 @@ import {
   useTrips,
   useTripDetail,
   useCreateTrip,
+  useUpdateTrip,
   getCreateTripErrorMessage,
   type Trip,
   type TripSummary,
   type TripDetail,
 } from "../use-trips";
 import { APIError } from "@/lib/api";
-import type { CreateTripInput } from "@journiful/shared/schemas";
+import type { CreateTripInput, UpdateTripInput } from "@journiful/shared/schemas";
 import type { GetTripsResponse } from "@journiful/shared/types";
 
 // Mock the API module
@@ -39,6 +40,16 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({
     push: mockPush,
   }),
+}));
+
+// Mock sonner toast
+const mockToast = vi.hoisted(() => ({
+  info: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+}));
+vi.mock("sonner", () => ({
+  toast: mockToast,
 }));
 
 describe("useTrips", () => {
@@ -1004,6 +1015,105 @@ describe("useTripDetail", () => {
       // Verify API was called twice
       expect(apiRequest).toHaveBeenCalledTimes(2);
     });
+  });
+});
+
+describe("useUpdateTrip", () => {
+  let queryClient: QueryClient;
+  let wrapper: ({ children }: { children: ReactNode }) => JSX.Element;
+
+  const existingTrip: Trip = {
+    id: "trip-123",
+    name: "Beach Getaway",
+    destination: "Cancun, Mexico",
+    destinationLat: null,
+    destinationLon: null,
+    startDate: "2026-06-01",
+    endDate: "2026-06-05",
+    preferredTimezone: "America/New_York",
+    description: "Fun trip",
+    coverImageUrl: null,
+    themeId: null,
+    themeFont: null,
+    createdBy: "user-123",
+    allowMembersToAddEvents: true,
+    showAllMembers: false,
+    cancelled: false,
+    createdAt: new Date("2026-02-06T12:00:00Z"),
+    updatedAt: new Date("2026-02-06T12:00:00Z"),
+  };
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+
+    wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    vi.clearAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    queryClient.clear();
+    await new Promise((r) => setTimeout(r, 0));
+  });
+
+  it("shows toast when timezoneAutoUpdated is true", async () => {
+    const { apiRequest } = await import("@/lib/api");
+    vi.mocked(apiRequest).mockResolvedValueOnce({
+      success: true,
+      trip: {
+        ...existingTrip,
+        destination: "Tokyo, Japan",
+        preferredTimezone: "Asia/Tokyo",
+        timezoneAutoUpdated: true,
+      },
+    });
+
+    const { result } = renderHook(() => useUpdateTrip(), { wrapper });
+
+    result.current.mutate({
+      tripId: "trip-123",
+      data: { destination: "Tokyo, Japan" } as UpdateTripInput,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockToast.info).toHaveBeenCalledWith(
+      "Timezone updated to Japan Standard Time (JST)",
+    );
+  });
+
+  it("does not show toast when timezoneAutoUpdated is not set", async () => {
+    const { apiRequest } = await import("@/lib/api");
+    vi.mocked(apiRequest).mockResolvedValueOnce({
+      success: true,
+      trip: {
+        ...existingTrip,
+        name: "Updated Name",
+      },
+    });
+
+    const { result } = renderHook(() => useUpdateTrip(), { wrapper });
+
+    result.current.mutate({
+      tripId: "trip-123",
+      data: { name: "Updated Name" } as UpdateTripInput,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockToast.info).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/hooks/use-trips.ts
+++ b/apps/web/src/hooks/use-trips.ts
@@ -9,7 +9,9 @@ import {
 } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import { apiRequest, APIError } from "@/lib/api";
+import { getTimezoneLabel } from "@/lib/constants";
 import type { CreateTripInput, UpdateTripInput } from "@journiful/shared/schemas";
 import type {
   Trip,
@@ -378,6 +380,14 @@ export function useUpdateTrip() {
 
       // Return context with previous data for rollback
       return { previousTrips, previousTrip };
+    },
+
+    // On success: Notify user if timezone was auto-updated
+    onSuccess: (updatedTrip) => {
+      if (updatedTrip.timezoneAutoUpdated) {
+        const label = getTimezoneLabel(updatedTrip.preferredTimezone);
+        toast.info(`Timezone updated to ${label}`);
+      }
     },
 
     // On error: Rollback optimistic update

--- a/shared/schemas/trip.ts
+++ b/shared/schemas/trip.ts
@@ -172,6 +172,7 @@ const tripEntitySchema = z.object({
   cancelled: z.boolean(),
   createdAt: z.date(),
   updatedAt: z.date(),
+  timezoneAutoUpdated: z.boolean().optional(),
 });
 
 /** Organizer info in trip summary */

--- a/shared/types/trip.ts
+++ b/shared/types/trip.ts
@@ -41,6 +41,8 @@ export interface Trip {
   createdAt: Date;
   /** Last update timestamp */
   updatedAt: Date;
+  /** Transient flag indicating timezone was auto-updated from destination geocoding */
+  timezoneAutoUpdated?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `getTimezone()` method to geocoding service that calls Open-Meteo's geocoding API to resolve IANA timezone strings from destination names
- Auto-populate `preferredTimezone` on trip create (overrides browser default) and update (when destination changes)
- Show toast notification on frontend when timezone is auto-updated after destination change
- Graceful fallback: if timezone lookup fails, keeps user-provided timezone

Closes #73

## Test plan

- [x] Unit tests for `getTimezone()` (8 tests: success, empty results, network error, edge cases)
- [x] Integration tests for trip create/update timezone auto-population (5 tests)
- [x] Frontend hook tests for toast notification behavior (2 tests)
- [ ] Manual: create trip with destination → verify timezone matches destination, not browser
- [ ] Manual: edit trip destination → verify toast appears with new timezone

🤖 Generated with [Claude Code](https://claude.com/claude-code)