### PR TITLE
Enhanced weather detail sheet with hourly forecasts (#115)

### DIFF
--- a/apps/api/src/services/weather.service.ts
+++ b/apps/api/src/services/weather.service.ts
@@ -2,7 +2,11 @@ import { eq, gt, and } from "drizzle-orm";
 import { trips, weatherCache } from "@/db/schema/index.js";
 import type { AppDatabase } from "@/types/index.js";
 import type { ITripService } from "@/services/trip.service.js";
-import type { TripWeatherResponse, DailyForecast } from "@journiful/shared/types";
+import type {
+  TripWeatherResponse,
+  DailyForecastExtended,
+  HourlyForecast,
+} from "@journiful/shared/types";
 
 const FORECAST_API_BASE = "https://api.open-meteo.com/v1/forecast";
 const CACHE_MAX_AGE_MS = 3 * 60 * 60 * 1000; // 3 hours
@@ -22,6 +26,24 @@ interface OpenMeteoDaily {
   temperature_2m_max: number[];
   temperature_2m_min: number[];
   precipitation_probability_max: number[];
+  sunrise: string[];
+  sunset: string[];
+  wind_speed_10m_max: number[];
+  wind_direction_10m_dominant: number[];
+  uv_index_max: number[];
+  apparent_temperature_max: number[];
+  apparent_temperature_min: number[];
+}
+
+interface OpenMeteoHourly {
+  time: string[];
+  temperature_2m: number[];
+  weather_code: number[];
+  wind_speed_10m: number[];
+  relative_humidity_2m: number[];
+  uv_index: number[];
+  dew_point_2m: number[];
+  precipitation_probability: number[];
 }
 
 /**
@@ -49,7 +71,7 @@ export class WeatherService implements IWeatherService {
       .limit(1);
 
     if (!trip) {
-      return { available: false, forecasts: [], fetchedAt: null };
+      return { available: false, forecasts: [], hourly: [], fetchedAt: null };
     }
 
     // 2. Check coordinates
@@ -58,6 +80,7 @@ export class WeatherService implements IWeatherService {
         available: false,
         message: "Set a destination to see weather",
         forecasts: [],
+        hourly: [],
         fetchedAt: null,
       };
     }
@@ -70,6 +93,7 @@ export class WeatherService implements IWeatherService {
         available: false,
         message: "Set trip dates to see weather",
         forecasts: [],
+        hourly: [],
         fetchedAt: null,
       };
     }
@@ -81,7 +105,7 @@ export class WeatherService implements IWeatherService {
       const endStr =
         end instanceof Date ? end.toISOString().slice(0, 10) : String(end);
       if (endStr < todayStr) {
-        return { available: false, forecasts: [], fetchedAt: null };
+        return { available: false, forecasts: [], hourly: [], fetchedAt: null };
       }
     }
 
@@ -96,6 +120,7 @@ export class WeatherService implements IWeatherService {
         available: false,
         message: "Weather forecast available within 16 days of your trip",
         forecasts: [],
+        hourly: [],
         fetchedAt: null,
       };
     }
@@ -113,21 +138,28 @@ export class WeatherService implements IWeatherService {
 
     if (cachedRows.length > 0) {
       const cached = cachedRows[0]!;
-      const forecasts = this.parseForecasts(cached.response);
-      return {
-        available: true,
-        ...(trip.destinationDisplayName
-          ? { location: trip.destinationDisplayName }
-          : {}),
-        forecasts: this.filterToDateRange(forecasts, start, end),
-        fetchedAt: cached.fetchedAt.toISOString(),
-      };
+      // TODO: Remove after 2026-05-15 — all cache entries will have hourly data by then
+      const hasHourly = !!(cached.response as { hourly?: unknown })?.hourly;
+      if (hasHourly) {
+        const forecasts = this.parseForecasts(cached.response);
+        const hourly = this.parseHourlyForecasts(cached.response);
+        return {
+          available: true,
+          ...(trip.destinationDisplayName
+            ? { location: trip.destinationDisplayName }
+            : {}),
+          forecasts: this.filterToDateRange(forecasts, start, end),
+          hourly: this.filterHourlyToDateRange(hourly, start, end),
+          fetchedAt: cached.fetchedAt.toISOString(),
+        };
+      }
+      // Old cache format without hourly — fall through to re-fetch
     }
 
     // 7. Fetch from Open-Meteo
     let rawResponse: unknown;
     try {
-      const url = `${FORECAST_API_BASE}?latitude=${trip.destinationLat}&longitude=${trip.destinationLon}&daily=weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max&timezone=${encodeURIComponent(trip.preferredTimezone)}&forecast_days=${MAX_FORECAST_DAYS}`;
+      const url = `${FORECAST_API_BASE}?latitude=${trip.destinationLat}&longitude=${trip.destinationLon}&daily=weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max,sunrise,sunset,wind_speed_10m_max,wind_direction_10m_dominant,uv_index_max,apparent_temperature_max,apparent_temperature_min&hourly=temperature_2m,weather_code,wind_speed_10m,relative_humidity_2m,uv_index,dew_point_2m,precipitation_probability&timezone=${encodeURIComponent(trip.preferredTimezone)}&forecast_days=${MAX_FORECAST_DAYS}`;
       const response = await fetch(url);
 
       if (!response.ok) {
@@ -135,6 +167,7 @@ export class WeatherService implements IWeatherService {
           available: false,
           message: "Weather temporarily unavailable",
           forecasts: [],
+          hourly: [],
           fetchedAt: null,
         };
       }
@@ -145,6 +178,7 @@ export class WeatherService implements IWeatherService {
         available: false,
         message: "Weather temporarily unavailable",
         forecasts: [],
+        hourly: [],
         fetchedAt: null,
       };
     }
@@ -165,6 +199,7 @@ export class WeatherService implements IWeatherService {
 
     // 9. Parse and filter forecasts
     const forecasts = this.parseForecasts(rawResponse);
+    const hourly = this.parseHourlyForecasts(rawResponse);
 
     return {
       available: true,
@@ -172,14 +207,15 @@ export class WeatherService implements IWeatherService {
         ? { location: trip.destinationDisplayName }
         : {}),
       forecasts: this.filterToDateRange(forecasts, start, end),
+      hourly: this.filterHourlyToDateRange(hourly, start, end),
       fetchedAt: now.toISOString(),
     };
   }
 
   /**
-   * Parse Open-Meteo parallel arrays into DailyForecast objects
+   * Parse Open-Meteo daily parallel arrays into DailyForecastExtended objects
    */
-  private parseForecasts(rawResponse: unknown): DailyForecast[] {
+  private parseForecasts(rawResponse: unknown): DailyForecastExtended[] {
     const data = rawResponse as { daily?: OpenMeteoDaily };
     const daily = data?.daily;
     if (!daily?.time) {
@@ -192,6 +228,35 @@ export class WeatherService implements IWeatherService {
       temperatureMax: daily.temperature_2m_max[i] ?? 0,
       temperatureMin: daily.temperature_2m_min[i] ?? 0,
       precipitationProbability: daily.precipitation_probability_max[i] ?? 0,
+      sunrise: (daily.sunrise?.[i] ?? "").slice(11, 16),
+      sunset: (daily.sunset?.[i] ?? "").slice(11, 16),
+      windSpeedMax: daily.wind_speed_10m_max?.[i] ?? 0,
+      windDirectionDominant: daily.wind_direction_10m_dominant?.[i] ?? 0,
+      uvIndexMax: daily.uv_index_max?.[i] ?? 0,
+      apparentTemperatureMax: daily.apparent_temperature_max?.[i] ?? 0,
+      apparentTemperatureMin: daily.apparent_temperature_min?.[i] ?? 0,
+    }));
+  }
+
+  /**
+   * Parse Open-Meteo hourly parallel arrays into HourlyForecast objects
+   */
+  private parseHourlyForecasts(rawResponse: unknown): HourlyForecast[] {
+    const data = rawResponse as { hourly?: OpenMeteoHourly };
+    const hourly = data?.hourly;
+    if (!hourly?.time) {
+      return [];
+    }
+
+    return hourly.time.map((time, i) => ({
+      time,
+      temperature: hourly.temperature_2m[i] ?? 0,
+      weatherCode: hourly.weather_code[i] ?? 0,
+      windSpeed: hourly.wind_speed_10m[i] ?? 0,
+      humidity: hourly.relative_humidity_2m[i] ?? 0,
+      uvIndex: hourly.uv_index[i] ?? 0,
+      dewPoint: hourly.dew_point_2m[i] ?? 0,
+      precipitationProbability: hourly.precipitation_probability[i] ?? 0,
     }));
   }
 
@@ -199,16 +264,35 @@ export class WeatherService implements IWeatherService {
    * Filter forecasts to dates within the trip's date range
    */
   private filterToDateRange(
-    forecasts: DailyForecast[],
+    forecasts: DailyForecastExtended[],
     start: Date | null,
     end: Date | null,
-  ): DailyForecast[] {
+  ): DailyForecastExtended[] {
     const startStr = start ? start.toISOString().slice(0, 10) : null;
     const endStr = end ? end.toISOString().slice(0, 10) : null;
 
     return forecasts.filter((f) => {
       if (startStr && f.date < startStr) return false;
       if (endStr && f.date > endStr) return false;
+      return true;
+    });
+  }
+
+  /**
+   * Filter hourly entries to the trip's date range
+   */
+  private filterHourlyToDateRange(
+    hourly: HourlyForecast[],
+    start: Date | null,
+    end: Date | null,
+  ): HourlyForecast[] {
+    const startStr = start ? start.toISOString().slice(0, 10) : null;
+    const endStr = end ? end.toISOString().slice(0, 10) : null;
+
+    return hourly.filter((h) => {
+      const dateStr = h.time.slice(0, 10);
+      if (startStr && dateStr < startStr) return false;
+      if (endStr && dateStr > endStr) return false;
       return true;
     });
   }

--- a/apps/api/tests/unit/weather.service.test.ts
+++ b/apps/api/tests/unit/weather.service.test.ts
@@ -444,4 +444,256 @@ describe("WeatherService", () => {
       precipitationProbability: 5,
     });
   });
