### PR TITLE
fix: address code review issues in location autocomplete

### DIFF
--- a/apps/api/src/routes/location.routes.ts
+++ b/apps/api/src/routes/location.routes.ts
@@ -19,8 +19,8 @@ const autocompleteResponseSchema = z.array(locationSuggestionSchema);
 
 type LocationIQResult = {
   display_name: string;
-  display_place: string;
-  display_address: string;
+  display_place?: string;
+  display_address?: string;
   lat: string;
   lon: string;
 };
@@ -43,14 +43,17 @@ export async function locationRoutes(fastify: FastifyInstance) {
 
       try {
         const url = `https://api.locationiq.com/v1/autocomplete?key=${encodeURIComponent(key)}&q=${encodeURIComponent(q)}&limit=5&normalizecity=1`;
-        const response = await fetch(url);
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 3000);
+        const response = await fetch(url, { signal: controller.signal });
+        clearTimeout(timeout);
         if (!response.ok) return reply.send([]);
 
         const data = (await response.json()) as LocationIQResult[];
         return data.map((r) => ({
           displayName: r.display_name,
-          displayPlace: r.display_place,
-          displayAddress: r.display_address,
+          displayPlace: r.display_place ?? r.display_name,
+          displayAddress: r.display_address ?? "",
           lat: parseFloat(r.lat),
           lon: parseFloat(r.lon),
         }));

--- a/apps/web/src/components/trip/create-trip-dialog.tsx
+++ b/apps/web/src/components/trip/create-trip-dialog.tsx
@@ -83,6 +83,15 @@ export function CreateTripDialog({
     },
   });
 
+  // Reset to step 1 when dialog closes so next open starts fresh
+  useEffect(() => {
+    if (!open) {
+      setCurrentStep(1);
+      setCreatedTrip(null);
+      setPendingTimezone("");
+    }
+  }, [open]);
+
   const watchedThemeId = form.watch("themeId");
   const watchedThemeFont = form.watch("themeFont");
 

--- a/apps/web/src/components/ui/location-input.tsx
+++ b/apps/web/src/components/ui/location-input.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, type ChangeEvent } from "react";
+import { useState, useRef, useEffect, type ChangeEvent } from "react";
 import { MapPin } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import {
@@ -44,6 +44,11 @@ export function LocationInput({
   const [query, setQuery] = useState(value);
   const [open, setOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  // Sync internal query when value prop changes externally (e.g. form.reset)
+  useEffect(() => {
+    setQuery(value);
+  }, [value]);
 
   const { data: suggestions = [] } = useLocationAutocomplete(query);
 
@@ -94,9 +99,9 @@ export function LocationInput({
         <Command shouldFilter={false}>
           <CommandList>
             <CommandEmpty>No results found.</CommandEmpty>
-            {suggestions.map((suggestion, i) => (
+            {suggestions.map((suggestion) => (
               <CommandItem
-                key={`${suggestion.lat}-${suggestion.lon}-${i}`}
+                key={`${suggestion.lat}-${suggestion.lon}`}
                 value={suggestion.displayName}
                 onSelect={() => handleSelect(suggestion)}
                 className="flex items-start gap-2 py-2 px-3 cursor-pointer"


### PR DESCRIPTION
## Summary

Follow-up to #131 addressing issues found in code review:

- **`LocationInput` value sync**: add `useEffect` to sync internal `query` state when `value` prop changes externally — fixes stale input in edit dialogs after `form.reset()`
- **`create-trip-dialog` reset on close**: reset step/createdTrip/pendingTimezone when dialog closes so next open starts at step 1
- **LocationIQ fetch timeout**: add 3s `AbortController` timeout, matching the pattern in `getTimezone`/`getTimezoneByCoords`
- **`display_place`/`display_address` nullability**: handle country-level LocationIQ results that may omit these fields
- **Suggestion key**: drop index from `lat-lon-i` key — `lat-lon` is sufficient

## Test plan
- [ ] Open edit event dialog twice for different events — location field shows correct pre-populated value each time
- [ ] Close create trip dialog mid-flow — next open starts at step 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)