### PR TITLE
fix: skip timezone confirmation when timezone didn't change

### DIFF
--- a/apps/web/src/components/trip/edit-trip-dialog.tsx
+++ b/apps/web/src/components/trip/edit-trip-dialog.tsx
@@ -139,7 +139,8 @@ export function EditTripDialog({
       { tripId: trip.id, data },
       {
         onSuccess: (updatedTrip) => {
-          if (destinationChanged) {
+          const timezoneChanged = updatedTrip.preferredTimezone !== trip.preferredTimezone;
+          if (destinationChanged && timezoneChanged) {
             setPendingTimezone(updatedTrip.preferredTimezone);
             setTimezoneConfirm({
               timezone: updatedTrip.preferredTimezone,


### PR DESCRIPTION
## Summary

When editing a trip destination, only show the timezone confirmation step if the timezone actually changed. Previously it always appeared when the destination changed, even if the resolved timezone was identical (e.g. Paris → Lyon, both `Europe/Paris`).

Now the condition is `destinationChanged && timezoneChanged` — both must be true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)