+
+  it("should return hourly: [] when API response has no hourly key", async () => {
+    mockTripService.getEffectiveDateRange.mockResolvedValue({
+      start: new Date("2026-01-01"),
+      end: new Date("2026-12-31"),
+    });
+
+    // Response without hourly data (simulates old Open-Meteo format)
+    const noHourlyResponse = {
+      daily: {
+        time: ["2026-03-10"],
+        weather_code: [3],
+        temperature_2m_max: [25.5],
+        temperature_2m_min: [15.0],
+        precipitation_probability_max: [5],
+        sunrise: ["2026-03-10T06:45"],
+        sunset: ["2026-03-10T18:30"],
+        wind_speed_10m_max: [12.0],
+        wind_direction_10m_dominant: [180],
+        uv_index_max: [4.5],
+        apparent_temperature_max: [27.0],
+        apparent_temperature_min: [13.0],
+      },
+    };
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(noHourlyResponse),
+      }),
+    );
+
+    const result = await service.getForecast(testTripId);
+
+    expect(result.available).toBe(true);
+    expect(result.forecasts).toHaveLength(1);
+    expect(result.hourly).toEqual([]);
+  });
+
+  it("should re-fetch when cached response lacks hourly key (cache compat guard)", async () => {
+    const start = new Date();
+    start.setDate(start.getDate() + 1);
+    const end = new Date();
+    end.setDate(end.getDate() + 3);
+    mockTripService.getEffectiveDateRange.mockResolvedValue({ start, end });
+
+    // Insert fresh cache WITHOUT hourly key (old cache format)
+    const oldCacheResponse = {
+      daily: {
+        time: [futureDateStr(1), futureDateStr(2), futureDateStr(3)],
+        weather_code: [0, 1, 61],
+        temperature_2m_max: [22.5, 21.0, 18.3],
+        temperature_2m_min: [14.2, 13.5, 12.1],
+        precipitation_probability_max: [0, 10, 80],
+        sunrise: [
+          `${futureDateStr(1)}T06:30`,
+          `${futureDateStr(2)}T06:28`,
+          `${futureDateStr(3)}T06:26`,
+        ],
+        sunset: [
+          `${futureDateStr(1)}T19:45`,
+          `${futureDateStr(2)}T19:46`,
+          `${futureDateStr(3)}T19:47`,
+        ],
+        wind_speed_10m_max: [15.2, 10.5, 22.0],
+        wind_direction_10m_dominant: [180, 270, 45],
+        uv_index_max: [5.5, 3.2, 7.8],
+        apparent_temperature_max: [24.0, 22.5, 16.0],
+        apparent_temperature_min: [12.0, 11.5, 10.0],
+      },
+      // No hourly key — old cache format
+    };
+
+    await db.insert(weatherCache).values({
+      tripId: testTripId,
+      response: oldCacheResponse,
+      fetchedAt: new Date(), // fresh timestamp
+    });
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockOpenMeteoResponse),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await service.getForecast(testTripId);
+
+    // Should have fallen through to re-fetch despite fresh cache
+    expect(mockFetch).toHaveBeenCalledOnce();
+    expect(result.available).toBe(true);
+    expect(result.hourly.length).toBeGreaterThan(0);
+  });
+
+  it("should include hourly array in getForecast response from fresh fetch", async () => {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const dayAfter = new Date();
+    dayAfter.setDate(dayAfter.getDate() + 3);
+
+    mockTripService.getEffectiveDateRange.mockResolvedValue({
+      start: tomorrow,
+      end: dayAfter,
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockOpenMeteoResponse),
+      }),
+    );
+
+    const result = await service.getForecast(testTripId);
+
+    expect(result.available).toBe(true);
+    expect(result).toHaveProperty("hourly");
+    expect(Array.isArray(result.hourly)).toBe(true);
+    expect(result.hourly.length).toBeGreaterThan(0);
+
+    // Verify each hourly entry has the correct HourlyForecast shape
+    for (const h of result.hourly) {
+      expect(h).toHaveProperty("time");
+      expect(h).toHaveProperty("temperature");
+      expect(h).toHaveProperty("weatherCode");
+      expect(h).toHaveProperty("windSpeed");
+      expect(h).toHaveProperty("humidity");
+      expect(h).toHaveProperty("uvIndex");
+      expect(h).toHaveProperty("dewPoint");
+      expect(h).toHaveProperty("precipitationProbability");
+    }
+  });
+
+  it("should include hourly array in cached response", async () => {
+    const start = new Date();
+    start.setDate(start.getDate() + 1);
+    const end = new Date();
+    end.setDate(end.getDate() + 3);
+    mockTripService.getEffectiveDateRange.mockResolvedValue({ start, end });
+
+    // Insert fresh cache WITH hourly data
+    await db.insert(weatherCache).values({
+      tripId: testTripId,
+      response: mockOpenMeteoResponse,
+      fetchedAt: new Date(),
+    });
+
+    const mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await service.getForecast(testTripId);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result.available).toBe(true);
+    expect(result).toHaveProperty("hourly");
+    expect(Array.isArray(result.hourly)).toBe(true);
+    expect(result.hourly.length).toBeGreaterThan(0);
+
+    // Verify hourly entries are correctly parsed from cache
+    for (const h of result.hourly) {
+      expect(h).toHaveProperty("time");
+      expect(h).toHaveProperty("temperature");
+      expect(h).toHaveProperty("weatherCode");
+      expect(h).toHaveProperty("windSpeed");
+      expect(h).toHaveProperty("humidity");
+      expect(h).toHaveProperty("uvIndex");
+      expect(h).toHaveProperty("dewPoint");
+      expect(h).toHaveProperty("precipitationProbability");
+    }
+  });
+
+  it("should include hourly: [] in all unavailable responses", async () => {
+    // No trip found
+    const noTripResult = await service.getForecast(
+      "00000000-0000-0000-0000-000000000000",
+    );
+    expect(noTripResult.available).toBe(false);
+    expect(noTripResult.hourly).toEqual([]);
+
+    // No coordinates
+    const [noCoordTrip] = await db
+      .insert(trips)
+      .values({
+        name: "No Coord Trip 2",
+        destination: "Unknown",
+        preferredTimezone: "UTC",
+        createdBy: testUserId,
+      })
+      .returning();
+
+    const noCoordResult = await service.getForecast(noCoordTrip.id);
+    expect(noCoordResult.available).toBe(false);
+    expect(noCoordResult.hourly).toEqual([]);
+    await db.delete(trips).where(eq(trips.id, noCoordTrip.id));
+
+    // No dates
+    mockTripService.getEffectiveDateRange.mockResolvedValue({
+      start: null,
+      end: null,
+    });
+    const noDatesResult = await service.getForecast(testTripId);
+    expect(noDatesResult.available).toBe(false);
+    expect(noDatesResult.hourly).toEqual([]);
+
+    // Past trip
+    mockTripService.getEffectiveDateRange.mockResolvedValue({
+      start: new Date("2024-01-01"),
+      end: new Date("2024-01-05"),
+    });
+    const pastResult = await service.getForecast(testTripId);
+    expect(pastResult.available).toBe(false);
+    expect(pastResult.hourly).toEqual([]);
+
+    // Too far in the future
+    const farFuture = new Date();
+    farFuture.setDate(farFuture.getDate() + 30);
+    const farFutureEnd = new Date();
+    farFutureEnd.setDate(farFutureEnd.getDate() + 35);
+    mockTripService.getEffectiveDateRange.mockResolvedValue({
+      start: farFuture,
+      end: farFutureEnd,
+    });
+    const farResult = await service.getForecast(testTripId);
+    expect(farResult.available).toBe(false);
+    expect(farResult.hourly).toEqual([]);
+
+    // API network error
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const dayAfter = new Date();
+    dayAfter.setDate(dayAfter.getDate() + 3);
+    mockTripService.getEffectiveDateRange.mockResolvedValue({
+      start: tomorrow,
+      end: dayAfter,
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("Network error")),
+    );
+    const errorResult = await service.getForecast(testTripId);
+    expect(errorResult.available).toBe(false);
+    expect(errorResult.hourly).toEqual([]);
+
+    // API non-OK response
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 500 }),
+    );
+    const serverErrorResult = await service.getForecast(testTripId);
+    expect(serverErrorResult.available).toBe(false);
+    expect(serverErrorResult.hourly).toEqual([]);
+  });
 });

