### PR TITLE
Show wind speed in mph when Fahrenheit is selected

### DIFF
--- a/apps/web/src/components/itinerary/weather-detail-sheet.tsx
+++ b/apps/web/src/components/itinerary/weather-detail-sheet.tsx
@@ -30,6 +30,8 @@ import {
 import {
   getWeatherInfo,
   toDisplayTemp,
+  toDisplayWindSpeed,
+  windSpeedUnit,
   TONE_STYLES,
 } from "@/lib/weather-codes";
 import {
@@ -312,7 +314,7 @@ export const WeatherDetailSheet = memo(function WeatherDetailSheet({
                     <span
                       className={`text-[0.625rem] ${isDark ? "text-foreground/60" : "text-muted-foreground"}`}
                     >
-                      {Math.round(hour.windSpeed)} km/h
+                      {toDisplayWindSpeed(hour.windSpeed, temperatureUnit)} {windSpeedUnit(temperatureUnit)}
                     </span>
                   </div>
                 );
@@ -325,7 +327,7 @@ export const WeatherDetailSheet = memo(function WeatherDetailSheet({
             <DetailCard
               icon={Wind}
               label="Wind"
-              value={`${Math.round(forecast.windSpeedMax)} km/h`}
+              value={`${toDisplayWindSpeed(forecast.windSpeedMax, temperatureUnit)} ${windSpeedUnit(temperatureUnit)}`}
               secondary={windDegreesToCompass(forecast.windDirectionDominant)}
               isDark={isDark}
             />

--- a/apps/web/src/lib/weather-codes.test.ts
+++ b/apps/web/src/lib/weather-codes.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { toDisplayTemp } from "./weather-codes";
+import { toDisplayTemp, toDisplayWindSpeed, windSpeedUnit } from "./weather-codes";
 
 describe("toDisplayTemp", () => {
   it("rounds celsius values to nearest integer", () => {
@@ -31,5 +31,32 @@ describe("toDisplayTemp", () => {
 
   it("handles negative celsius in celsius mode", () => {
     expect(toDisplayTemp(-5.3, "celsius")).toBe(-5);
+  });
+});
+
+describe("toDisplayWindSpeed", () => {
+  it("rounds km/h for celsius (metric)", () => {
+    expect(toDisplayWindSpeed(10, "celsius")).toBe(10);
+    expect(toDisplayWindSpeed(10.7, "celsius")).toBe(11);
+  });
+
+  it("converts km/h to mph for fahrenheit (imperial)", () => {
+    expect(toDisplayWindSpeed(10, "fahrenheit")).toBe(6);
+    expect(toDisplayWindSpeed(100, "fahrenheit")).toBe(62);
+  });
+
+  it("handles zero", () => {
+    expect(toDisplayWindSpeed(0, "fahrenheit")).toBe(0);
+    expect(toDisplayWindSpeed(0, "celsius")).toBe(0);
+  });
+});
+
+describe("windSpeedUnit", () => {
+  it("returns km/h for celsius", () => {
+    expect(windSpeedUnit("celsius")).toBe("km/h");
+  });
+
+  it("returns mph for fahrenheit", () => {
+    expect(windSpeedUnit("fahrenheit")).toBe("mph");
   });
 });

--- a/apps/web/src/lib/weather-codes.ts
+++ b/apps/web/src/lib/weather-codes.ts
@@ -146,3 +146,22 @@ export function toDisplayTemp(celsius: number, unit: TemperatureUnit): number {
   }
   return Math.round(celsius);
 }
+
+/**
+ * Convert wind speed from km/h to the requested unit and round.
+ * Fahrenheit preference implies imperial (mph).
+ */
+export function toDisplayWindSpeed(
+  kmh: number,
+  unit: TemperatureUnit,
+): number {
+  if (unit === "fahrenheit") {
+    return Math.round(kmh * 0.621371);
+  }
+  return Math.round(kmh);
+}
+
+/** Return the wind speed unit label for the given preference. */
+export function windSpeedUnit(unit: TemperatureUnit): string {
+  return unit === "fahrenheit" ? "mph" : "km/h";
+}


### PR DESCRIPTION
## Summary

- Add `toDisplayWindSpeed()` and `windSpeedUnit()` helpers to convert km/h → mph when user preference is Fahrenheit
- Update weather detail sheet hourly cards and Wind detail card to use dynamic unit conversion
- Wind displays as km/h for Celsius (metric) and mph for Fahrenheit (imperial)

## Test plan

- [x] Unit tests for `toDisplayWindSpeed` (0, 10, 100 km/h in both unit modes)
- [x] Unit tests for `windSpeedUnit` (returns "km/h" or "mph")
- [x] TypeScript strict mode passes
- [ ] Manual QA: toggle between °C/°F in profile settings, verify wind units change

🤖 Generated with [Claude Code](https://claude.com/claude-code)