### PR TITLE
feat(#119): structured links with optional display names

### DIFF
--- a/apps/api/src/db/migrations/0030_magenta_black_tarantula.sql
+++ b/apps/api/src/db/migrations/0030_magenta_black_tarantula.sql
@@ -1,0 +1,24 @@
+-- Convert events.links and accommodations.links from text[] to jsonb
+-- Storing structured { url, name? } objects instead of plain URL strings.
+-- Existing plain URLs become [{"url": "..."}] (no name) so callers reading
+-- the new shape see the URL fall back when name is absent.
+
+ALTER TABLE "events" ADD COLUMN "links_new" jsonb;--> statement-breakpoint
+UPDATE "events"
+SET "links_new" = (
+  SELECT jsonb_agg(jsonb_build_object('url', x))
+  FROM unnest("links") AS x
+)
+WHERE "links" IS NOT NULL AND array_length("links", 1) > 0;--> statement-breakpoint
+ALTER TABLE "events" DROP COLUMN "links";--> statement-breakpoint
+ALTER TABLE "events" RENAME COLUMN "links_new" TO "links";--> statement-breakpoint
+
+ALTER TABLE "accommodations" ADD COLUMN "links_new" jsonb;--> statement-breakpoint
+UPDATE "accommodations"
+SET "links_new" = (
+  SELECT jsonb_agg(jsonb_build_object('url', x))
+  FROM unnest("links") AS x
+)
+WHERE "links" IS NOT NULL AND array_length("links", 1) > 0;--> statement-breakpoint
+ALTER TABLE "accommodations" DROP COLUMN "links";--> statement-breakpoint
+ALTER TABLE "accommodations" RENAME COLUMN "links_new" TO "links";

--- a/apps/api/src/db/migrations/meta/0030_snapshot.json
+++ b/apps/api/src/db/migrations/meta/0030_snapshot.json
@@ -1,0 +1,3395 @@
+{
+  "id": "8289b5ca-90c8-4407-aba3-e776967aac7d",
+  "prevId": "8a078fc4-b439-480f-b78c-daaebb6d8177",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accommodations": {
+      "name": "accommodations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "check_in": {
+          "name": "check_in",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_out": {
+          "name": "check_out",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "links": {
+          "name": "links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accommodations_trip_id_idx": {
+          "name": "accommodations_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_created_by_idx": {
+          "name": "accommodations_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_check_in_idx": {
+          "name": "accommodations_check_in_idx",
+          "columns": [
+            {
+              "expression": "check_in",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_deleted_at_idx": {
+          "name": "accommodations_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_trip_id_deleted_at_idx": {
+          "name": "accommodations_trip_id_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_trip_id_not_deleted_idx": {
+          "name": "accommodations_trip_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accommodations\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accommodations_trip_id_trips_id_fk": {
+          "name": "accommodations_trip_id_trips_id_fk",
+          "tableFrom": "accommodations",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accommodations_created_by_users_id_fk": {
+          "name": "accommodations_created_by_users_id_fk",
+          "tableFrom": "accommodations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "accommodations_deleted_by_users_id_fk": {
+          "name": "accommodations_deleted_by_users_id_fk",
+          "tableFrom": "accommodations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.affiliate_dismissals": {
+      "name": "affiliate_dismissals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestion_type": {
+          "name": "suggestion_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestion_key": {
+          "name": "suggestion_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "affiliate_dismissals_user_trip_idx": {
+          "name": "affiliate_dismissals_user_trip_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "affiliate_dismissals_unique_idx": {
+          "name": "affiliate_dismissals_unique_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "suggestion_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "suggestion_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "affiliate_dismissals_user_id_users_id_fk": {
+          "name": "affiliate_dismissals_user_id_users_id_fk",
+          "tableFrom": "affiliate_dismissals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "affiliate_dismissals_trip_id_trips_id_fk": {
+          "name": "affiliate_dismissals_trip_id_trips_id_fk",
+          "tableFrom": "affiliate_dismissals",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.affiliate_events": {
+      "name": "affiliate_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_slug": {
+          "name": "partner_slug",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestion_type": {
+          "name": "suggestion_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "affiliate_events_user_trip_idx": {
+          "name": "affiliate_events_user_trip_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "affiliate_events_created_at_idx": {
+          "name": "affiliate_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "affiliate_events_user_id_users_id_fk": {
+          "name": "affiliate_events_user_id_users_id_fk",
+          "tableFrom": "affiliate_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "affiliate_events_trip_id_trips_id_fk": {
+          "name": "affiliate_events_trip_id_trips_id_fk",
+          "tableFrom": "affiliate_events",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_attempts": {
+      "name": "auth_attempts",
+      "schema": "",
+      "columns": {
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_failed_at": {
+          "name": "last_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blacklisted_tokens": {
+      "name": "blacklisted_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "jti": {
+          "name": "jti",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blacklisted_tokens_expires_at_idx": {
+          "name": "blacklisted_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blacklisted_tokens_user_id_users_id_fk": {
+          "name": "blacklisted_tokens_user_id_users_id_fk",
+          "tableFrom": "blacklisted_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "blacklisted_tokens_jti_unique": {
+          "name": "blacklisted_tokens_jti_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "jti"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meetup_location": {
+          "name": "meetup_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meetup_time": {
+          "name": "meetup_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_day": {
+          "name": "all_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_optional": {
+          "name": "is_optional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "links": {
+          "name": "links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_trip_id_idx": {
+          "name": "events_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_created_by_idx": {
+          "name": "events_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_start_time_idx": {
+          "name": "events_start_time_idx",
+          "columns": [
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_deleted_at_idx": {
+          "name": "events_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_trip_id_deleted_at_idx": {
+          "name": "events_trip_id_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_trip_id_not_deleted_idx": {
+          "name": "events_trip_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_trip_id_trips_id_fk": {
+          "name": "events_trip_id_trips_id_fk",
+          "tableFrom": "events",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_created_by_users_id_fk": {
+          "name": "events_created_by_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_deleted_by_users_id_fk": {
+          "name": "events_deleted_by_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flight_cache": {
+      "name": "flight_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "flight_number": {
+          "name": "flight_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "flight_cache_flight_number_date_unique": {
+          "name": "flight_cache_flight_number_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "flight_number",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_phone": {
+          "name": "invitee_phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitations_trip_id_idx": {
+          "name": "invitations_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_invitee_phone_idx": {
+          "name": "invitations_invitee_phone_idx",
+          "columns": [
+            {
+              "expression": "invitee_phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_trip_id_trips_id_fk": {
+          "name": "invitations_trip_id_trips_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_id_users_id_fk": {
+          "name": "invitations_inviter_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitations_trip_phone_unique": {
+          "name": "invitations_trip_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trip_id",
+            "invitee_phone"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member_travel": {
+      "name": "member_travel",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "travel_type": {
+          "name": "travel_type",
+          "type": "member_travel_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flight_number": {
+          "name": "flight_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_travel_trip_id_idx": {
+          "name": "member_travel_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_member_id_idx": {
+          "name": "member_travel_member_id_idx",
+          "columns": [
+            {
+              "expression": "member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_time_idx": {
+          "name": "member_travel_time_idx",
+          "columns": [
+            {
+              "expression": "time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_deleted_at_idx": {
+          "name": "member_travel_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_member_id_deleted_at_idx": {
+          "name": "member_travel_member_id_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_trip_id_deleted_at_idx": {
+          "name": "member_travel_trip_id_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_trip_id_not_deleted_idx": {
+          "name": "member_travel_trip_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"member_travel\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_travel_trip_id_trips_id_fk": {
+          "name": "member_travel_trip_id_trips_id_fk",
+          "tableFrom": "member_travel",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_travel_member_id_members_id_fk": {
+          "name": "member_travel_member_id_members_id_fk",
+          "tableFrom": "member_travel",
+          "tableTo": "members",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_travel_deleted_by_users_id_fk": {
+          "name": "member_travel_deleted_by_users_id_fk",
+          "tableFrom": "member_travel",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "rsvp_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'no_response'"
+        },
+        "is_organizer": {
+          "name": "is_organizer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "share_phone": {
+          "name": "share_phone",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "calendar_excluded": {
+          "name": "calendar_excluded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "members_trip_id_idx": {
+          "name": "members_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "members_user_id_idx": {
+          "name": "members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "members_trip_id_is_organizer_idx": {
+          "name": "members_trip_id_is_organizer_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_organizer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "members_trip_id_trips_id_fk": {
+          "name": "members_trip_id_trips_id_fk",
+          "tableFrom": "members",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "members_user_id_users_id_fk": {
+          "name": "members_user_id_users_id_fk",
+          "tableFrom": "members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "members_trip_user_unique": {
+          "name": "members_trip_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trip_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_reactions": {
+      "name": "message_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_reactions_message_id_idx": {
+          "name": "message_reactions_message_id_idx",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_reactions_user_id_idx": {
+          "name": "message_reactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_reactions_message_id_messages_id_fk": {
+          "name": "message_reactions_message_id_messages_id_fk",
+          "tableFrom": "message_reactions",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_reactions_user_id_users_id_fk": {
+          "name": "message_reactions_user_id_users_id_fk",
+          "tableFrom": "message_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "message_reactions_message_user_emoji_unique": {
+          "name": "message_reactions_message_user_emoji_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id",
+            "user_id",
+            "emoji"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_trip_id_created_at_idx": {
+          "name": "messages_trip_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_parent_id_idx": {
+          "name": "messages_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_author_id_idx": {
+          "name": "messages_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_trip_toplevel_idx": {
+          "name": "messages_trip_toplevel_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"messages\".\"parent_id\" IS NULL AND \"messages\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_trip_id_not_deleted_idx": {
+          "name": "messages_trip_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"messages\".\"deleted_at\" IS NULL AND \"messages\".\"parent_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_trip_id_trips_id_fk": {
+          "name": "messages_trip_id_trips_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_author_id_users_id_fk": {
+          "name": "messages_author_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_parent_id_messages_id_fk": {
+          "name": "messages_parent_id_messages_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_deleted_by_users_id_fk": {
+          "name": "messages_deleted_by_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.muted_members": {
+      "name": "muted_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted_by": {
+          "name": "muted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "muted_members_trip_id_trips_id_fk": {
+          "name": "muted_members_trip_id_trips_id_fk",
+          "tableFrom": "muted_members",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "muted_members_user_id_users_id_fk": {
+          "name": "muted_members_user_id_users_id_fk",
+          "tableFrom": "muted_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "muted_members_muted_by_users_id_fk": {
+          "name": "muted_members_muted_by_users_id_fk",
+          "tableFrom": "muted_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "muted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "muted_members_trip_user_unique": {
+          "name": "muted_members_trip_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trip_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daily_itinerary": {
+          "name": "daily_itinerary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "trip_messages": {
+          "name": "trip_messages",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_user_id_users_id_fk": {
+          "name": "notification_preferences_user_id_users_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_preferences_trip_id_trips_id_fk": {
+          "name": "notification_preferences_trip_id_trips_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_preferences_user_trip_unique": {
+          "name": "notification_preferences_user_trip_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "trip_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_created_at_idx": {
+          "name": "notifications_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_id_created_at_desc_idx": {
+          "name": "notifications_user_id_created_at_desc_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notifications\".\"read_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_trip_user_created_at_idx": {
+          "name": "notifications_trip_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_trip_id_trips_id_fk": {
+          "name": "notifications_trip_id_trips_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_participants": {
+      "name": "payment_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_amount": {
+          "name": "share_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_participants_payment_id_idx": {
+          "name": "payment_participants_payment_id_idx",
+          "columns": [
+            {
+              "expression": "payment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_participants_user_id_idx": {
+          "name": "payment_participants_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_participants_guest_id_idx": {
+          "name": "payment_participants_guest_id_idx",
+          "columns": [
+            {
+              "expression": "guest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_participants_payment_id_payments_id_fk": {
+          "name": "payment_participants_payment_id_payments_id_fk",
+          "tableFrom": "payment_participants",
+          "tableTo": "payments",
+          "columnsFrom": [
+            "payment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_participants_user_id_users_id_fk": {
+          "name": "payment_participants_user_id_users_id_fk",
+          "tableFrom": "payment_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_participants_guest_id_trip_guests_id_fk": {
+          "name": "payment_participants_guest_id_trip_guests_id_fk",
+          "tableFrom": "payment_participants",
+          "tableTo": "trip_guests",
+          "columnsFrom": [
+            "guest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payments_trip_id_not_deleted_idx": {
+          "name": "payments_trip_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"payments\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_user_id_idx": {
+          "name": "payments_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_guest_id_idx": {
+          "name": "payments_guest_id_idx",
+          "columns": [
+            {
+              "expression": "guest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_trip_id_trips_id_fk": {
+          "name": "payments_trip_id_trips_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payments_user_id_users_id_fk": {
+          "name": "payments_user_id_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payments_guest_id_trip_guests_id_fk": {
+          "name": "payments_guest_id_trip_guests_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "trip_guests",
+          "columnsFrom": [
+            "guest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payments_created_by_users_id_fk": {
+          "name": "payments_created_by_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_subscriptions_user_id_idx": {
+          "name": "push_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_id_users_id_fk": {
+          "name": "push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_subscriptions_endpoint_unique": {
+          "name": "push_subscriptions_endpoint_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "endpoint"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_entries": {
+      "name": "rate_limit_entries",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rate_limit_entries_expires_at_idx": {
+          "name": "rate_limit_entries_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sent_reminders": {
+      "name": "sent_reminders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sent_reminders_type_ref_idx": {
+          "name": "sent_reminders_type_ref_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sent_reminders_user_id_users_id_fk": {
+          "name": "sent_reminders_user_id_users_id_fk",
+          "tableFrom": "sent_reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sent_reminders_type_ref_user_unique": {
+          "name": "sent_reminders_type_ref_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "type",
+            "reference_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trip_guests": {
+      "name": "trip_guests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trip_guests_trip_id_idx": {
+          "name": "trip_guests_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trip_guests_trip_id_trips_id_fk": {
+          "name": "trip_guests_trip_id_trips_id_fk",
+          "tableFrom": "trip_guests",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_guests_created_by_users_id_fk": {
+          "name": "trip_guests_created_by_users_id_fk",
+          "tableFrom": "trip_guests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trip_photos": {
+      "name": "trip_photos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "photo_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trip_photos_trip_id_idx": {
+          "name": "trip_photos_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trip_photos_uploaded_by_idx": {
+          "name": "trip_photos_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trip_photos_trip_id_trips_id_fk": {
+          "name": "trip_photos_trip_id_trips_id_fk",
+          "tableFrom": "trip_photos",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_photos_uploaded_by_users_id_fk": {
+          "name": "trip_photos_uploaded_by_users_id_fk",
+          "tableFrom": "trip_photos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trips": {
+      "name": "trips",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_lat": {
+          "name": "destination_lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_lon": {
+          "name": "destination_lon",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_display_name": {
+          "name": "destination_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_timezone": {
+          "name": "preferred_timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_id": {
+          "name": "theme_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_font": {
+          "name": "theme_font",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allow_members_to_add_events": {
+          "name": "allow_members_to_add_events",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_all_members": {
+          "name": "show_all_members",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancelled": {
+          "name": "cancelled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trips_created_by_idx": {
+          "name": "trips_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trips_created_by_users_id_fk": {
+          "name": "trips_created_by_users_id_fk",
+          "tableFrom": "trips",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_photo_url": {
+          "name": "profile_photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handles": {
+          "name": "handles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature_unit": {
+          "name": "temperature_unit",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'celsius'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "calendar_token": {
+          "name": "calendar_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_at": {
+          "name": "sms_consent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_version": {
+          "name": "sms_consent_version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "users_phone_number_idx": {
+          "name": "users_phone_number_idx",
+          "columns": [
+            {
+              "expression": "phone_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_phone_number_unique": {
+          "name": "users_phone_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone_number"
+          ]
+        },
+        "users_calendar_token_unique": {
+          "name": "users_calendar_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "calendar_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weather_cache": {
+      "name": "weather_cache",
+      "schema": "",
+      "columns": {
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "weather_cache_trip_id_trips_id_fk": {
+          "name": "weather_cache_trip_id_trips_id_fk",
+          "tableFrom": "weather_cache",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.event_type": {
+      "name": "event_type",
+      "schema": "public",
+      "values": [
+        "travel",
+        "meal",
+        "activity"
+      ]
+    },
+    "public.invitation_status": {
+      "name": "invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "declined",
+        "failed"
+      ]
+    },
+    "public.member_travel_type": {
+      "name": "member_travel_type",
+      "schema": "public",
+      "values": [
+        "arrival",
+        "departure"
+      ]
+    },
+    "public.photo_status": {
+      "name": "photo_status",
+      "schema": "public",
+      "values": [
+        "processing",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.rsvp_status": {
+      "name": "rsvp_status",
+      "schema": "public",
+      "values": [
+        "going",
+        "not_going",
+        "maybe",
+        "no_response"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1776010793362,
       "tag": "0029_daily_boom_boom",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1777137286277,
+      "tag": "0030_magenta_black_tarantula",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -16,6 +16,7 @@ import {
   integer,
   doublePrecision,
 } from "drizzle-orm/pg-core";
+import type { LinkItem } from "@journiful/shared/types";
 
 // Users table
 export const users = pgTable(
@@ -211,7 +212,7 @@ export const events = pgTable(
     endTime: timestamp("end_time", { withTimezone: true }),
     allDay: boolean("all_day").notNull().default(false),
     isOptional: boolean("is_optional").notNull().default(false),
-    links: text("links").array(),
+    links: jsonb("links").$type<LinkItem[]>(),
     deletedAt: timestamp("deleted_at", { withTimezone: true }),
     deletedBy: uuid("deleted_by").references(() => users.id),
     createdAt: timestamp("created_at", { withTimezone: true })
@@ -253,7 +254,7 @@ export const accommodations = pgTable(
     description: text("description"),
     checkIn: timestamp("check_in", { withTimezone: true }).notNull(),
     checkOut: timestamp("check_out", { withTimezone: true }).notNull(),
-    links: text("links").array(),
+    links: jsonb("links").$type<LinkItem[]>(),
     deletedAt: timestamp("deleted_at", { withTimezone: true }),
     deletedBy: uuid("deleted_by").references(() => users.id),
     createdAt: timestamp("created_at", { withTimezone: true })

--- a/apps/api/src/services/calendar.service.ts
+++ b/apps/api/src/services/calendar.service.ts
@@ -212,7 +212,10 @@ export class CalendarService implements ICalendarService {
         // Links
         if (event.links && event.links.length > 0) {
           descriptionParts.push(
-            "Links:\n" + event.links.map((l) => `- ${l}`).join("\n"),
+            "Links:\n" +
+              event.links
+                .map((l) => (l.name ? `- ${l.name}: ${l.url}` : `- ${l.url}`))
+                .join("\n"),
           );
         }
 
@@ -261,7 +264,10 @@ export class CalendarService implements ICalendarService {
 
         if (acc.links && acc.links.length > 0) {
           descriptionParts.push(
-            "Links:\n" + acc.links.map((l) => `- ${l}`).join("\n"),
+            "Links:\n" +
+              acc.links
+                .map((l) => (l.name ? `- ${l.name}: ${l.url}` : `- ${l.url}`))
+                .join("\n"),
           );
         }
 

--- a/apps/api/tests/integration/itinerary-schema.test.ts
+++ b/apps/api/tests/integration/itinerary-schema.test.ts
@@ -72,7 +72,10 @@ describe("Itinerary Schema Integration", () => {
         endTime: new Date("2026-03-15T20:00:00Z"),
         allDay: false,
         isOptional: false,
-        links: ["https://restaurant.example.com", "https://maps.example.com"],
+        links: [
+          { url: "https://restaurant.example.com", name: "Restaurant" },
+          { url: "https://maps.example.com" },
+        ],
       };
 
       const result = await db.insert(events).values(eventData).returning();
@@ -218,7 +221,10 @@ describe("Itinerary Schema Integration", () => {
         description: "Luxury hotel with ocean view",
         checkIn: new Date("2026-03-15T14:00:00.000Z"),
         checkOut: new Date("2026-03-20T11:00:00.000Z"),
-        links: ["https://hotel.example.com", "https://booking.example.com/123"],
+        links: [
+          { url: "https://hotel.example.com", name: "Hotel website" },
+          { url: "https://booking.example.com/123" },
+        ],
       };
 
       const result = await db
@@ -600,7 +606,10 @@ describe("Itinerary Schema Integration", () => {
         startTime: new Date("2026-03-16T12:00:00Z"),
         allDay: false,
         isOptional: false,
-        links: [testUrl, "https://other-url.example.com"],
+        links: [
+          { url: testUrl },
+          { url: "https://other-url.example.com" },
+        ],
       });
 
       // Note: Drizzle doesn't have built-in array contains, but we can verify the data
@@ -610,11 +619,35 @@ describe("Itinerary Schema Integration", () => {
         .where(eq(events.tripId, testTripId));
 
       const eventsWithUrl = allEvents.filter(
-        (e) => e.links && e.links.includes(testUrl),
+        (e) => e.links?.some((link) => link.url === testUrl),
       );
 
       expect(eventsWithUrl).toHaveLength(1);
       expect(eventsWithUrl[0]!.name).toBe("Event with specific link");
+    });
+
+    it("should round-trip links with optional name", async () => {
+      const eventData = {
+        tripId: testTripId,
+        createdBy: testUserId,
+        name: "Event with named links",
+        eventType: "activity" as const,
+        startTime: new Date("2026-03-16T13:00:00Z"),
+        allDay: false,
+        isOptional: false,
+        links: [
+          { url: "https://reservation.example.com", name: "Reservation" },
+          { url: "https://maps.example.com" },
+        ],
+      };
+
+      const result = await db.insert(events).values(eventData).returning();
+      const queried = await db
+        .select()
+        .from(events)
+        .where(eq(events.id, result[0]!.id));
+
+      expect(queried[0]!.links).toEqual(eventData.links);
     });
   });
 });

--- a/apps/api/tests/unit/accommodation.service.test.ts
+++ b/apps/api/tests/unit/accommodation.service.test.ts
@@ -146,7 +146,7 @@ describe("accommodation.service", () => {
         description: "Luxury beachfront resort",
         checkIn: "2026-07-01T14:00:00.000Z",
         checkOut: "2026-07-10T11:00:00.000Z",
-        links: ["https://resort.example.com"],
+        links: [{ url: "https://resort.example.com" }],
       };
 
       const accommodation = await accommodationService.createAccommodation(
@@ -563,8 +563,8 @@ describe("accommodation.service", () => {
         checkIn: "2026-10-01T14:00:00.000Z",
         checkOut: "2026-10-05T11:00:00.000Z",
         links: [
-          "https://booking.example.com",
-          "https://confirmation.example.com",
+          { url: "https://booking.example.com" },
+          { url: "https://confirmation.example.com" },
         ],
       };
 
@@ -576,6 +576,28 @@ describe("accommodation.service", () => {
 
       expect(accommodation.links).toHaveLength(2);
       expect(accommodation.links).toEqual(accommodationData.links);
+    });
+
+    it("should handle accommodation with named links", async () => {
+      const accommodationData = {
+        name: "Hotel with Named Links",
+        checkIn: "2026-10-10T14:00:00.000Z",
+        checkOut: "2026-10-12T11:00:00.000Z",
+        links: [
+          { url: "https://airbnb.example.com/listing", name: "Airbnb" },
+          { url: "https://maps.example.com/hotel" },
+        ],
+      };
+
+      const accommodation = await accommodationService.createAccommodation(
+        testOrganizerId,
+        testTripId,
+        accommodationData,
+      );
+
+      expect(accommodation.links).toEqual(accommodationData.links);
+      expect(accommodation.links?.[0]?.name).toBe("Airbnb");
+      expect(accommodation.links?.[1]?.name).toBeUndefined();
     });
 
     it("should handle same-day check-in and check-out as invalid", async () => {

--- a/apps/api/tests/unit/calendar.service.test.ts
+++ b/apps/api/tests/unit/calendar.service.test.ts
@@ -48,7 +48,7 @@ function makeEvent(overrides: Partial<Event> = {}): Event {
     endTime: new Date("2026-07-02T12:00:00Z"),
     allDay: false,
     isOptional: false,
-    links: ["https://reef-tours.example.com"],
+    links: [{ url: "https://reef-tours.example.com" }],
     deletedAt: null,
     deletedBy: null,
     createdAt: new Date("2026-01-01T00:00:00Z"),
@@ -69,7 +69,7 @@ function makeAccommodation(
     description: "Oceanfront hotel with pool",
     checkIn: new Date("2026-07-01T15:00:00Z"),
     checkOut: new Date("2026-07-05T11:00:00Z"),
-    links: ["https://seaside-resort.example.com"],
+    links: [{ url: "https://seaside-resort.example.com" }],
     deletedAt: null,
     deletedBy: null,
     createdAt: new Date("2026-01-01T00:00:00Z"),
@@ -267,7 +267,10 @@ describe("CalendarService.generateIcsFeed", () => {
         meetupTime: new Date("2026-07-02T08:30:00Z"),
         meetupLocation: "Hotel Lobby",
         description: "Great reef trip",
-        links: ["https://reef-tours.example.com", "https://maps.example.com"],
+        links: [
+          { url: "https://reef-tours.example.com" },
+          { url: "https://maps.example.com" },
+        ],
         allDay: false,
       });
       const ics = service.generateIcsFeed([{ trip, events: [event], accommodations: [] }]);
@@ -278,6 +281,27 @@ describe("CalendarService.generateIcsFeed", () => {
       expect(ics).toContain("Links:");
       expect(ics).toContain("https://reef-tours.example.com");
       expect(ics).toContain("https://maps.example.com");
+    });
+
+    it("should format named links as 'Name: url' and bare links as just url", () => {
+      const trip = makeTrip({ startDate: null });
+      const event = makeEvent({
+        meetupTime: null,
+        meetupLocation: null,
+        description: null,
+        links: [
+          { url: "https://reef-tours.example.com", name: "Reef Tours" },
+          { url: "https://maps.example.com" },
+        ],
+        allDay: false,
+      });
+      const ics = unfold(
+        service.generateIcsFeed([{ trip, events: [event], accommodations: [] }]),
+      );
+
+      expect(ics).toContain("- Reef Tours: https://reef-tours.example.com");
+      expect(ics).toContain("- https://maps.example.com");
+      expect(ics).not.toContain("- https://reef-tours.example.com");
     });
 
     it("should handle missing optional fields gracefully", () => {
@@ -471,7 +495,7 @@ describe("CalendarService.generateIcsFeed", () => {
       const trip = makeTrip({ startDate: null });
       const acc = makeAccommodation({
         description: "Oceanfront hotel with pool",
-        links: ["https://seaside-resort.example.com"],
+        links: [{ url: "https://seaside-resort.example.com" }],
       });
       const ics = unfold(
         service.generateIcsFeed([
@@ -482,6 +506,25 @@ describe("CalendarService.generateIcsFeed", () => {
       expect(ics).toContain("Oceanfront hotel with pool");
       expect(ics).toContain("Links:");
       expect(ics).toContain("https://seaside-resort.example.com");
+    });
+
+    it("should format named accommodation links as 'Name: url'", () => {
+      const trip = makeTrip({ startDate: null });
+      const acc = makeAccommodation({
+        description: null,
+        links: [
+          { url: "https://airbnb.example.com/listing", name: "Airbnb" },
+          { url: "https://maps.example.com/hotel" },
+        ],
+      });
+      const ics = unfold(
+        service.generateIcsFeed([
+          { trip, events: [], accommodations: [acc] },
+        ]),
+      );
+
+      expect(ics).toContain("- Airbnb: https://airbnb.example.com/listing");
+      expect(ics).toContain("- https://maps.example.com/hotel");
     });
   });
 });

--- a/apps/api/tests/unit/event.service.test.ts
+++ b/apps/api/tests/unit/event.service.test.ts
@@ -148,7 +148,7 @@ describe("event.service", () => {
         endTime: "2026-06-16T20:00:00Z",
         allDay: false,
         isOptional: false,
-        links: ["https://example.com"],
+        links: [{ url: "https://example.com" }],
       };
 
       const event = await eventService.createEvent(
@@ -542,8 +542,8 @@ describe("event.service", () => {
         eventType: "travel" as const,
         startTime: "2026-06-23T08:00:00Z",
         links: [
-          "https://example.com/booking",
-          "https://example.com/confirmation",
+          { url: "https://example.com/booking" },
+          { url: "https://example.com/confirmation" },
         ],
       };
 
@@ -555,6 +555,28 @@ describe("event.service", () => {
 
       expect(event.links).toHaveLength(2);
       expect(event.links).toEqual(eventData.links);
+    });
+
+    it("should handle event with named links", async () => {
+      const eventData = {
+        name: "Event with Named Link",
+        eventType: "activity" as const,
+        startTime: "2026-06-24T08:00:00Z",
+        links: [
+          { url: "https://example.com/reservation", name: "Reservation" },
+          { url: "https://maps.example.com" },
+        ],
+      };
+
+      const event = await eventService.createEvent(
+        testOrganizerId,
+        testTripId,
+        eventData,
+      );
+
+      expect(event.links).toEqual(eventData.links);
+      expect(event.links?.[0]?.name).toBe("Reservation");
+      expect(event.links?.[1]?.name).toBeUndefined();
     });
 
     it("should handle updating only time fields", async () => {

--- a/apps/web/src/components/itinerary/__tests__/create-accommodation-dialog.test.tsx
+++ b/apps/web/src/components/itinerary/__tests__/create-accommodation-dialog.test.tsx
@@ -232,7 +232,9 @@ describe("CreateAccommodationDialog", () => {
         />,
       );
 
-      const linkInput = screen.getByLabelText(/link url/i);
+      await user.click(screen.getByText("More details"));
+
+      const linkInput = await screen.findByLabelText(/link url/i);
       await user.type(linkInput, "https://example.com");
 
       const addButton = screen.getByRole("button", { name: /add link/i });
@@ -240,6 +242,36 @@ describe("CreateAccommodationDialog", () => {
 
       await waitFor(() => {
         expect(screen.getByText("https://example.com")).toBeDefined();
+      });
+    });
+
+    it("allows adding a link with a display name", async () => {
+      const user = userEvent.setup();
+      renderWithQueryClient(
+        <CreateAccommodationDialog
+          open={true}
+          onOpenChange={mockOnOpenChange}
+          tripId={tripId}
+          timezone="America/New_York"
+        />,
+      );
+
+      await user.click(screen.getByText("More details"));
+
+      const linkInput = await screen.findByLabelText(/link url/i);
+      await user.click(linkInput);
+      await user.paste("https://airbnb.example.com");
+
+      const nameInput = screen.getByLabelText(/link display name/i);
+      await user.click(nameInput);
+      await user.paste("Airbnb listing");
+
+      const addButton = screen.getByRole("button", { name: /add link/i });
+      await user.click(addButton);
+
+      await waitFor(() => {
+        expect(screen.getByText("Airbnb listing")).toBeDefined();
+        expect(screen.getByText("https://airbnb.example.com")).toBeDefined();
       });
     });
 
@@ -254,7 +286,9 @@ describe("CreateAccommodationDialog", () => {
         />,
       );
 
-      const linkInput = screen.getByLabelText(/link url/i);
+      await user.click(screen.getByText("More details"));
+
+      const linkInput = await screen.findByLabelText(/link url/i);
       await user.type(linkInput, "not a valid url");
 
       const addButton = screen.getByRole("button", { name: /add link/i });

--- a/apps/web/src/components/itinerary/__tests__/create-event-dialog.test.tsx
+++ b/apps/web/src/components/itinerary/__tests__/create-event-dialog.test.tsx
@@ -366,7 +366,8 @@ describe("CreateEventDialog", () => {
   });
 
   describe("Links field", () => {
-    it("shows link input field", () => {
+    it("shows link input field", async () => {
+      const user = userEvent.setup();
       renderWithQueryClient(
         <CreateEventDialog
           open={true}
@@ -376,7 +377,9 @@ describe("CreateEventDialog", () => {
         />,
       );
 
-      expect(screen.getByLabelText(/link url/i)).toBeDefined();
+      await user.click(screen.getByText("More details"));
+
+      expect(await screen.findByLabelText(/link url/i)).toBeDefined();
     });
 
     it("allows adding valid link", async () => {
@@ -390,7 +393,9 @@ describe("CreateEventDialog", () => {
         />,
       );
 
-      const linkInput = screen.getByLabelText(/link url/i);
+      await user.click(screen.getByText("More details"));
+
+      const linkInput = await screen.findByLabelText(/link url/i);
       await user.click(linkInput);
       await user.paste("https://example.com");
 
@@ -399,6 +404,36 @@ describe("CreateEventDialog", () => {
 
       await waitFor(() => {
         expect(screen.getByText("https://example.com")).toBeDefined();
+      });
+    });
+
+    it("allows adding a link with a display name", async () => {
+      const user = userEvent.setup();
+      renderWithQueryClient(
+        <CreateEventDialog
+          open={true}
+          onOpenChange={mockOnOpenChange}
+          tripId={tripId}
+          timezone="America/New_York"
+        />,
+      );
+
+      await user.click(screen.getByText("More details"));
+
+      const linkInput = await screen.findByLabelText(/link url/i);
+      await user.click(linkInput);
+      await user.paste("https://restaurant.example.com");
+
+      const nameInput = screen.getByLabelText(/link display name/i);
+      await user.click(nameInput);
+      await user.paste("Restaurant menu");
+
+      const addButton = screen.getByRole("button", { name: /add link/i });
+      await user.click(addButton);
+
+      await waitFor(() => {
+        expect(screen.getByText("Restaurant menu")).toBeDefined();
+        expect(screen.getByText("https://restaurant.example.com")).toBeDefined();
       });
     });
 
@@ -413,7 +448,9 @@ describe("CreateEventDialog", () => {
         />,
       );
 
-      const linkInput = screen.getByLabelText(/link url/i);
+      await user.click(screen.getByText("More details"));
+
+      const linkInput = await screen.findByLabelText(/link url/i);
       await user.type(linkInput, "not a valid url");
 
       const addButton = screen.getByRole("button", { name: /add link/i });
@@ -435,7 +472,9 @@ describe("CreateEventDialog", () => {
         />,
       );
 
-      const linkInput = screen.getByLabelText(/link url/i);
+      await user.click(screen.getByText("More details"));
+
+      const linkInput = await screen.findByLabelText(/link url/i);
       await user.type(linkInput, "https://example.com");
 
       const addButton = screen.getByRole("button", { name: /add link/i });

--- a/apps/web/src/components/itinerary/__tests__/edit-accommodation-dialog.test.tsx
+++ b/apps/web/src/components/itinerary/__tests__/edit-accommodation-dialog.test.tsx
@@ -37,7 +37,7 @@ describe("EditAccommodationDialog", () => {
     description: "Test description",
     checkIn: "2026-07-15T14:00:00.000Z",
     checkOut: "2026-07-20T11:00:00.000Z",
-    links: ["https://example.com"],
+    links: [{ url: "https://example.com" }],
     deletedAt: null,
     deletedBy: null,
     createdAt: new Date(),
@@ -158,7 +158,8 @@ describe("EditAccommodationDialog", () => {
       expect(checkOutButton.textContent).toMatch(/jul 20, 2026/i);
     });
 
-    it("pre-populates links", () => {
+    it("pre-populates links", async () => {
+      const user = userEvent.setup();
       renderWithQueryClient(
         <EditAccommodationDialog
           open={true}
@@ -168,7 +169,39 @@ describe("EditAccommodationDialog", () => {
         />,
       );
 
-      expect(screen.getByText("https://example.com")).toBeDefined();
+      await user.click(screen.getByText("More details"));
+
+      expect(await screen.findByText("https://example.com")).toBeDefined();
+    });
+
+    it("allows adding a link with a display name", async () => {
+      const user = userEvent.setup();
+      renderWithQueryClient(
+        <EditAccommodationDialog
+          open={true}
+          onOpenChange={mockOnOpenChange}
+          accommodation={mockAccommodation}
+          timezone="America/New_York"
+        />,
+      );
+
+      await user.click(screen.getByText("More details"));
+
+      const linkInput = await screen.findByLabelText(/link url/i);
+      await user.click(linkInput);
+      await user.paste("https://booking.example.com");
+
+      const nameInput = screen.getByLabelText(/link display name/i);
+      await user.click(nameInput);
+      await user.paste("Booking confirmation");
+
+      const addButton = screen.getByRole("button", { name: /add link/i });
+      await user.click(addButton);
+
+      await waitFor(() => {
+        expect(screen.getByText("Booking confirmation")).toBeDefined();
+        expect(screen.getByText("https://booking.example.com")).toBeDefined();
+      });
     });
   });
 

--- a/apps/web/src/components/itinerary/__tests__/edit-event-dialog.test.tsx
+++ b/apps/web/src/components/itinerary/__tests__/edit-event-dialog.test.tsx
@@ -42,7 +42,7 @@ describe("EditEventDialog", () => {
     endTime: new Date("2026-07-15T16:00:00.000Z"),
     allDay: false,
     isOptional: false,
-    links: ["https://example.com"],
+    links: [{ url: "https://example.com" }],
     deletedAt: null,
     deletedBy: null,
     createdAt: new Date(),
@@ -157,7 +157,8 @@ describe("EditEventDialog", () => {
       expect(startTimeButton.textContent).toMatch(/jul 15, 2026/i);
     });
 
-    it("pre-populates links", () => {
+    it("pre-populates links", async () => {
+      const user = userEvent.setup();
       renderWithQueryClient(
         <EditEventDialog
           open={true}
@@ -167,7 +168,9 @@ describe("EditEventDialog", () => {
         />,
       );
 
-      expect(screen.getByText("https://example.com")).toBeDefined();
+      await user.click(screen.getByText("More details"));
+
+      expect(await screen.findByText("https://example.com")).toBeDefined();
     });
 
     it("pre-populates checkbox fields", () => {
@@ -436,15 +439,47 @@ describe("EditEventDialog", () => {
         />,
       );
 
-      const linkInput = screen.getByLabelText(/link url/i);
+      await user.click(screen.getByText("More details"));
+
+      const linkInput = await screen.findByLabelText(/link url/i);
       await user.click(linkInput);
       await user.paste("https://newlink.com");
 
-      const addButton = screen.getByRole("button", { name: "" });
+      const addButton = screen.getByRole("button", { name: /add link/i });
       await user.click(addButton);
 
       await waitFor(() => {
         expect(screen.getByText("https://newlink.com")).toBeDefined();
+      });
+    });
+
+    it("allows adding a link with a display name", async () => {
+      const user = userEvent.setup();
+      renderWithQueryClient(
+        <EditEventDialog
+          open={true}
+          onOpenChange={mockOnOpenChange}
+          event={mockEvent}
+          timezone="America/New_York"
+        />,
+      );
+
+      await user.click(screen.getByText("More details"));
+
+      const linkInput = await screen.findByLabelText(/link url/i);
+      await user.click(linkInput);
+      await user.paste("https://booking.example.com");
+
+      const nameInput = screen.getByLabelText(/link display name/i);
+      await user.click(nameInput);
+      await user.paste("Booking confirmation");
+
+      const addButton = screen.getByRole("button", { name: /add link/i });
+      await user.click(addButton);
+
+      await waitFor(() => {
+        expect(screen.getByText("Booking confirmation")).toBeDefined();
+        expect(screen.getByText("https://booking.example.com")).toBeDefined();
       });
     });
 
@@ -459,7 +494,9 @@ describe("EditEventDialog", () => {
         />,
       );
 
-      const removeButton = screen.getByRole("button", {
+      await user.click(screen.getByText("More details"));
+
+      const removeButton = await screen.findByRole("button", {
         name: /remove https:\/\/example\.com/i,
       });
       await user.click(removeButton);

--- a/apps/web/src/components/itinerary/__tests__/event-card.test.tsx
+++ b/apps/web/src/components/itinerary/__tests__/event-card.test.tsx
@@ -19,7 +19,7 @@ describe("EventCard", () => {
     endTime: new Date("2026-07-15T14:00:00Z"),
     allDay: false,
     isOptional: false,
-    links: ["https://example.com/menu"],
+    links: [{ url: "https://example.com/menu" }],
     deletedAt: null,
     deletedBy: null,
     createdAt: new Date("2026-01-01T00:00:00Z"),

--- a/apps/web/src/components/itinerary/accommodation-detail-sheet.tsx
+++ b/apps/web/src/components/itinerary/accommodation-detail-sheet.tsx
@@ -195,16 +195,16 @@ export const AccommodationDetailSheet = memo(function AccommodationDetailSheet({
           {/* Links */}
           {accommodation.links && accommodation.links.length > 0 && (
             <div className="space-y-2">
-              {accommodation.links.map((link, index) => (
+              {accommodation.links.map((link) => (
                 <a
-                  key={index}
-                  href={link}
+                  key={link.url}
+                  href={link.url}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="flex items-center gap-2 text-sm text-primary hover:text-primary/80 transition-colors"
                 >
                   <ExternalLink className="w-3.5 h-3.5 shrink-0" />
-                  <span className="truncate">{link}</span>
+                  <span className="truncate">{link.name ?? link.url}</span>
                 </a>
               ))}
             </div>

--- a/apps/web/src/components/itinerary/create-accommodation-dialog.tsx
+++ b/apps/web/src/components/itinerary/create-accommodation-dialog.tsx
@@ -56,7 +56,10 @@ export function CreateAccommodationDialog({
   tripEndDate,
 }: CreateAccommodationDialogProps) {
   const { mutate: createAccommodation, isPending } = useCreateAccommodation();
-  const [newLink, setNewLink] = useState("");
+  const [newLink, setNewLink] = useState<{ url: string; name: string }>({
+    url: "",
+    name: "",
+  });
   const [linkError, setLinkError] = useState<string | null>(null);
 
   const form = useForm<CreateAccommodationInput>({
@@ -75,7 +78,7 @@ export function CreateAccommodationDialog({
   useEffect(() => {
     if (!open) {
       form.reset();
-      setNewLink("");
+      setNewLink({ url: "", name: "" });
       setLinkError(null);
     }
   }, [open, form]);
@@ -135,19 +138,19 @@ export function CreateAccommodationDialog({
   const handleAddLink = () => {
     setLinkError(null);
 
-    if (!newLink.trim()) {
+    if (!newLink.url.trim()) {
       setLinkError("URL is required");
       return;
     }
 
     // Auto-prepend https:// if no protocol is provided
-    let normalizedLink = newLink.trim();
-    if (!/^https?:\/\//i.test(normalizedLink)) {
-      normalizedLink = `https://${normalizedLink}`;
+    let normalizedUrl = newLink.url.trim();
+    if (!/^https?:\/\//i.test(normalizedUrl)) {
+      normalizedUrl = `https://${normalizedUrl}`;
     }
 
     try {
-      new URL(normalizedLink);
+      new URL(normalizedUrl);
     } catch {
       setLinkError("Please enter a valid URL");
       return;
@@ -159,20 +162,24 @@ export function CreateAccommodationDialog({
       return;
     }
 
-    if (currentLinks.includes(normalizedLink)) {
+    if (currentLinks.some((link) => link.url === normalizedUrl)) {
       setLinkError("This URL is already added");
       return;
     }
 
-    form.setValue("links", [...currentLinks, normalizedLink]);
-    setNewLink("");
+    const trimmedName = newLink.name.trim();
+    form.setValue("links", [
+      ...currentLinks,
+      { url: normalizedUrl, ...(trimmedName ? { name: trimmedName } : {}) },
+    ]);
+    setNewLink({ url: "", name: "" });
   };
 
-  const handleRemoveLink = (linkToRemove: string) => {
+  const handleRemoveLink = (urlToRemove: string) => {
     const currentLinks = form.getValues("links") || [];
     form.setValue(
       "links",
-      currentLinks.filter((link) => link !== linkToRemove),
+      currentLinks.filter((link) => link.url !== urlToRemove),
     );
   };
 
@@ -348,20 +355,33 @@ export function CreateAccommodationDialog({
                         <div className="space-y-2 mt-2">
                           {links.map((link) => (
                             <div
-                              key={link}
+                              key={link.url}
                               className="flex items-center justify-between p-3 rounded-lg bg-secondary border border-border"
                             >
-                              <span className="text-sm font-medium text-foreground truncate">
-                                {link}
-                              </span>
+                              <div className="min-w-0 flex-1">
+                                {link.name && (
+                                  <p className="text-sm font-medium text-foreground truncate">
+                                    {link.name}
+                                  </p>
+                                )}
+                                <p
+                                  className={
+                                    link.name
+                                      ? "text-xs text-muted-foreground truncate"
+                                      : "text-sm font-medium text-foreground truncate"
+                                  }
+                                >
+                                  {link.url}
+                                </p>
+                              </div>
                               <Button
                                 type="button"
                                 variant="ghost"
                                 size="icon"
-                                onClick={() => handleRemoveLink(link)}
+                                onClick={() => handleRemoveLink(link.url)}
                                 disabled={isPending}
                                 className="min-w-[44px] min-h-[44px] rounded-full hover:bg-muted"
-                                aria-label={`Remove ${link}`}
+                                aria-label={`Remove ${link.name ?? link.url}`}
                               >
                                 <X className="w-4 h-4 text-muted-foreground" />
                               </Button>
@@ -372,13 +392,16 @@ export function CreateAccommodationDialog({
 
                       {/* Add link input */}
                       <div className="space-y-2 mt-2">
-                        <div className="flex gap-2">
+                        <div className="flex flex-col gap-2 sm:flex-row">
                           <Input
                             type="url"
                             placeholder="https://example.com"
-                            value={newLink}
+                            value={newLink.url}
                             onChange={(e) => {
-                              setNewLink(e.target.value);
+                              setNewLink((prev) => ({
+                                ...prev,
+                                url: e.target.value,
+                              }));
                               setLinkError(null);
                             }}
                             onKeyDown={(e) => {
@@ -393,6 +416,28 @@ export function CreateAccommodationDialog({
                             aria-describedby={
                               linkError ? "accommodation-link-error" : undefined
                             }
+                          />
+                          <Input
+                            type="text"
+                            placeholder="Display name (optional)"
+                            value={newLink.name}
+                            maxLength={100}
+                            onChange={(e) => {
+                              setNewLink((prev) => ({
+                                ...prev,
+                                name: e.target.value,
+                              }));
+                              setLinkError(null);
+                            }}
+                            onKeyDown={(e) => {
+                              if (e.key === "Enter") {
+                                e.preventDefault();
+                                handleAddLink();
+                              }
+                            }}
+                            disabled={isPending}
+                            className="flex-1 h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
+                            aria-label="Link display name"
                           />
                           <Button
                             type="button"

--- a/apps/web/src/components/itinerary/create-event-dialog.tsx
+++ b/apps/web/src/components/itinerary/create-event-dialog.tsx
@@ -69,7 +69,10 @@ export function CreateEventDialog({
   tripEndDate,
 }: CreateEventDialogProps) {
   const { mutate: createEvent, isPending } = useCreateEvent();
-  const [newLink, setNewLink] = useState("");
+  const [newLink, setNewLink] = useState<{ url: string; name: string }>({
+    url: "",
+    name: "",
+  });
   const [linkError, setLinkError] = useState<string | null>(null);
 
   const form = useForm({
@@ -94,7 +97,7 @@ export function CreateEventDialog({
   useEffect(() => {
     if (!open) {
       form.reset();
-      setNewLink("");
+      setNewLink({ url: "", name: "" });
       setLinkError(null);
     }
   }, [open, form]);
@@ -160,19 +163,19 @@ export function CreateEventDialog({
   const handleAddLink = () => {
     setLinkError(null);
 
-    if (!newLink.trim()) {
+    if (!newLink.url.trim()) {
       setLinkError("URL is required");
       return;
     }
 
     // Auto-prepend https:// if no protocol is provided
-    let normalizedLink = newLink.trim();
-    if (!/^https?:\/\//i.test(normalizedLink)) {
-      normalizedLink = `https://${normalizedLink}`;
+    let normalizedUrl = newLink.url.trim();
+    if (!/^https?:\/\//i.test(normalizedUrl)) {
+      normalizedUrl = `https://${normalizedUrl}`;
     }
 
     try {
-      new URL(normalizedLink);
+      new URL(normalizedUrl);
     } catch {
       setLinkError("Please enter a valid URL");
       return;
@@ -184,20 +187,24 @@ export function CreateEventDialog({
       return;
     }
 
-    if (currentLinks.includes(normalizedLink)) {
+    if (currentLinks.some((link) => link.url === normalizedUrl)) {
       setLinkError("This URL is already added");
       return;
     }
 
-    form.setValue("links", [...currentLinks, normalizedLink]);
-    setNewLink("");
+    const trimmedName = newLink.name.trim();
+    form.setValue("links", [
+      ...currentLinks,
+      { url: normalizedUrl, ...(trimmedName ? { name: trimmedName } : {}) },
+    ]);
+    setNewLink({ url: "", name: "" });
   };
 
-  const handleRemoveLink = (linkToRemove: string) => {
+  const handleRemoveLink = (urlToRemove: string) => {
     const currentLinks = form.getValues("links") || [];
     form.setValue(
       "links",
-      currentLinks.filter((link) => link !== linkToRemove),
+      currentLinks.filter((link) => link.url !== urlToRemove),
     );
   };
 
@@ -541,20 +548,33 @@ export function CreateEventDialog({
                           <div className="space-y-2 mt-2">
                             {links.map((link) => (
                               <div
-                                key={link}
+                                key={link.url}
                                 className="flex items-center justify-between p-3 rounded-lg bg-secondary border border-border"
                               >
-                                <span className="text-sm font-medium text-foreground truncate">
-                                  {link}
-                                </span>
+                                <div className="min-w-0 flex-1">
+                                  {link.name && (
+                                    <p className="text-sm font-medium text-foreground truncate">
+                                      {link.name}
+                                    </p>
+                                  )}
+                                  <p
+                                    className={
+                                      link.name
+                                        ? "text-xs text-muted-foreground truncate"
+                                        : "text-sm font-medium text-foreground truncate"
+                                    }
+                                  >
+                                    {link.url}
+                                  </p>
+                                </div>
                                 <Button
                                   type="button"
                                   variant="ghost"
                                   size="icon"
-                                  onClick={() => handleRemoveLink(link)}
+                                  onClick={() => handleRemoveLink(link.url)}
                                   disabled={isPending}
                                   className="min-w-[44px] min-h-[44px] rounded-full hover:bg-muted"
-                                  aria-label={`Remove ${link}`}
+                                  aria-label={`Remove ${link.name ?? link.url}`}
                                 >
                                   <X className="w-4 h-4 text-muted-foreground" />
                                 </Button>
@@ -565,13 +585,16 @@ export function CreateEventDialog({
 
                         {/* Add link input */}
                         <div className="space-y-2 mt-2">
-                          <div className="flex gap-2">
+                          <div className="flex flex-col gap-2 sm:flex-row">
                             <Input
                               type="url"
                               placeholder="https://example.com"
-                              value={newLink}
+                              value={newLink.url}
                               onChange={(e) => {
-                                setNewLink(e.target.value);
+                                setNewLink((prev) => ({
+                                  ...prev,
+                                  url: e.target.value,
+                                }));
                                 setLinkError(null);
                               }}
                               onKeyDown={(e) => {
@@ -586,6 +609,28 @@ export function CreateEventDialog({
                               aria-describedby={
                                 linkError ? "event-link-error" : undefined
                               }
+                            />
+                            <Input
+                              type="text"
+                              placeholder="Display name (optional)"
+                              value={newLink.name}
+                              maxLength={100}
+                              onChange={(e) => {
+                                setNewLink((prev) => ({
+                                  ...prev,
+                                  name: e.target.value,
+                                }));
+                                setLinkError(null);
+                              }}
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter") {
+                                  e.preventDefault();
+                                  handleAddLink();
+                                }
+                              }}
+                              disabled={isPending}
+                              className="flex-1 h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
+                              aria-label="Link display name"
                             />
                             <Button
                               type="button"

--- a/apps/web/src/components/itinerary/edit-accommodation-dialog.tsx
+++ b/apps/web/src/components/itinerary/edit-accommodation-dialog.tsx
@@ -72,7 +72,10 @@ export function EditAccommodationDialog({
   const { mutate: updateAccommodation, isPending } = useUpdateAccommodation();
   const { mutate: deleteAccommodation, isPending: isDeleting } =
     useDeleteAccommodation();
-  const [newLink, setNewLink] = useState("");
+  const [newLink, setNewLink] = useState<{ url: string; name: string }>({
+    url: "",
+    name: "",
+  });
   const [linkError, setLinkError] = useState<string | null>(null);
   const isInitializing = useRef(false);
 
@@ -100,7 +103,7 @@ export function EditAccommodationDialog({
         checkOut: accommodation.checkOut,
         links: accommodation.links || [],
       });
-      setNewLink("");
+      setNewLink({ url: "", name: "" });
       setLinkError(null);
       requestAnimationFrame(() => {
         isInitializing.current = false;
@@ -180,19 +183,19 @@ export function EditAccommodationDialog({
   const handleAddLink = () => {
     setLinkError(null);
 
-    if (!newLink.trim()) {
+    if (!newLink.url.trim()) {
       setLinkError("URL is required");
       return;
     }
 
     // Auto-prepend https:// if no protocol is provided
-    let normalizedLink = newLink.trim();
-    if (!/^https?:\/\//i.test(normalizedLink)) {
-      normalizedLink = `https://${normalizedLink}`;
+    let normalizedUrl = newLink.url.trim();
+    if (!/^https?:\/\//i.test(normalizedUrl)) {
+      normalizedUrl = `https://${normalizedUrl}`;
     }
 
     try {
-      new URL(normalizedLink);
+      new URL(normalizedUrl);
     } catch {
       setLinkError("Please enter a valid URL");
       return;
@@ -204,20 +207,24 @@ export function EditAccommodationDialog({
       return;
     }
 
-    if (currentLinks.includes(normalizedLink)) {
+    if (currentLinks.some((link) => link.url === normalizedUrl)) {
       setLinkError("This URL is already added");
       return;
     }
 
-    form.setValue("links", [...currentLinks, normalizedLink]);
-    setNewLink("");
+    const trimmedName = newLink.name.trim();
+    form.setValue("links", [
+      ...currentLinks,
+      { url: normalizedUrl, ...(trimmedName ? { name: trimmedName } : {}) },
+    ]);
+    setNewLink({ url: "", name: "" });
   };
 
-  const handleRemoveLink = (linkToRemove: string) => {
+  const handleRemoveLink = (urlToRemove: string) => {
     const currentLinks = form.getValues("links") || [];
     form.setValue(
       "links",
-      currentLinks.filter((link) => link !== linkToRemove),
+      currentLinks.filter((link) => link.url !== urlToRemove),
     );
   };
 
@@ -391,20 +398,33 @@ export function EditAccommodationDialog({
                         <div className="space-y-2 mt-2">
                           {links.map((link) => (
                             <div
-                              key={link}
+                              key={link.url}
                               className="flex items-center justify-between p-3 rounded-lg bg-secondary border border-border"
                             >
-                              <span className="text-sm font-medium text-foreground truncate">
-                                {link}
-                              </span>
+                              <div className="min-w-0 flex-1">
+                                {link.name && (
+                                  <p className="text-sm font-medium text-foreground truncate">
+                                    {link.name}
+                                  </p>
+                                )}
+                                <p
+                                  className={
+                                    link.name
+                                      ? "text-xs text-muted-foreground truncate"
+                                      : "text-sm font-medium text-foreground truncate"
+                                  }
+                                >
+                                  {link.url}
+                                </p>
+                              </div>
                               <Button
                                 type="button"
                                 variant="ghost"
                                 size="icon"
-                                onClick={() => handleRemoveLink(link)}
+                                onClick={() => handleRemoveLink(link.url)}
                                 disabled={isPending || isDeleting}
                                 className="min-w-[44px] min-h-[44px] rounded-full hover:bg-muted"
-                                aria-label={`Remove ${link}`}
+                                aria-label={`Remove ${link.name ?? link.url}`}
                               >
                                 <X className="w-4 h-4 text-muted-foreground" />
                               </Button>
@@ -415,13 +435,16 @@ export function EditAccommodationDialog({
 
                       {/* Add link input */}
                       <div className="space-y-2 mt-2">
-                        <div className="flex gap-2">
+                        <div className="flex flex-col gap-2 sm:flex-row">
                           <Input
                             type="url"
                             placeholder="https://example.com"
-                            value={newLink}
+                            value={newLink.url}
                             onChange={(e) => {
-                              setNewLink(e.target.value);
+                              setNewLink((prev) => ({
+                                ...prev,
+                                url: e.target.value,
+                              }));
                               setLinkError(null);
                             }}
                             onKeyDown={(e) => {
@@ -439,12 +462,35 @@ export function EditAccommodationDialog({
                                 : undefined
                             }
                           />
+                          <Input
+                            type="text"
+                            placeholder="Display name (optional)"
+                            value={newLink.name}
+                            maxLength={100}
+                            onChange={(e) => {
+                              setNewLink((prev) => ({
+                                ...prev,
+                                name: e.target.value,
+                              }));
+                              setLinkError(null);
+                            }}
+                            onKeyDown={(e) => {
+                              if (e.key === "Enter") {
+                                e.preventDefault();
+                                handleAddLink();
+                              }
+                            }}
+                            disabled={isPending || isDeleting}
+                            className="flex-1 h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
+                            aria-label="Link display name"
+                          />
                           <Button
                             type="button"
                             onClick={handleAddLink}
                             disabled={isPending || isDeleting}
                             className="h-12 px-4 bg-muted hover:bg-muted text-foreground rounded-md"
                             variant="outline"
+                            aria-label="Add link"
                           >
                             <Plus className="w-5 h-5" />
                           </Button>

--- a/apps/web/src/components/itinerary/edit-event-dialog.tsx
+++ b/apps/web/src/components/itinerary/edit-event-dialog.tsx
@@ -87,7 +87,10 @@ export function EditEventDialog({
 }: EditEventDialogProps) {
   const { mutate: updateEvent, isPending } = useUpdateEvent();
   const { mutate: deleteEvent, isPending: isDeleting } = useDeleteEvent();
-  const [newLink, setNewLink] = useState("");
+  const [newLink, setNewLink] = useState<{ url: string; name: string }>({
+    url: "",
+    name: "",
+  });
   const [linkError, setLinkError] = useState<string | null>(null);
   const isInitializing = useRef(false);
 
@@ -133,7 +136,7 @@ export function EditEventDialog({
           : undefined,
         timezone: timezone,
       });
-      setNewLink("");
+      setNewLink({ url: "", name: "" });
       setLinkError(null);
       requestAnimationFrame(() => {
         isInitializing.current = false;
@@ -218,19 +221,19 @@ export function EditEventDialog({
   const handleAddLink = () => {
     setLinkError(null);
 
-    if (!newLink.trim()) {
+    if (!newLink.url.trim()) {
       setLinkError("URL is required");
       return;
     }
 
     // Auto-prepend https:// if no protocol is provided
-    let normalizedLink = newLink.trim();
-    if (!/^https?:\/\//i.test(normalizedLink)) {
-      normalizedLink = `https://${normalizedLink}`;
+    let normalizedUrl = newLink.url.trim();
+    if (!/^https?:\/\//i.test(normalizedUrl)) {
+      normalizedUrl = `https://${normalizedUrl}`;
     }
 
     try {
-      new URL(normalizedLink);
+      new URL(normalizedUrl);
     } catch {
       setLinkError("Please enter a valid URL");
       return;
@@ -242,20 +245,24 @@ export function EditEventDialog({
       return;
     }
 
-    if (currentLinks.includes(normalizedLink)) {
+    if (currentLinks.some((link) => link.url === normalizedUrl)) {
       setLinkError("This URL is already added");
       return;
     }
 
-    form.setValue("links", [...currentLinks, normalizedLink]);
-    setNewLink("");
+    const trimmedName = newLink.name.trim();
+    form.setValue("links", [
+      ...currentLinks,
+      { url: normalizedUrl, ...(trimmedName ? { name: trimmedName } : {}) },
+    ]);
+    setNewLink({ url: "", name: "" });
   };
 
-  const handleRemoveLink = (linkToRemove: string) => {
+  const handleRemoveLink = (urlToRemove: string) => {
     const currentLinks = form.getValues("links") || [];
     form.setValue(
       "links",
-      currentLinks.filter((link) => link !== linkToRemove),
+      currentLinks.filter((link) => link.url !== urlToRemove),
     );
   };
 
@@ -597,20 +604,33 @@ export function EditEventDialog({
                           <div className="space-y-2 mt-2">
                             {links.map((link) => (
                               <div
-                                key={link}
+                                key={link.url}
                                 className="flex items-center justify-between p-3 rounded-lg bg-secondary border border-border"
                               >
-                                <span className="text-sm font-medium text-foreground truncate">
-                                  {link}
-                                </span>
+                                <div className="min-w-0 flex-1">
+                                  {link.name && (
+                                    <p className="text-sm font-medium text-foreground truncate">
+                                      {link.name}
+                                    </p>
+                                  )}
+                                  <p
+                                    className={
+                                      link.name
+                                        ? "text-xs text-muted-foreground truncate"
+                                        : "text-sm font-medium text-foreground truncate"
+                                    }
+                                  >
+                                    {link.url}
+                                  </p>
+                                </div>
                                 <Button
                                   type="button"
                                   variant="ghost"
                                   size="icon"
-                                  onClick={() => handleRemoveLink(link)}
+                                  onClick={() => handleRemoveLink(link.url)}
                                   disabled={isPending || isDeleting}
                                   className="min-w-[44px] min-h-[44px] rounded-full hover:bg-muted"
-                                  aria-label={`Remove ${link}`}
+                                  aria-label={`Remove ${link.name ?? link.url}`}
                                 >
                                   <X className="w-4 h-4 text-muted-foreground" />
                                 </Button>
@@ -621,13 +641,16 @@ export function EditEventDialog({
 
                         {/* Add link input */}
                         <div className="space-y-2 mt-2">
-                          <div className="flex gap-2">
+                          <div className="flex flex-col gap-2 sm:flex-row">
                             <Input
                               type="url"
                               placeholder="https://example.com"
-                              value={newLink}
+                              value={newLink.url}
                               onChange={(e) => {
-                                setNewLink(e.target.value);
+                                setNewLink((prev) => ({
+                                  ...prev,
+                                  url: e.target.value,
+                                }));
                                 setLinkError(null);
                               }}
                               onKeyDown={(e) => {
@@ -643,12 +666,35 @@ export function EditEventDialog({
                                 linkError ? "edit-event-link-error" : undefined
                               }
                             />
+                            <Input
+                              type="text"
+                              placeholder="Display name (optional)"
+                              value={newLink.name}
+                              maxLength={100}
+                              onChange={(e) => {
+                                setNewLink((prev) => ({
+                                  ...prev,
+                                  name: e.target.value,
+                                }));
+                                setLinkError(null);
+                              }}
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter") {
+                                  e.preventDefault();
+                                  handleAddLink();
+                                }
+                              }}
+                              disabled={isPending || isDeleting}
+                              className="flex-1 h-12 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md"
+                              aria-label="Link display name"
+                            />
                             <Button
                               type="button"
                               onClick={handleAddLink}
                               disabled={isPending || isDeleting}
                               className="h-12 px-4 bg-muted hover:bg-muted text-foreground rounded-md"
                               variant="outline"
+                              aria-label="Add link"
                             >
                               <Plus className="w-5 h-5" />
                             </Button>

--- a/apps/web/src/components/itinerary/event-detail-sheet.tsx
+++ b/apps/web/src/components/itinerary/event-detail-sheet.tsx
@@ -286,16 +286,16 @@ function EventDetailBody({
       {/* Links */}
       {event.links && event.links.length > 0 && (
         <div className="space-y-1.5">
-          {event.links.map((link, index) => (
+          {event.links.map((link) => (
             <a
-              key={index}
-              href={link}
+              key={link.url}
+              href={link.url}
               target="_blank"
               rel="noopener noreferrer"
               className="flex items-center gap-1.5 text-sm text-primary hover:text-primary/80 transition-colors"
             >
               <ExternalLink className="w-3.5 h-3.5 shrink-0" />
-              <span className="truncate">{link}</span>
+              <span className="truncate">{link.name ?? link.url}</span>
             </a>
           ))}
         </div>

--- a/shared/__tests__/accommodation-schemas.test.ts
+++ b/shared/__tests__/accommodation-schemas.test.ts
@@ -44,9 +44,9 @@ describe("createAccommodationSchema", () => {
       address: "789 Beach Boulevard, Miami, FL 33139",
       description: "Five-star resort with ocean view and spa facilities",
       links: [
-        "https://example.com/resort",
-        "https://example.com/booking",
-        "https://example.com/amenities",
+        { url: "https://example.com/resort" },
+        { url: "https://example.com/booking" },
+        { url: "https://example.com/amenities" },
       ],
     };
 
@@ -310,10 +310,10 @@ describe("createAccommodationSchema", () => {
 
   it("should reject invalid URLs in links array", () => {
     const invalidUrls = [
-      ["not-a-url"],
-      ["https://valid.com", "invalid-url"],
-      ["just text"],
-      ["example.com"], // Missing protocol
+      [{ url: "not-a-url" }],
+      [{ url: "https://valid.com" }, { url: "invalid-url" }],
+      [{ url: "just text" }],
+      [{ url: "example.com" }], // Missing protocol
     ];
 
     invalidUrls.forEach((links) => {
@@ -331,10 +331,10 @@ describe("createAccommodationSchema", () => {
 
   it("should accept valid URLs in links array", () => {
     const validUrls = [
-      ["https://example.com"],
-      ["http://example.com/booking"],
-      ["https://example.com", "https://another.com/reviews"],
-      ["https://cdn.example.com/brochure.pdf"],
+      [{ url: "https://example.com" }],
+      [{ url: "http://example.com/booking" }],
+      [{ url: "https://example.com" }, { url: "https://another.com/reviews" }],
+      [{ url: "https://cdn.example.com/brochure.pdf" }],
     ];
 
     validUrls.forEach((links) => {
@@ -352,7 +352,7 @@ describe("createAccommodationSchema", () => {
   });
 
   it("should reject links array exceeding max items", () => {
-    const tooManyLinks = Array(11).fill("https://example.com");
+    const tooManyLinks = Array(11).fill({ url: "https://example.com" });
     const accommodation = {
       name: "Hotel",
       checkIn: "2026-07-15T14:00:00.000Z",
@@ -368,7 +368,7 @@ describe("createAccommodationSchema", () => {
   });
 
   it("should accept links array at max items", () => {
-    const maxLinks = Array(10).fill("https://example.com");
+    const maxLinks = Array(10).fill({ url: "https://example.com" });
     const accommodation = {
       name: "Hotel",
       checkIn: "2026-07-15T14:00:00.000Z",
@@ -389,6 +389,49 @@ describe("createAccommodationSchema", () => {
 
     expect(() => createAccommodationSchema.parse(accommodation)).not.toThrow();
   });
+
+  it("should accept links with optional name", () => {
+    const accommodation = {
+      name: "Hotel",
+      checkIn: "2026-07-15T14:00:00.000Z",
+      checkOut: "2026-07-16T11:00:00.000Z",
+      links: [
+        { url: "https://example.com/booking", name: "Reservation" },
+        { url: "https://maps.example.com" },
+      ],
+    };
+
+    expect(() => createAccommodationSchema.parse(accommodation)).not.toThrow();
+  });
+
+  it("should reject link name exceeding 100 characters", () => {
+    const accommodation = {
+      name: "Hotel",
+      checkIn: "2026-07-15T14:00:00.000Z",
+      checkOut: "2026-07-16T11:00:00.000Z",
+      links: [{ url: "https://example.com", name: "a".repeat(101) }],
+    };
+
+    const result = createAccommodationSchema.safeParse(accommodation);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toContain(
+        "not exceed 100 characters",
+      );
+    }
+  });
+
+  it("should reject link missing url", () => {
+    const accommodation = {
+      name: "Hotel",
+      checkIn: "2026-07-15T14:00:00.000Z",
+      checkOut: "2026-07-16T11:00:00.000Z",
+      links: [{ name: "No URL here" }],
+    };
+
+    const result = createAccommodationSchema.safeParse(accommodation);
+    expect(result.success).toBe(false);
+  });
 });
 
 describe("updateAccommodationSchema", () => {
@@ -399,7 +442,7 @@ describe("updateAccommodationSchema", () => {
       { description: "Updated description" },
       { checkIn: "2026-08-01T14:00:00.000Z" },
       { checkOut: "2026-08-10T11:00:00.000Z" },
-      { links: ["https://example.com"] },
+      { links: [{ url: "https://example.com" }] },
     ];
 
     partialUpdates.forEach((update) => {
@@ -429,8 +472,8 @@ describe("updateAccommodationSchema", () => {
       { checkIn: "not-a-date" }, // Invalid datetime format
       { checkOut: "2026/07/16" }, // Invalid datetime format
       { description: "a".repeat(2001) }, // Too long
-      { links: ["not-a-url"] }, // Invalid URL
-      { links: Array(11).fill("https://example.com") }, // Too many links
+      { links: [{ url: "not-a-url" }] }, // Invalid URL
+      { links: Array(11).fill({ url: "https://example.com" }) }, // Too many links
     ];
 
     invalidUpdates.forEach((update) => {

--- a/shared/__tests__/event-schemas.test.ts
+++ b/shared/__tests__/event-schemas.test.ts
@@ -42,8 +42,8 @@ describe("createEventSchema", () => {
       allDay: false,
       isOptional: true,
       links: [
-        "https://example.com/conference",
-        "https://example.com/speaker-bio",
+        { url: "https://example.com/conference" },
+        { url: "https://example.com/speaker-bio" },
       ],
     };
 
@@ -311,10 +311,10 @@ describe("createEventSchema", () => {
 
   it("should reject invalid URLs in links array", () => {
     const invalidUrls = [
-      ["not-a-url"],
-      ["https://valid.com", "invalid-url"],
-      ["just text"],
-      ["example.com"], // Missing protocol
+      [{ url: "not-a-url" }],
+      [{ url: "https://valid.com" }, { url: "invalid-url" }],
+      [{ url: "just text" }],
+      [{ url: "example.com" }], // Missing protocol
     ];
 
     invalidUrls.forEach((links) => {
@@ -332,10 +332,10 @@ describe("createEventSchema", () => {
 
   it("should accept valid URLs in links array", () => {
     const validUrls = [
-      ["https://example.com"],
-      ["http://example.com/path"],
-      ["https://example.com", "https://another.com/page"],
-      ["https://cdn.example.com/resource.pdf"],
+      [{ url: "https://example.com" }],
+      [{ url: "http://example.com/path" }],
+      [{ url: "https://example.com" }, { url: "https://another.com/page" }],
+      [{ url: "https://cdn.example.com/resource.pdf" }],
     ];
 
     validUrls.forEach((links) => {
@@ -351,7 +351,7 @@ describe("createEventSchema", () => {
   });
 
   it("should reject links array exceeding max items", () => {
-    const tooManyLinks = Array(11).fill("https://example.com");
+    const tooManyLinks = Array(11).fill({ url: "https://example.com" });
     const event = {
       name: "Test Event",
       eventType: "meal" as const,
@@ -367,7 +367,7 @@ describe("createEventSchema", () => {
   });
 
   it("should accept links array at max items", () => {
-    const maxLinks = Array(10).fill("https://example.com");
+    const maxLinks = Array(10).fill({ url: "https://example.com" });
     const event = {
       name: "Test Event",
       eventType: "meal" as const,
@@ -388,6 +388,49 @@ describe("createEventSchema", () => {
 
     expect(() => createEventSchema.parse(event)).not.toThrow();
   });
+
+  it("should accept links with optional name", () => {
+    const event = {
+      name: "Test Event",
+      eventType: "meal" as const,
+      startTime: "2026-07-15T12:00:00Z",
+      links: [
+        { url: "https://example.com", name: "Reservation" },
+        { url: "https://maps.example.com" },
+      ],
+    };
+
+    expect(() => createEventSchema.parse(event)).not.toThrow();
+  });
+
+  it("should reject link name exceeding 100 characters", () => {
+    const event = {
+      name: "Test Event",
+      eventType: "meal" as const,
+      startTime: "2026-07-15T12:00:00Z",
+      links: [{ url: "https://example.com", name: "a".repeat(101) }],
+    };
+
+    const result = createEventSchema.safeParse(event);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toContain(
+        "not exceed 100 characters",
+      );
+    }
+  });
+
+  it("should reject link missing url", () => {
+    const event = {
+      name: "Test Event",
+      eventType: "meal" as const,
+      startTime: "2026-07-15T12:00:00Z",
+      links: [{ name: "No URL here" }],
+    };
+
+    const result = createEventSchema.safeParse(event);
+    expect(result.success).toBe(false);
+  });
 });
 
 describe("updateEventSchema", () => {
@@ -401,7 +444,7 @@ describe("updateEventSchema", () => {
       { endTime: "2026-08-01T12:00:00Z" },
       { allDay: true },
       { isOptional: true },
-      { links: ["https://example.com"] },
+      { links: [{ url: "https://example.com" }] },
     ];
 
     partialUpdates.forEach((update) => {
@@ -433,8 +476,8 @@ describe("updateEventSchema", () => {
       { startTime: "not-a-datetime" }, // Invalid datetime format
       { endTime: "2026-07-15" }, // Invalid datetime format
       { description: "a".repeat(2001) }, // Too long
-      { links: ["not-a-url"] }, // Invalid URL
-      { links: Array(11).fill("https://example.com") }, // Too many links
+      { links: [{ url: "not-a-url" }] }, // Invalid URL
+      { links: Array(11).fill({ url: "https://example.com" }) }, // Too many links
     ];
 
     invalidUpdates.forEach((update) => {

--- a/shared/schemas/accommodation.ts
+++ b/shared/schemas/accommodation.ts
@@ -2,6 +2,7 @@
 
 import { z } from "zod";
 import { stripControlChars } from "../utils/sanitize";
+import { linkItemSchema, linksArraySchema } from "./link";
 
 /**
  * Base accommodation data schema (without cross-field validation)
@@ -26,12 +27,7 @@ const baseAccommodationSchema = z.object({
     .optional(),
   checkIn: z.string().datetime({ offset: true }).or(z.string().datetime()),
   checkOut: z.string().datetime({ offset: true }).or(z.string().datetime()),
-  links: z
-    .array(z.string().url("Link must be a valid URL"))
-    .max(10, {
-      error: "Links must not exceed 10 items",
-    })
-    .optional(),
+  links: linksArraySchema.optional(),
 });
 
 /**
@@ -87,7 +83,7 @@ const accommodationEntitySchema = z.object({
   description: z.string().nullable(),
   checkIn: z.date(),
   checkOut: z.date(),
-  links: z.array(z.string()).nullable(),
+  links: z.array(linkItemSchema).nullable(),
   deletedAt: z.date().nullable(),
   deletedBy: z.string().nullable(),
   createdAt: z.date(),

--- a/shared/schemas/accommodation.ts
+++ b/shared/schemas/accommodation.ts
@@ -37,7 +37,7 @@ const baseAccommodationSchema = z.object({
  * - description: max 2000 characters (optional)
  * - checkIn: ISO 8601 datetime string (required)
  * - checkOut: ISO 8601 datetime string (required), must be > checkIn
- * - links: array of URLs, max 10 items (optional)
+ * - links: array of `{ url, name? }` objects, max 10 items (optional)
  */
 export const createAccommodationSchema = baseAccommodationSchema.refine(
   (data) => {

--- a/shared/schemas/event.ts
+++ b/shared/schemas/event.ts
@@ -48,7 +48,7 @@ const baseEventSchema = z.object({
  * - endTime: ISO 8601 datetime string (optional), must be > startTime
  * - allDay: boolean (defaults to false)
  * - isOptional: boolean (defaults to false)
- * - links: array of URLs, max 10 items (optional)
+ * - links: array of `{ url, name? }` objects, max 10 items (optional)
  */
 export const createEventSchema = baseEventSchema.refine(
   (data) => {

--- a/shared/schemas/event.ts
+++ b/shared/schemas/event.ts
@@ -2,6 +2,7 @@
 
 import { z } from "zod";
 import { stripControlChars } from "../utils/sanitize";
+import { linkItemSchema, linksArraySchema } from "./link";
 
 /**
  * Base event data schema (without cross-field validation)
@@ -33,12 +34,7 @@ const baseEventSchema = z.object({
   endTime: z.string().datetime().optional(),
   allDay: z.boolean().default(false),
   isOptional: z.boolean().default(false),
-  links: z
-    .array(z.string().url("Link must be a valid URL"))
-    .max(10, {
-      error: "Links must not exceed 10 items",
-    })
-    .optional(),
+  links: linksArraySchema.optional(),
   timezone: z.string().max(100).optional(),
 });
 
@@ -104,7 +100,7 @@ const eventEntitySchema = z.object({
   endTime: z.date().nullable(),
   allDay: z.boolean(),
   isOptional: z.boolean(),
-  links: z.array(z.string()).nullable(),
+  links: z.array(linkItemSchema).nullable(),
   deletedAt: z.date().nullable(),
   deletedBy: z.string().nullable(),
   createdAt: z.date(),

--- a/shared/schemas/index.ts
+++ b/shared/schemas/index.ts
@@ -226,6 +226,13 @@ export {
   type TrackImpressionsInput,
 } from "./affiliate";
 
+// Re-export link schemas
+export {
+  linkItemSchema,
+  linksArraySchema,
+  type LinkItemInput,
+} from "./link";
+
 // Re-export admin schemas
 export {
   adminListUsersQuerySchema,

--- a/shared/schemas/link.ts
+++ b/shared/schemas/link.ts
@@ -1,6 +1,7 @@
 // Link validation schemas for events and accommodations
 
 import { z } from "zod";
+import { stripControlChars } from "../utils/sanitize";
 
 /**
  * Validates a single link entry: URL is required, optional display name (max 100 chars).
@@ -10,6 +11,7 @@ export const linkItemSchema = z.object({
   name: z
     .string()
     .max(100, { error: "Link name must not exceed 100 characters" })
+    .transform(stripControlChars)
     .optional(),
 });
 

--- a/shared/schemas/link.ts
+++ b/shared/schemas/link.ts
@@ -1,0 +1,23 @@
+// Link validation schemas for events and accommodations
+
+import { z } from "zod";
+
+/**
+ * Validates a single link entry: URL is required, optional display name (max 100 chars).
+ */
+export const linkItemSchema = z.object({
+  url: z.string().url("Link must be a valid URL"),
+  name: z
+    .string()
+    .max(100, { error: "Link name must not exceed 100 characters" })
+    .optional(),
+});
+
+/**
+ * Validates an array of link items. Maximum 10 items.
+ */
+export const linksArraySchema = z.array(linkItemSchema).max(10, {
+  error: "Links must not exceed 10 items",
+});
+
+export type LinkItemInput = z.infer<typeof linkItemSchema>;

--- a/shared/types/accommodation.ts
+++ b/shared/types/accommodation.ts
@@ -2,6 +2,8 @@
  * Accommodation types and response interfaces
  */
 
+import type { LinkItem } from "./link";
+
 /**
  * Accommodation entity
  */
@@ -14,7 +16,7 @@ export interface Accommodation {
   description: string | null;
   checkIn: string;
   checkOut: string;
-  links: string[] | null;
+  links: LinkItem[] | null;
   deletedAt: Date | null;
   deletedBy: string | null;
   createdAt: Date;

--- a/shared/types/event.ts
+++ b/shared/types/event.ts
@@ -2,6 +2,8 @@
  * Event types and response interfaces
  */
 
+import type { LinkItem } from "./link";
+
 /**
  * Event entity
  */
@@ -19,7 +21,7 @@ export interface Event {
   endTime: Date | null;
   allDay: boolean;
   isOptional: boolean;
-  links: string[] | null;
+  links: LinkItem[] | null;
   deletedAt: Date | null;
   deletedBy: string | null;
   createdAt: Date;

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -182,3 +182,6 @@ export type {
   SuggestionsResponse,
   DismissSuggestionInput,
 } from "./affiliate";
+
+// Re-export link types
+export type { LinkItem } from "./link";

--- a/shared/types/link.ts
+++ b/shared/types/link.ts
@@ -1,0 +1,11 @@
+/**
+ * Link types for events and accommodations
+ */
+
+/**
+ * A link with an optional display name
+ */
+export interface LinkItem {
+  url: string;
+  name?: string | undefined;
+}


### PR DESCRIPTION
## Summary

- Converts `events.links` and `accommodations.links` from `text[]` to `jsonb`, storing `{ url: string, name?: string }[]`
- Migration `0030` backfills all existing rows to the new object shape (each plain URL becomes `{ url }`)
- All four create/edit dialogs (event + accommodation) gain an optional display name input alongside the URL field
- Detail sheets render `name` when present, falling back to the raw URL; the anchor `href` is always the URL
- Calendar `.ics` export formats named links as `"- Name: url"` and bare links as `"- url"`

## Migration note

Rows with `links = '{}'` (empty array) will become `links = NULL` after the migration. Rows with `links = NULL` remain `NULL`. Both are treated identically by the app (null-checked before rendering), so there is no user-visible difference.

## Test plan

- [ ] `pnpm -r typecheck` — all three packages pass
- [ ] `pnpm --filter @journiful/shared test` — event/accommodation/link schema tests green (pre-existing weather-schema failures on main excluded)
- [ ] `pnpm --filter @journiful/api test` — event/accommodation service and calendar service tests green (pre-existing S3-dependent failures on main excluded)
- [ ] `pnpm --filter @journiful/web test` — dialog and event-card tests green (pre-existing layout/app-header failures on main excluded)
- [ ] `pnpm --filter @journiful/api db:migrate` — migration applies cleanly to dev DB
- [ ] Manual QA: create an event with a named link → detail sheet shows name; create one without a name → raw URL shown; ICS download includes formatted links
- [ ] E2E `itinerary-journey.spec.ts` — `input[aria-label="Link URL"]` and `button "Add link"` selectors preserved; URL still visible in More Details

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)