--- a/apps/api/tests/unit/weather.service.test.ts
+++ b/apps/api/tests/unit/weather.service.test.ts
@@ -21,6 +21,23 @@ let mockOpenMeteoResponse: {
     temperature_2m_max: number[];
     temperature_2m_min: number[];
     precipitation_probability_max: number[];
+    sunrise: string[];
+    sunset: string[];
+    wind_speed_10m_max: number[];
+    wind_direction_10m_dominant: number[];
+    uv_index_max: number[];
+    apparent_temperature_max: number[];
+    apparent_temperature_min: number[];
+  };
+  hourly: {
+    time: string[];
+    temperature_2m: number[];
+    weather_code: number[];
+    wind_speed_10m: number[];
+    relative_humidity_2m: number[];
+    uv_index: number[];
+    dew_point_2m: number[];
+    precipitation_probability: number[];
   };
 };
 
@@ -73,6 +90,38 @@ describe("WeatherService", () => {
         temperature_2m_max: [22.5, 21.0, 18.3],
         temperature_2m_min: [14.2, 13.5, 12.1],
         precipitation_probability_max: [0, 10, 80],
+        sunrise: [
+          `${futureDateStr(1)}T06:30`,
+          `${futureDateStr(2)}T06:28`,
+          `${futureDateStr(3)}T06:26`,
+        ],
+        sunset: [
+          `${futureDateStr(1)}T19:45`,
+          `${futureDateStr(2)}T19:46`,
+          `${futureDateStr(3)}T19:47`,
+        ],
+        wind_speed_10m_max: [15.2, 10.5, 22.0],
+        wind_direction_10m_dominant: [180, 270, 45],
+        uv_index_max: [5.5, 3.2, 7.8],
+        apparent_temperature_max: [24.0, 22.5, 16.0],
+        apparent_temperature_min: [12.0, 11.5, 10.0],
+      },
+      hourly: {
+        time: [
+          `${futureDateStr(1)}T00:00`,
+          `${futureDateStr(1)}T01:00`,
+          `${futureDateStr(2)}T00:00`,
+          `${futureDateStr(2)}T01:00`,
+          `${futureDateStr(3)}T00:00`,
+          `${futureDateStr(3)}T01:00`,
+        ],
+        temperature_2m: [14.2, 13.8, 13.5, 13.0, 12.1, 11.8],
+        weather_code: [0, 0, 1, 1, 61, 61],
+        wind_speed_10m: [8.5, 7.2, 5.3, 4.8, 15.0, 14.5],
+        relative_humidity_2m: [72, 75, 68, 70, 85, 88],
+        uv_index: [0, 0, 0, 0, 0, 0],
+        dew_point_2m: [9.5, 9.2, 7.8, 7.5, 9.8, 10.0],
+        precipitation_probability: [0, 0, 10, 10, 80, 80],
       },
     };
 
@@ -319,6 +368,23 @@ describe("WeatherService", () => {
         temperature_2m_max: [25.5, 19.0],
         temperature_2m_min: [15.0, 11.5],
         precipitation_probability_max: [5, 90],
+        sunrise: ["2026-03-10T06:45", "2026-03-11T06:43"],
+        sunset: ["2026-03-10T18:30", "2026-03-11T18:31"],
+        wind_speed_10m_max: [12.0, 20.5],
+        wind_direction_10m_dominant: [180, 315],
+        uv_index_max: [4.5, 2.0],
+        apparent_temperature_max: [27.0, 17.5],
+        apparent_temperature_min: [13.0, 9.0],
+      },
+      hourly: {
+        time: ["2026-03-10T00:00", "2026-03-10T01:00", "2026-03-11T00:00"],
+        temperature_2m: [15.0, 14.5, 11.5],
+        weather_code: [3, 3, 61],
+        wind_speed_10m: [8.0, 7.5, 15.0],
+        relative_humidity_2m: [70, 72, 85],
+        uv_index: [0, 0, 0],
+        dew_point_2m: [9.5, 9.0, 9.0],
+        precipitation_probability: [5, 5, 90],
       },
     };
 
@@ -341,6 +407,13 @@ describe("WeatherService", () => {
       temperatureMax: 25.5,
       temperatureMin: 15.0,
       precipitationProbability: 5,
+      sunrise: "06:45",
+      sunset: "18:30",
+      windSpeedMax: 12.0,
+      windDirectionDominant: 180,
+      uvIndexMax: 4.5,
+      apparentTemperatureMax: 27.0,
+      apparentTemperatureMin: 13.0,
     });
 
     expect(result.forecasts[1]).toEqual({
@@ -349,6 +422,26 @@ describe("WeatherService", () => {
       temperatureMax: 19.0,
       temperatureMin: 11.5,
       precipitationProbability: 90,
+      sunrise: "06:43",
+      sunset: "18:31",
+      windSpeedMax: 20.5,
+      windDirectionDominant: 315,
+      uvIndexMax: 2.0,
+      apparentTemperatureMax: 17.5,
+      apparentTemperatureMin: 9.0,
+    });
+
+    // Verify hourly data is also returned
+    expect(result.hourly).toHaveLength(3);
+    expect(result.hourly[0]).toEqual({
+      time: "2026-03-10T00:00",
+      temperature: 15.0,
+      weatherCode: 3,
+      windSpeed: 8.0,
+      humidity: 70,
+      uvIndex: 0,
+      dewPoint: 9.5,
+      precipitationProbability: 5,
     });
   });
 });

--- a/apps/web/src/components/itinerary/weather-detail-sheet.tsx
+++ b/apps/web/src/components/itinerary/weather-detail-sheet.tsx
@@ -207,26 +207,14 @@ export const WeatherDetailSheet = memo(function WeatherDetailSheet({
   temperatureUnit,
   isDark,
 }: WeatherDetailSheetProps) {
-  const forecast = forecasts[selectedIndex];
-  if (!forecast) return null;
-
-  const { icon: WeatherIcon, label, tone } = getWeatherInfo(
-    forecast.weatherCode,
-  );
-  const styles = TONE_STYLES[tone];
-  const iconColor = isDark ? styles.iconDark : styles.icon;
-  const today = isToday(forecast.date);
-  const unit = temperatureUnit === "fahrenheit" ? "F" : "C";
-  const high = toDisplayTemp(forecast.temperatureMax, temperatureUnit);
-  const low = toDisplayTemp(forecast.temperatureMin, temperatureUnit);
-
-  const currentTemp = today
-    ? getCurrentHourTemp(hourly, forecast.date)
-    : null;
-
-  const nextForecast = forecasts[selectedIndex + 1];
-  const dayHours = getHourlyForDay(hourly, forecast.date, nextForecast?.date);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const forecast = forecasts[selectedIndex];
+
+  const today = forecast ? isToday(forecast.date) : false;
+  const nextForecast = forecast ? forecasts[selectedIndex + 1] : undefined;
+  const dayHours = forecast
+    ? getHourlyForDay(hourly, forecast.date, nextForecast?.date)
+    : [];
   const anchorIdx = today ? getAnchorHourIndex(dayHours, new Date()) : 0;
 
   useEffect(() => {
@@ -235,6 +223,21 @@ export const WeatherDetailSheet = memo(function WeatherDetailSheet({
       | undefined;
     el?.scrollIntoView({ inline: "start", behavior: "instant" });
   }, [anchorIdx, selectedIndex]);
+
+  if (!forecast) return null;
+
+  const { icon: WeatherIcon, label, tone } = getWeatherInfo(
+    forecast.weatherCode,
+  );
+  const styles = TONE_STYLES[tone];
+  const iconColor = isDark ? styles.iconDark : styles.icon;
+  const unit = temperatureUnit === "fahrenheit" ? "F" : "C";
+  const high = toDisplayTemp(forecast.temperatureMax, temperatureUnit);
+  const low = toDisplayTemp(forecast.temperatureMin, temperatureUnit);
+
+  const currentTemp = today
+    ? getCurrentHourTemp(hourly, forecast.date)
+    : null;
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>

--- a/apps/web/src/components/itinerary/weather-detail-sheet.tsx
+++ b/apps/web/src/components/itinerary/weather-detail-sheet.tsx
@@ -24,6 +24,7 @@ import {
   SheetBody,
   SheetClose,
   SheetContent,
+  SheetDescription,
   SheetTitle,
 } from "@/components/ui/sheet";
 import {
@@ -247,6 +248,7 @@ export const WeatherDetailSheet = memo(function WeatherDetailSheet({
       >
         <VisuallyHidden.Root>
           <SheetTitle>Weather details</SheetTitle>
+          <SheetDescription>Detailed weather forecast for the selected day</SheetDescription>
         </VisuallyHidden.Root>
 
         {/* Header actions */}

--- a/apps/web/src/components/itinerary/weather-detail-sheet.tsx
+++ b/apps/web/src/components/itinerary/weather-detail-sheet.tsx
@@ -1,0 +1,406 @@
+"use client";
+
+import { memo, useEffect, useRef } from "react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  CloudRain,
+  Droplets,
+  Sun,
+  Sunrise,
+  Sunset,
+  Wind,
+  XIcon,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { VisuallyHidden } from "radix-ui";
+import type {
+  DailyForecastExtended,
+  HourlyForecast,
+  TemperatureUnit,
+} from "@journiful/shared/types";
+import {
+  Sheet,
+  SheetBody,
+  SheetClose,
+  SheetContent,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import {
+  getWeatherInfo,
+  toDisplayTemp,
+  type WeatherTone,
+} from "@/lib/weather-codes";
+import {
+  getHourlyForDay,
+  getAnchorHourIndex,
+  windDegreesToCompass,
+  uvIndexLevel,
+} from "@/lib/weather-utils";
+
+const TONE_STYLES: Record<
+  WeatherTone,
+  { light: string; dark: string; icon: string; iconDark: string }
+> = {
+  sunny: {
+    light: "bg-amber-100",
+    dark: "bg-amber-950",
+    icon: "text-amber-500",
+    iconDark: "text-amber-400",
+  },
+  cloudy: {
+    light: "bg-white",
+    dark: "bg-gray-900",
+    icon: "text-gray-400",
+    iconDark: "text-gray-400",
+  },
+  fog: {
+    light: "bg-white",
+    dark: "bg-gray-900",
+    icon: "text-gray-400",
+    iconDark: "text-gray-400",
+  },
+  rain: {
+    light: "bg-blue-100",
+    dark: "bg-blue-950",
+    icon: "text-blue-500",
+    iconDark: "text-blue-400",
+  },
+  snow: {
+    light: "bg-blue-50",
+    dark: "bg-blue-950",
+    icon: "text-sky-400",
+    iconDark: "text-sky-300",
+  },
+  storm: {
+    light: "bg-blue-200",
+    dark: "bg-blue-950",
+    icon: "text-blue-600",
+    iconDark: "text-blue-300",
+  },
+};
+
+interface WeatherDetailSheetProps {
+  forecasts: DailyForecastExtended[];
+  hourly: HourlyForecast[];
+  selectedIndex: number;
+  onIndexChange: (i: number) => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  temperatureUnit: TemperatureUnit;
+  isDark: boolean;
+}
+
+function formatSheetDate(dateStr: string): string {
+  const [yearStr, monthStr, dayStr] = dateStr.split("-");
+  const date = new Date(Number(yearStr), Number(monthStr) - 1, Number(dayStr));
+  return date.toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function isToday(dateStr: string): boolean {
+  const now = new Date();
+  const todayStr = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+  return dateStr === todayStr;
+}
+
+function formatHour(timeStr: string): string {
+  const [, timePart] = timeStr.split("T") as [string, string];
+  const hour = Number(timePart.split(":")[0]);
+  if (hour === 0) return "12 AM";
+  if (hour === 12) return "12 PM";
+  if (hour < 12) return `${hour} AM`;
+  return `${hour - 12} PM`;
+}
+
+function getCurrentHourTemp(
+  hourly: HourlyForecast[],
+  date: string,
+): number | null {
+  const now = new Date();
+  const currentHour = now.getHours();
+  // Find the hourly entry closest to the current hour for today
+  let closest: HourlyForecast | null = null;
+  let closestDiff = Infinity;
+  for (const entry of hourly) {
+    const [datePart, timePart] = entry.time.split("T") as [string, string];
+    if (datePart !== date) continue;
+    const hour = Number(timePart.split(":")[0]);
+    const diff = Math.abs(hour - currentHour);
+    if (diff < closestDiff) {
+      closestDiff = diff;
+      closest = entry;
+    }
+  }
+  return closest?.temperature ?? null;
+}
+
+function formatSunTime(time: string): string {
+  const [hourStr, minuteStr] = time.split(":") as [string, string];
+  let hour = Number(hourStr);
+  const suffix = hour >= 12 ? "PM" : "AM";
+  if (hour === 0) hour = 12;
+  else if (hour > 12) hour -= 12;
+  return `${hour}:${minuteStr} ${suffix}`;
+}
+
+function getMaxHourlyValue(
+  hourly: HourlyForecast[],
+  date: string,
+  field: "humidity" | "dewPoint",
+): number {
+  let max = 0;
+  for (const entry of hourly) {
+    const [datePart] = entry.time.split("T");
+    if (datePart === date && entry[field] > max) {
+      max = entry[field];
+    }
+  }
+  return max;
+}
+
+function DetailCard({
+  icon: Icon,
+  label,
+  value,
+  secondary,
+  isDark,
+}: {
+  icon: LucideIcon;
+  label: string;
+  value: string;
+  secondary?: string;
+  isDark: boolean;
+}) {
+  return (
+    <div
+      className={`flex flex-col items-center gap-1.5 rounded-md p-3 ${isDark ? "bg-gray-900" : "bg-muted/50"}`}
+    >
+      <div
+        className={`flex items-center gap-1.5 text-xs ${isDark ? "text-foreground/60" : "text-muted-foreground"}`}
+      >
+        <Icon className="h-3.5 w-3.5" />
+        <span>{label}</span>
+      </div>
+      <span className="text-lg font-semibold tabular-nums">{value}</span>
+      {secondary && (
+        <span
+          className={`text-xs ${isDark ? "text-foreground/50" : "text-muted-foreground"}`}
+        >
+          {secondary}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export const WeatherDetailSheet = memo(function WeatherDetailSheet({
+  forecasts,
+  hourly,
+  selectedIndex,
+  onIndexChange,
+  open,
+  onOpenChange,
+  temperatureUnit,
+  isDark,
+}: WeatherDetailSheetProps) {
+  const forecast = forecasts[selectedIndex];
+  if (!forecast) return null;
+
+  const { icon: WeatherIcon, label, tone } = getWeatherInfo(
+    forecast.weatherCode,
+  );
+  const styles = TONE_STYLES[tone];
+  const iconColor = isDark ? styles.iconDark : styles.icon;
+  const today = isToday(forecast.date);
+  const unit = temperatureUnit === "fahrenheit" ? "F" : "C";
+  const high = toDisplayTemp(forecast.temperatureMax, temperatureUnit);
+  const low = toDisplayTemp(forecast.temperatureMin, temperatureUnit);
+
+  const currentTemp = today
+    ? getCurrentHourTemp(hourly, forecast.date)
+    : null;
+
+  const nextForecast = forecasts[selectedIndex + 1];
+  const dayHours = getHourlyForDay(hourly, forecast.date, nextForecast?.date);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const anchorIdx = today ? getAnchorHourIndex(dayHours, new Date()) : 0;
+
+  useEffect(() => {
+    const el = scrollRef.current?.children[anchorIdx] as
+      | HTMLElement
+      | undefined;
+    el?.scrollIntoView({ inline: "start", behavior: "instant" });
+  }, [anchorIdx, selectedIndex]);
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        showCloseButton={false}
+        className={isDark ? "bg-gray-950 text-white" : "bg-white"}
+      >
+        <VisuallyHidden.Root>
+          <SheetTitle>Weather details</SheetTitle>
+        </VisuallyHidden.Root>
+
+        {/* Header actions */}
+        <div className="flex items-center justify-end gap-1 px-4 pt-4">
+          <SheetClose className="rounded-md p-2 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer">
+            <XIcon className="w-4 h-4" />
+            <span className="sr-only">Close</span>
+          </SheetClose>
+        </div>
+
+        <SheetBody className="space-y-5">
+          {/* Day navigation header */}
+          <div className="flex items-center justify-between">
+            <button
+              onClick={() => onIndexChange(selectedIndex - 1)}
+              disabled={selectedIndex === 0}
+              className="rounded-md p-2 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default"
+              aria-label="Previous day"
+            >
+              <ChevronLeft className="w-5 h-5" />
+            </button>
+            <span className="text-sm font-semibold">
+              {formatSheetDate(forecast.date)}
+            </span>
+            <button
+              onClick={() => onIndexChange(selectedIndex + 1)}
+              disabled={selectedIndex === forecasts.length - 1}
+              className="rounded-md p-2 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default"
+              aria-label="Next day"
+            >
+              <ChevronRight className="w-5 h-5" />
+            </button>
+          </div>
+
+          {/* Day summary */}
+          <div className="flex flex-col items-center gap-1 text-center">
+            {today && currentTemp !== null ? (
+              <>
+                <div className="text-5xl font-light tabular-nums">
+                  {toDisplayTemp(currentTemp, temperatureUnit)}&deg;
+                  <span className="text-lg">{unit}</span>
+                </div>
+                <p
+                  className={`text-sm ${isDark ? "text-foreground/60" : "text-muted-foreground"}`}
+                >
+                  Feels like{" "}
+                  {toDisplayTemp(
+                    forecast.apparentTemperatureMax,
+                    temperatureUnit,
+                  )}
+                  &deg;
+                </p>
+                <div className="flex items-center gap-1.5 mt-1">
+                  <WeatherIcon className={`h-5 w-5 ${iconColor}`} />
+                  <span className="text-sm">{label}</span>
+                </div>
+              </>
+            ) : (
+              <>
+                <WeatherIcon className={`h-10 w-10 ${iconColor}`} />
+                <span className="text-sm font-medium">{label}</span>
+              </>
+            )}
+            <p
+              className={`text-sm ${isDark ? "text-foreground/60" : "text-muted-foreground"}`}
+            >
+              High {high}&deg; &middot; Low {low}&deg;
+            </p>
+          </div>
+
+          {/* Hourly forecast scroll */}
+          {dayHours.length > 0 && (
+            <div
+              ref={scrollRef}
+              className="flex gap-1.5 overflow-x-auto scrollbar-none"
+            >
+              {dayHours.map((hour) => {
+                const hourInfo = getWeatherInfo(hour.weatherCode);
+                const hourStyles = TONE_STYLES[hourInfo.tone];
+                const hourBg = isDark ? hourStyles.dark : hourStyles.light;
+                const hourIconColor = isDark
+                  ? hourStyles.iconDark
+                  : hourStyles.icon;
+                const HourIcon = hourInfo.icon;
+
+                return (
+                  <div
+                    key={hour.time}
+                    className={`flex min-w-[4.5rem] flex-col items-center gap-1 rounded-md px-2 py-2.5 ${hourBg}`}
+                  >
+                    <span
+                      className={`text-xs font-medium ${isDark ? "text-foreground/70" : "text-muted-foreground"}`}
+                    >
+                      {formatHour(hour.time)}
+                    </span>
+                    <HourIcon
+                      className={`h-5 w-5 ${hourIconColor}`}
+                      aria-hidden="true"
+                    />
+                    <span className="text-sm font-semibold tabular-nums">
+                      {toDisplayTemp(hour.temperature, temperatureUnit)}&deg;
+                    </span>
+                    <span
+                      className={`text-[0.625rem] ${isDark ? "text-foreground/60" : "text-muted-foreground"}`}
+                    >
+                      {Math.round(hour.windSpeed)} km/h
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* Detail grid */}
+          <div className="grid grid-cols-2 gap-2">
+            <DetailCard
+              icon={Wind}
+              label="Wind"
+              value={`${Math.round(forecast.windSpeedMax)} km/h`}
+              secondary={windDegreesToCompass(forecast.windDirectionDominant)}
+              isDark={isDark}
+            />
+            <DetailCard
+              icon={Sun}
+              label="UV Index"
+              value={String(Math.round(forecast.uvIndexMax))}
+              secondary={uvIndexLevel(forecast.uvIndexMax)}
+              isDark={isDark}
+            />
+            <DetailCard
+              icon={Droplets}
+              label="Humidity"
+              value={`${getMaxHourlyValue(hourly, forecast.date, "humidity")}%`}
+              secondary={`Dew point ${toDisplayTemp(getMaxHourlyValue(hourly, forecast.date, "dewPoint"), temperatureUnit)}\u00B0`}
+              isDark={isDark}
+            />
+            <DetailCard
+              icon={CloudRain}
+              label="Precipitation"
+              value={`${forecast.precipitationProbability}%`}
+              isDark={isDark}
+            />
+            <DetailCard
+              icon={Sunrise}
+              label="Sunrise"
+              value={formatSunTime(forecast.sunrise)}
+              isDark={isDark}
+            />
+            <DetailCard
+              icon={Sunset}
+              label="Sunset"
+              value={formatSunTime(forecast.sunset)}
+              isDark={isDark}
+            />
+          </div>
+        </SheetBody>
+      </SheetContent>
+    </Sheet>
+  );
+});

--- a/apps/web/src/components/itinerary/weather-detail-sheet.tsx
+++ b/apps/web/src/components/itinerary/weather-detail-sheet.tsx
@@ -30,7 +30,7 @@ import {
 import {
   getWeatherInfo,
   toDisplayTemp,
-  type WeatherTone,
+  TONE_STYLES,
 } from "@/lib/weather-codes";
 import {
   getHourlyForDay,
@@ -38,48 +38,6 @@ import {
   windDegreesToCompass,
   uvIndexLevel,
 } from "@/lib/weather-utils";
-
-const TONE_STYLES: Record<
-  WeatherTone,
-  { light: string; dark: string; icon: string; iconDark: string }
-> = {
-  sunny: {
-    light: "bg-amber-100",
-    dark: "bg-amber-950",
-    icon: "text-amber-500",
-    iconDark: "text-amber-400",
-  },
-  cloudy: {
-    light: "bg-white",
-    dark: "bg-gray-900",
-    icon: "text-gray-400",
-    iconDark: "text-gray-400",
-  },
-  fog: {
-    light: "bg-white",
-    dark: "bg-gray-900",
-    icon: "text-gray-400",
-    iconDark: "text-gray-400",
-  },
-  rain: {
-    light: "bg-blue-100",
-    dark: "bg-blue-950",
-    icon: "text-blue-500",
-    iconDark: "text-blue-400",
-  },
-  snow: {
-    light: "bg-blue-50",
-    dark: "bg-blue-950",
-    icon: "text-sky-400",
-    iconDark: "text-sky-300",
-  },
-  storm: {
-    light: "bg-blue-200",
-    dark: "bg-blue-950",
-    icon: "text-blue-600",
-    iconDark: "text-blue-300",
-  },
-};
 
 interface WeatherDetailSheetProps {
   forecasts: DailyForecastExtended[];

--- a/apps/web/src/components/itinerary/weather-forecast-card.tsx
+++ b/apps/web/src/components/itinerary/weather-forecast-card.tsx
@@ -9,7 +9,7 @@ import type {
 import {
   getWeatherInfo,
   toDisplayTemp,
-  type WeatherTone,
+  TONE_STYLES,
 } from "@/lib/weather-codes";
 import { Skeleton } from "@/components/ui/skeleton";
 
@@ -44,47 +44,6 @@ function formatDate(dateStr: string): string {
   return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
 }
 
-const TONE_STYLES: Record<
-  WeatherTone,
-  { light: string; dark: string; icon: string; iconDark: string }
-> = {
-  sunny: {
-    light: "bg-amber-100",
-    dark: "bg-amber-950",
-    icon: "text-amber-500",
-    iconDark: "text-amber-400",
-  },
-  cloudy: {
-    light: "bg-white",
-    dark: "bg-gray-900",
-    icon: "text-gray-400",
-    iconDark: "text-gray-400",
-  },
-  fog: {
-    light: "bg-white",
-    dark: "bg-gray-900",
-    icon: "text-gray-400",
-    iconDark: "text-gray-400",
-  },
-  rain: {
-    light: "bg-blue-100",
-    dark: "bg-blue-950",
-    icon: "text-blue-500",
-    iconDark: "text-blue-400",
-  },
-  snow: {
-    light: "bg-blue-50",
-    dark: "bg-blue-950",
-    icon: "text-sky-400",
-    iconDark: "text-sky-300",
-  },
-  storm: {
-    light: "bg-blue-200",
-    dark: "bg-blue-950",
-    icon: "text-blue-600",
-    iconDark: "text-blue-300",
-  },
-};
 
 export const WeatherForecastCard = memo(function WeatherForecastCard({
   weather,

--- a/apps/web/src/components/itinerary/weather-forecast-card.tsx
+++ b/apps/web/src/components/itinerary/weather-forecast-card.tsx
@@ -18,6 +18,7 @@ interface WeatherForecastCardProps {
   isLoading: boolean;
   temperatureUnit: TemperatureUnit;
   isDark?: boolean;
+  onDayClick?: (date: string) => void;
 }
 
 function formatDayOfWeek(dateStr: string): string {
@@ -90,6 +91,7 @@ export const WeatherForecastCard = memo(function WeatherForecastCard({
   isLoading,
   temperatureUnit,
   isDark = false,
+  onDayClick,
 }: WeatherForecastCardProps) {
   if (isLoading) {
     return (
@@ -142,9 +144,22 @@ export const WeatherForecastCard = memo(function WeatherForecastCard({
           return (
             <div
               key={day.date}
-              className={`flex min-w-[4.5rem] flex-1 flex-col items-center rounded-md px-1 py-2 ${tileBg}`}
+              className={`flex min-w-[4.5rem] flex-1 flex-col items-center rounded-md px-1 py-2 ${tileBg}${onDayClick ? " cursor-pointer" : ""}`}
               title={label}
               aria-label={`${formatDayOfWeek(day.date)}: ${label}, high ${high}, low ${low}${day.precipitationProbability > 5 ? `, ${day.precipitationProbability}% rain` : ""}`}
+              onClick={() => onDayClick?.(day.date)}
+              role={onDayClick ? "button" : undefined}
+              tabIndex={onDayClick ? 0 : undefined}
+              onKeyDown={
+                onDayClick
+                  ? (e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        onDayClick(day.date);
+                      }
+                    }
+                  : undefined
+              }
             >
               {/* Day + date */}
               <span

--- a/apps/web/src/components/trip/mobile/panels/info-panel.tsx
+++ b/apps/web/src/components/trip/mobile/panels/info-panel.tsx
@@ -14,6 +14,7 @@ import { Button } from "@/components/ui/button";
 
 import { RsvpPills } from "@/components/trip/rsvp-pills";
 import { WeatherForecastCard } from "@/components/itinerary/weather-forecast-card";
+import { WeatherDetailSheet } from "@/components/itinerary/weather-detail-sheet";
 import { AccommodationDetailSheet } from "@/components/itinerary/accommodation-detail-sheet";
 import { EditAccommodationDialog } from "@/components/itinerary/edit-accommodation-dialog";
 import { CreateAccommodationDialog } from "@/components/itinerary/create-accommodation-dialog";
@@ -121,6 +122,7 @@ export function InfoPanel({
     () => suggestions.find((s) => s.gapType === "no_accommodation"),
     [suggestions],
   );
+  const [selectedWeatherDate, setSelectedWeatherDate] = useState<string | null>(null);
   const [selectedAccommodation, setSelectedAccommodation] = useState<Accommodation | null>(null);
   const [editingAccommodation, setEditingAccommodation] = useState<Accommodation | null>(null);
   const [isCreateAccommodationOpen, setIsCreateAccommodationOpen] = useState(false);
@@ -185,6 +187,8 @@ export function InfoPanel({
       </>
     );
   }, [todayDateStr, todayForecast, temperatureUnit]);
+
+  const selectedWeatherIndex = weather?.forecasts.findIndex(f => f.date === selectedWeatherDate) ?? -1;
 
   return (
     <div
@@ -445,9 +449,22 @@ export function InfoPanel({
             isLoading={weatherLoading}
             temperatureUnit={temperatureUnit}
             isDark={preset?.background.isDark ?? false}
+            onDayClick={setSelectedWeatherDate}
           />
         </div>
       </div>
+
+      {/* Weather detail sheet */}
+      <WeatherDetailSheet
+        forecasts={weather?.forecasts ?? []}
+        hourly={weather?.hourly ?? []}
+        selectedIndex={Math.max(0, selectedWeatherIndex)}
+        onIndexChange={(i) => setSelectedWeatherDate(weather?.forecasts[i]?.date ?? null)}
+        open={selectedWeatherDate !== null && selectedWeatherIndex >= 0}
+        onOpenChange={(open) => { if (!open) setSelectedWeatherDate(null); }}
+        temperatureUnit={temperatureUnit}
+        isDark={preset?.background.isDark ?? false}
+      />
 
       {/* Accommodation detail sheet */}
       <AccommodationDetailSheet

--- a/apps/web/src/lib/__tests__/weather-utils.test.ts
+++ b/apps/web/src/lib/__tests__/weather-utils.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import type { HourlyForecast } from "@journiful/shared/types";
+import {
+  windDegreesToCompass,
+  uvIndexLevel,
+  getHourlyForDay,
+  getAnchorHourIndex,
+} from "../weather-utils";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a minimal HourlyForecast stub with the given ISO time string. */
+function hourly(time: string): HourlyForecast {
+  return {
+    time,
+    temperature: 20,
+    weatherCode: 0,
+    windSpeed: 10,
+    humidity: 50,
+    uvIndex: 3,
+    dewPoint: 12,
+    precipitationProbability: 10,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// windDegreesToCompass
+// ---------------------------------------------------------------------------
+
+describe("windDegreesToCompass", () => {
+  it.each([
+    [0, "N"],
+    [90, "E"],
+    [180, "S"],
+    [270, "W"],
+    [45, "NE"],
+    [135, "SE"],
+    [225, "SW"],
+    [315, "NW"],
+  ])("maps %d degrees to %s", (degrees, expected) => {
+    expect(windDegreesToCompass(degrees)).toBe(expected);
+  });
+
+  it("treats 360 the same as 0 (North)", () => {
+    expect(windDegreesToCompass(360)).toBe("N");
+  });
+
+  it("handles values greater than 360 via modulo", () => {
+    expect(windDegreesToCompass(450)).toBe("E"); // 450 % 360 = 90
+  });
+
+  it("handles negative degrees", () => {
+    expect(windDegreesToCompass(-90)).toBe("W"); // -90 → 270
+  });
+});
+
+// ---------------------------------------------------------------------------
+// uvIndexLevel
+// ---------------------------------------------------------------------------
+
+describe("uvIndexLevel", () => {
+  it.each([
+    [0, "Low"],
+    [1, "Low"],
+    [2, "Low"],
+    [3, "Moderate"],
+    [4, "Moderate"],
+    [5, "Moderate"],
+    [6, "High"],
+    [7, "High"],
+    [8, "Very High"],
+    [9, "Very High"],
+    [10, "Very High"],
+    [11, "Extreme"],
+    [15, "Extreme"],
+  ])("returns %s for UV index %d", (index, expected) => {
+    expect(uvIndexLevel(index)).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getHourlyForDay
+// ---------------------------------------------------------------------------
+
+describe("getHourlyForDay", () => {
+  // Build a full two-day hourly dataset (every hour for 2026-04-16 and 2026-04-17)
+  const allHours: HourlyForecast[] = [];
+  for (let day = 16; day <= 17; day++) {
+    for (let h = 0; h < 24; h++) {
+      const hh = String(h).padStart(2, "0");
+      allHours.push(hourly(`2026-04-${day}T${hh}:00`));
+    }
+  }
+
+  it("returns 9 entries (every 3h + trailing midnight) when nextDate is provided", () => {
+    const result = getHourlyForDay(allHours, "2026-04-16", "2026-04-17");
+    expect(result).toHaveLength(9);
+  });
+
+  it("samples the correct 3-hour intervals", () => {
+    const result = getHourlyForDay(allHours, "2026-04-16", "2026-04-17");
+    const times = result.map((e) => e.time);
+    expect(times).toEqual([
+      "2026-04-16T00:00",
+      "2026-04-16T03:00",
+      "2026-04-16T06:00",
+      "2026-04-16T09:00",
+      "2026-04-16T12:00",
+      "2026-04-16T15:00",
+      "2026-04-16T18:00",
+      "2026-04-16T21:00",
+      "2026-04-17T00:00", // trailing midnight from next day
+    ]);
+  });
+
+  it("returns 8 entries when nextDate is undefined (last forecast day)", () => {
+    const result = getHourlyForDay(allHours, "2026-04-17");
+    expect(result).toHaveLength(8);
+    const lastTime = result[result.length - 1]!.time;
+    expect(lastTime).toBe("2026-04-17T21:00");
+  });
+
+  it("returns empty array when no hourly data matches the date", () => {
+    const result = getHourlyForDay(allHours, "2026-04-20");
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAnchorHourIndex
+// ---------------------------------------------------------------------------
+
+describe("getAnchorHourIndex", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const dayHours = [
+    hourly("2026-04-16T00:00"),
+    hourly("2026-04-16T03:00"),
+    hourly("2026-04-16T06:00"),
+    hourly("2026-04-16T09:00"),
+    hourly("2026-04-16T12:00"),
+    hourly("2026-04-16T15:00"),
+    hourly("2026-04-16T18:00"),
+    hourly("2026-04-16T21:00"),
+    hourly("2026-04-17T00:00"),
+  ];
+
+  it("returns the index of the first slot at or after now", () => {
+    vi.useFakeTimers();
+    // 10:30 AM — the next 3h slot is 12:00 (index 4)
+    vi.setSystemTime(new Date("2026-04-16T10:30:00"));
+    expect(getAnchorHourIndex(dayHours, new Date())).toBe(4);
+  });
+
+  it("returns exact slot index when now falls exactly on a slot", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-16T06:00:00"));
+    expect(getAnchorHourIndex(dayHours, new Date())).toBe(2);
+  });
+
+  it("returns 0 when now is before all slots", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-15T23:00:00"));
+    expect(getAnchorHourIndex(dayHours, new Date())).toBe(0);
+  });
+
+  it("returns 0 when now is after all slots (fallback)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-17T02:00:00"));
+    expect(getAnchorHourIndex(dayHours, new Date())).toBe(0);
+  });
+
+  it("returns last index when now is just before the last slot", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-16T23:59:00"));
+    // The next slot at or after 23:59 is 2026-04-17T00:00 (index 8)
+    expect(getAnchorHourIndex(dayHours, new Date())).toBe(8);
+  });
+});

--- a/apps/web/src/lib/weather-codes.ts
+++ b/apps/web/src/lib/weather-codes.ts
@@ -94,6 +94,48 @@ export function getWeatherInfo(code: number): WeatherInfo {
   return WMO_CODE_MAP[code] ?? UNKNOWN_WEATHER;
 }
 
+export const TONE_STYLES: Record<
+  WeatherTone,
+  { light: string; dark: string; icon: string; iconDark: string }
+> = {
+  sunny: {
+    light: "bg-amber-100",
+    dark: "bg-amber-950",
+    icon: "text-amber-500",
+    iconDark: "text-amber-400",
+  },
+  cloudy: {
+    light: "bg-white",
+    dark: "bg-gray-900",
+    icon: "text-gray-400",
+    iconDark: "text-gray-400",
+  },
+  fog: {
+    light: "bg-white",
+    dark: "bg-gray-900",
+    icon: "text-gray-400",
+    iconDark: "text-gray-400",
+  },
+  rain: {
+    light: "bg-blue-100",
+    dark: "bg-blue-950",
+    icon: "text-blue-500",
+    iconDark: "text-blue-400",
+  },
+  snow: {
+    light: "bg-blue-50",
+    dark: "bg-blue-950",
+    icon: "text-sky-400",
+    iconDark: "text-sky-300",
+  },
+  storm: {
+    light: "bg-blue-200",
+    dark: "bg-blue-950",
+    icon: "text-blue-600",
+    iconDark: "text-blue-300",
+  },
+};
+
 /**
  * Convert a Celsius temperature to the requested unit and round to the
  * nearest integer for display.

--- a/apps/web/src/lib/weather-utils.ts
+++ b/apps/web/src/lib/weather-utils.ts
@@ -1,0 +1,81 @@
+import type { HourlyForecast } from "@journiful/shared/types";
+
+const COMPASS_DIRECTIONS = [
+  "N",
+  "NNE",
+  "NE",
+  "ENE",
+  "E",
+  "ESE",
+  "SE",
+  "SSE",
+  "S",
+  "SSW",
+  "SW",
+  "WSW",
+  "W",
+  "WNW",
+  "NW",
+  "NNW",
+] as const;
+
+/** Map a wind direction in degrees (0-360) to a 16-point compass label. */
+export function windDegreesToCompass(degrees: number): string {
+  const index = Math.round(((degrees % 360) + 360) % 360 / 22.5) % 16;
+  return COMPASS_DIRECTIONS[index] ?? "N";
+}
+
+/** Return the UV index risk level label. */
+export function uvIndexLevel(index: number): string {
+  if (index <= 2) return "Low";
+  if (index <= 5) return "Moderate";
+  if (index <= 7) return "High";
+  if (index <= 10) return "Very High";
+  return "Extreme";
+}
+
+/**
+ * Find the index of the nearest upcoming 3h slot in a list of hourly entries.
+ * Returns 0 if no match is found (e.g. all hours are in the past).
+ */
+export function getAnchorHourIndex(
+  hours: HourlyForecast[],
+  now: Date,
+): number {
+  const nowMs = now.getTime();
+  for (let i = 0; i < hours.length; i++) {
+    const entry = hours[i]!;
+    const hourMs = new Date(entry.time).getTime();
+    if (hourMs >= nowMs) return i;
+  }
+  return 0;
+}
+
+const EVERY_3H = new Set([0, 3, 6, 9, 12, 15, 18, 21]);
+
+/**
+ * Filter hourly entries for a single day, sampling every 3 hours
+ * (00, 03, 06, 09, 12, 15, 18, 21) plus hour 00 of the next day.
+ *
+ * If `nextDate` is undefined (last forecast day), returns 8 cards ending at 21:00.
+ */
+export function getHourlyForDay(
+  hourly: HourlyForecast[],
+  date: string,
+  nextDate?: string,
+): HourlyForecast[] {
+  const result: HourlyForecast[] = [];
+
+  for (const entry of hourly) {
+    const [datePart, timePart] = entry.time.split("T") as [string, string];
+    const hour = Number(timePart.split(":")[0]);
+
+    if (datePart === date && EVERY_3H.has(hour)) {
+      result.push(entry);
+    } else if (nextDate && datePart === nextDate && hour === 0) {
+      result.push(entry);
+    }
+  }
+
+  return result;
+}

--- a/shared/schemas/index.ts
+++ b/shared/schemas/index.ts
@@ -152,8 +152,10 @@ export {
 // Re-export weather schemas
 export {
   dailyForecastSchema,
+  hourlyForecastSchema,
   tripWeatherResponseSchema,
   type DailyForecastSchema,
+  type HourlyForecastSchema,
   type TripWeatherResponseSchema,
 } from "./weather";
 

--- a/shared/schemas/weather.ts
+++ b/shared/schemas/weather.ts
@@ -6,6 +6,24 @@ export const dailyForecastSchema = z.object({
   temperatureMax: z.number(),
   temperatureMin: z.number(),
   precipitationProbability: z.number().min(0).max(100),
+  sunrise: z.string(),
+  sunset: z.string(),
+  windSpeedMax: z.number(),
+  windDirectionDominant: z.number(),
+  uvIndexMax: z.number(),
+  apparentTemperatureMax: z.number(),
+  apparentTemperatureMin: z.number(),
+});
+
+export const hourlyForecastSchema = z.object({
+  time: z.string(),
+  temperature: z.number(),
+  weatherCode: z.number().int(),
+  windSpeed: z.number(),
+  humidity: z.number().min(0).max(100),
+  uvIndex: z.number(),
+  dewPoint: z.number(),
+  precipitationProbability: z.number().min(0).max(100),
 });
 
 export const tripWeatherResponseSchema = z.object({
@@ -13,10 +31,12 @@ export const tripWeatherResponseSchema = z.object({
   message: z.string().optional(),
   location: z.string().optional(),
   forecasts: z.array(dailyForecastSchema),
+  hourly: z.array(hourlyForecastSchema),
   fetchedAt: z.string().nullable(),
 });
 
 export type DailyForecastSchema = z.infer<typeof dailyForecastSchema>;
+export type HourlyForecastSchema = z.infer<typeof hourlyForecastSchema>;
 export type TripWeatherResponseSchema = z.infer<
   typeof tripWeatherResponseSchema
 >;

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -131,6 +131,8 @@ export type { ThemeFont, ThemeBackground, ThemePreset } from "./theme";
 export type {
   TemperatureUnit,
   DailyForecast,
+  HourlyForecast,
+  DailyForecastExtended,
   TripWeatherResponse,
 } from "./weather";
 

--- a/shared/types/weather.ts
+++ b/shared/types/weather.ts
@@ -8,10 +8,32 @@ export interface DailyForecast {
   precipitationProbability: number; // 0-100
 }
 
+export interface HourlyForecast {
+  time: string; // ISO datetime "2026-04-16T15:00"
+  temperature: number; // Celsius
+  weatherCode: number; // WMO code
+  windSpeed: number; // km/h
+  humidity: number; // 0-100%
+  uvIndex: number;
+  dewPoint: number; // Celsius
+  precipitationProbability: number; // 0-100
+}
+
+export interface DailyForecastExtended extends DailyForecast {
+  sunrise: string; // "06:12"
+  sunset: string; // "19:48"
+  windSpeedMax: number; // km/h
+  windDirectionDominant: number; // degrees (0-360)
+  uvIndexMax: number;
+  apparentTemperatureMax: number; // Celsius (feels like)
+  apparentTemperatureMin: number;
+}
+
 export interface TripWeatherResponse {
   available: boolean;
   message?: string;
   location?: string;
-  forecasts: DailyForecast[];
+  forecasts: DailyForecastExtended[];
+  hourly: HourlyForecast[];
   fetchedAt: string | null;
 }


### PR DESCRIPTION
## Summary

- Tappable day tiles in weather forecast section open a detail sheet with richer data
- Detail sheet shows adaptive day header (today: current temp + feels like; future: icon + high/low)
- Scrollable hourly forecast cards every 3h (12am–12am), anchored to current hour for today
- 2×3 detail card grid: Wind, UV Index, Humidity, Precipitation, Sunrise, Sunset (Lucide icons)
- Prev/next arrow buttons to navigate between forecast days
- Backend expands single Open-Meteo fetch with hourly + extended daily params (no extra API calls)
- Cache compat guard auto-refreshes old entries missing hourly data
- Sheet inherits trip theme (isDark, tone colors)

## Test plan

- [x] Weather utils unit tests (windDegreesToCompass, uvIndexLevel, getHourlyForDay, getAnchorHourIndex)
- [x] Weather service tests (extended parsing, hourly arrays, cache compat guard, unavailable responses)
- [x] TypeScript strict mode passes
- [ ] Manual QA: tap day tile → sheet opens with hourly cards + detail grid
- [ ] Manual QA: prev/next navigation between days
- [ ] Manual QA: verify theme inheritance (light/dark)

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)