### PR TITLE
fix: location autocomplete polish + timezone UX improvements

### DIFF
--- a/apps/api/src/routes/location.routes.ts
+++ b/apps/api/src/routes/location.routes.ts
@@ -11,6 +11,7 @@ const autocompleteQuerySchema = z.object({
 
 const locationSuggestionSchema = z.object({
   placeId: z.string(),
+  shortName: z.string(),
   displayName: z.string(),
   displayPlace: z.string(),
   displayAddress: z.string(),
@@ -49,6 +50,17 @@ type LocationIQResult = {
   display_address?: string;
   address?: LocationIQAddress;
 };
+
+function buildShortName(r: LocationIQResult): string {
+  const place = r.display_place ?? r.display_name;
+  const addr = r.address;
+  if (!addr) return place;
+  const city = addr.city ?? addr.town ?? addr.village ?? addr.suburb;
+  const region = addr.country_code === "us" ? addr.state : addr.country;
+  // Use city as secondary if it differs from the place name, otherwise use region
+  const secondary = city && city !== place ? city : region;
+  return [place, secondary].filter(Boolean).join(", ");
+}
 
 export async function locationRoutes(fastify: FastifyInstance) {
   fastify.get<{ Querystring: z.infer<typeof autocompleteQuerySchema> }>(
@@ -89,6 +101,7 @@ export async function locationRoutes(fastify: FastifyInstance) {
           })
           .map((r) => ({
             placeId: r.place_id,
+            shortName: buildShortName(r),
             displayName: r.display_name,
             displayPlace: r.display_place ?? r.display_name,
             displayAddress: r.display_address ?? "",

--- a/apps/api/src/routes/location.routes.ts
+++ b/apps/api/src/routes/location.routes.ts
@@ -18,13 +18,34 @@ const locationSuggestionSchema = z.object({
 
 const autocompleteResponseSchema = z.array(locationSuggestionSchema);
 
+type LocationIQAddress = {
+  name?: string;
+  house_number?: string;
+  road?: string;
+  suburb?: string;
+  city?: string;
+  town?: string;
+  village?: string;
+  county?: string;
+  state?: string;
+  postcode?: string;
+  country?: string;
+  country_code?: string;
+};
+
 type LocationIQResult = {
   place_id: string;
+  osm_id: string;
+  osm_type: string;
+  lat: string;
+  lon: string;
+  boundingbox: [string, string, string, string];
+  class: string;
+  type: string;
   display_name: string;
   display_place?: string;
   display_address?: string;
-  lat: string;
-  lon: string;
+  address?: LocationIQAddress;
 };
 
 export async function locationRoutes(fastify: FastifyInstance) {

--- a/apps/api/src/routes/location.routes.ts
+++ b/apps/api/src/routes/location.routes.ts
@@ -42,7 +42,7 @@ export async function locationRoutes(fastify: FastifyInstance) {
       if (!key) return reply.send([]);
 
       try {
-        const url = `https://api.locationiq.com/v1/autocomplete?key=${encodeURIComponent(key)}&q=${encodeURIComponent(q)}&limit=5&normalizecity=1`;
+        const url = `https://api.locationiq.com/v1/autocomplete?key=${encodeURIComponent(key)}&q=${encodeURIComponent(q)}&limit=10&normalizecity=1`;
         const controller = new AbortController();
         const timeout = setTimeout(() => controller.abort(), 3000);
         const response = await fetch(url, { signal: controller.signal });

--- a/apps/api/src/routes/location.routes.ts
+++ b/apps/api/src/routes/location.routes.ts
@@ -5,6 +5,8 @@ import { defaultRateLimitConfig } from "@/middleware/rate-limit.middleware.js";
 
 const autocompleteQuerySchema = z.object({
   q: z.string().min(1).max(200),
+  lat: z.coerce.number().optional(),
+  lon: z.coerce.number().optional(),
 });
 
 const locationSuggestionSchema = z.object({
@@ -59,13 +61,18 @@ export async function locationRoutes(fastify: FastifyInstance) {
       preHandler: [fastify.rateLimit(defaultRateLimitConfig), authenticate],
     },
     async (request, reply) => {
-      const { q } = request.query;
+      const { q, lat, lon } = request.query;
       const key = request.server.config.LOCATIONIQ_API_KEY;
 
       if (!key) return reply.send([]);
 
       try {
-        const url = `https://api.locationiq.com/v1/autocomplete?key=${encodeURIComponent(key)}&q=${encodeURIComponent(q)}&limit=10&normalizecity=1&dedupe=1&accept-language=en`;
+        const DELTA = 1; // ~110km bounding box
+        const viewbox =
+          lat != null && lon != null
+            ? `&viewbox=${lon + DELTA},${lat + DELTA},${lon - DELTA},${lat - DELTA}`
+            : "";
+        const url = `https://api.locationiq.com/v1/autocomplete?key=${encodeURIComponent(key)}&q=${encodeURIComponent(q)}&limit=10&normalizecity=1&dedupe=1&accept-language=en${viewbox}`;
         const controller = new AbortController();
         const timeout = setTimeout(() => controller.abort(), 3000);
         const response = await fetch(url, { signal: controller.signal });

--- a/apps/api/src/routes/location.routes.ts
+++ b/apps/api/src/routes/location.routes.ts
@@ -8,6 +8,7 @@ const autocompleteQuerySchema = z.object({
 });
 
 const locationSuggestionSchema = z.object({
+  placeId: z.string(),
   displayName: z.string(),
   displayPlace: z.string(),
   displayAddress: z.string(),
@@ -18,6 +19,7 @@ const locationSuggestionSchema = z.object({
 const autocompleteResponseSchema = z.array(locationSuggestionSchema);
 
 type LocationIQResult = {
+  place_id: string;
   display_name: string;
   display_place?: string;
   display_address?: string;
@@ -51,6 +53,7 @@ export async function locationRoutes(fastify: FastifyInstance) {
 
         const data = (await response.json()) as LocationIQResult[];
         return data.map((r) => ({
+          placeId: r.place_id,
           displayName: r.display_name,
           displayPlace: r.display_place ?? r.display_name,
           displayAddress: r.display_address ?? "",

--- a/apps/api/src/routes/location.routes.ts
+++ b/apps/api/src/routes/location.routes.ts
@@ -65,7 +65,7 @@ export async function locationRoutes(fastify: FastifyInstance) {
       if (!key) return reply.send([]);
 
       try {
-        const url = `https://api.locationiq.com/v1/autocomplete?key=${encodeURIComponent(key)}&q=${encodeURIComponent(q)}&limit=10&normalizecity=1`;
+        const url = `https://api.locationiq.com/v1/autocomplete?key=${encodeURIComponent(key)}&q=${encodeURIComponent(q)}&limit=10&normalizecity=1&dedupe=1`;
         const controller = new AbortController();
         const timeout = setTimeout(() => controller.abort(), 3000);
         const response = await fetch(url, { signal: controller.signal });
@@ -73,14 +73,21 @@ export async function locationRoutes(fastify: FastifyInstance) {
         if (!response.ok) return reply.send([]);
 
         const data = (await response.json()) as LocationIQResult[];
-        return data.map((r) => ({
-          placeId: r.place_id,
-          displayName: r.display_name,
-          displayPlace: r.display_place ?? r.display_name,
-          displayAddress: r.display_address ?? "",
-          lat: parseFloat(r.lat),
-          lon: parseFloat(r.lon),
-        }));
+        const seen = new Set<string>();
+        return data
+          .filter((r) => {
+            if (seen.has(r.place_id)) return false;
+            seen.add(r.place_id);
+            return true;
+          })
+          .map((r) => ({
+            placeId: r.place_id,
+            displayName: r.display_name,
+            displayPlace: r.display_place ?? r.display_name,
+            displayAddress: r.display_address ?? "",
+            lat: parseFloat(r.lat),
+            lon: parseFloat(r.lon),
+          }));
       } catch {
         return reply.send([]);
       }

--- a/apps/api/src/routes/location.routes.ts
+++ b/apps/api/src/routes/location.routes.ts
@@ -65,7 +65,7 @@ export async function locationRoutes(fastify: FastifyInstance) {
       if (!key) return reply.send([]);
 
       try {
-        const url = `https://api.locationiq.com/v1/autocomplete?key=${encodeURIComponent(key)}&q=${encodeURIComponent(q)}&limit=10&normalizecity=1&dedupe=1`;
+        const url = `https://api.locationiq.com/v1/autocomplete?key=${encodeURIComponent(key)}&q=${encodeURIComponent(q)}&limit=10&normalizecity=1&dedupe=1&accept-language=en`;
         const controller = new AbortController();
         const timeout = setTimeout(() => controller.abort(), 3000);
         const response = await fetch(url, { signal: controller.signal });

--- a/apps/web/src/app/(app)/trips/[id]/trip-detail-shell.tsx
+++ b/apps/web/src/app/(app)/trips/[id]/trip-detail-shell.tsx
@@ -607,6 +607,8 @@ export function TripDetailShell({
             }}
             accommodation={editingAccommodation}
             timezone={trip.preferredTimezone}
+            tripLat={trip.destinationLat}
+            tripLon={trip.destinationLon}
           />
         )}
 

--- a/apps/web/src/components/itinerary/create-accommodation-dialog.tsx
+++ b/apps/web/src/components/itinerary/create-accommodation-dialog.tsx
@@ -45,6 +45,8 @@ interface CreateAccommodationDialogProps {
   onSuccess?: () => void;
   tripStartDate?: string | null | undefined;
   tripEndDate?: string | null | undefined;
+  tripLat?: number | null;
+  tripLon?: number | null;
 }
 
 export function CreateAccommodationDialog({
@@ -55,6 +57,8 @@ export function CreateAccommodationDialog({
   onSuccess,
   tripStartDate,
   tripEndDate,
+  tripLat,
+  tripLon,
 }: CreateAccommodationDialogProps) {
   const { mutate: createAccommodation, isPending } = useCreateAccommodation();
   const [newLink, setNewLink] = useState<{ url: string; name: string }>({
@@ -254,6 +258,7 @@ export function CreateAccommodationDialog({
                           form.setValue("addressLat", result.lat);
                           form.setValue("addressLon", result.lon);
                         }}
+                        context={tripLat != null && tripLon != null ? { lat: tripLat, lon: tripLon } : null}
                         placeholder="123 Beach Blvd, Miami Beach, FL 33139"
                         disabled={isPending}
                       />

--- a/apps/web/src/components/itinerary/create-accommodation-dialog.tsx
+++ b/apps/web/src/components/itinerary/create-accommodation-dialog.tsx
@@ -254,7 +254,7 @@ export function CreateAccommodationDialog({
                           form.setValue("addressLon", null);
                         }}
                         onSelect={(result) => {
-                          field.onChange(result.displayName);
+                          field.onChange(result.shortName);
                           form.setValue("addressLat", result.lat);
                           form.setValue("addressLon", result.lon);
                         }}

--- a/apps/web/src/components/itinerary/create-event-dialog.tsx
+++ b/apps/web/src/components/itinerary/create-event-dialog.tsx
@@ -379,7 +379,7 @@ export function CreateEventDialog({
                           form.setValue("locationLon", null);
                         }}
                         onSelect={(result) => {
-                          field.onChange(result.displayName);
+                          field.onChange(result.shortName);
                           form.setValue("locationLat", result.lat);
                           form.setValue("locationLon", result.lon);
                         }}

--- a/apps/web/src/components/itinerary/create-event-dialog.tsx
+++ b/apps/web/src/components/itinerary/create-event-dialog.tsx
@@ -50,6 +50,8 @@ interface CreateEventDialogProps {
   onSuccess?: () => void;
   tripStartDate?: string | null | undefined;
   tripEndDate?: string | null | undefined;
+  tripLat?: number | null;
+  tripLon?: number | null;
 }
 
 export function CreateEventDialog({
@@ -60,6 +62,8 @@ export function CreateEventDialog({
   onSuccess,
   tripStartDate,
   tripEndDate,
+  tripLat,
+  tripLon,
 }: CreateEventDialogProps) {
   const { mutate: createEvent, isPending } = useCreateEvent();
   const [newLink, setNewLink] = useState<{ url: string; name: string }>({
@@ -379,6 +383,7 @@ export function CreateEventDialog({
                           form.setValue("locationLat", result.lat);
                           form.setValue("locationLon", result.lon);
                         }}
+                        context={tripLat != null && tripLon != null ? { lat: tripLat, lon: tripLon } : null}
                         placeholder="123 Main St, Miami Beach"
                         disabled={isPending}
                       />

--- a/apps/web/src/components/itinerary/edit-accommodation-dialog.tsx
+++ b/apps/web/src/components/itinerary/edit-accommodation-dialog.tsx
@@ -297,7 +297,7 @@ export function EditAccommodationDialog({
                           form.setValue("addressLon", null);
                         }}
                         onSelect={(result) => {
-                          field.onChange(result.displayName);
+                          field.onChange(result.shortName);
                           form.setValue("addressLat", result.lat);
                           form.setValue("addressLon", result.lon);
                         }}

--- a/apps/web/src/components/itinerary/edit-accommodation-dialog.tsx
+++ b/apps/web/src/components/itinerary/edit-accommodation-dialog.tsx
@@ -59,6 +59,8 @@ interface EditAccommodationDialogProps {
   onSuccess?: () => void;
   tripStartDate?: string | null | undefined;
   tripEndDate?: string | null | undefined;
+  tripLat?: number | null;
+  tripLon?: number | null;
 }
 
 export function EditAccommodationDialog({
@@ -69,6 +71,8 @@ export function EditAccommodationDialog({
   onSuccess,
   tripStartDate,
   tripEndDate,
+  tripLat,
+  tripLon,
 }: EditAccommodationDialogProps) {
   const { mutate: updateAccommodation, isPending } = useUpdateAccommodation();
   const { mutate: deleteAccommodation, isPending: isDeleting } =
@@ -297,6 +301,7 @@ export function EditAccommodationDialog({
                           form.setValue("addressLat", result.lat);
                           form.setValue("addressLon", result.lon);
                         }}
+                        context={tripLat != null && tripLon != null ? { lat: tripLat, lon: tripLon } : null}
                         placeholder="123 Beach Blvd, Miami Beach, FL 33139"
                         disabled={isPending || isDeleting}
                       />

--- a/apps/web/src/components/itinerary/edit-event-dialog.tsx
+++ b/apps/web/src/components/itinerary/edit-event-dialog.tsx
@@ -67,6 +67,8 @@ interface EditEventDialogProps {
   onSuccess?: () => void;
   tripStartDate?: string | null | undefined;
   tripEndDate?: string | null | undefined;
+  tripLat?: number | null;
+  tripLon?: number | null;
 }
 
 export function EditEventDialog({
@@ -77,6 +79,8 @@ export function EditEventDialog({
   onSuccess,
   tripStartDate,
   tripEndDate,
+  tripLat,
+  tripLon,
 }: EditEventDialogProps) {
   const { mutate: updateEvent, isPending } = useUpdateEvent();
   const { mutate: deleteEvent, isPending: isDeleting } = useDeleteEvent();
@@ -429,6 +433,7 @@ export function EditEventDialog({
                           form.setValue("locationLat", result.lat);
                           form.setValue("locationLon", result.lon);
                         }}
+                        context={tripLat != null && tripLon != null ? { lat: tripLat, lon: tripLon } : null}
                         placeholder="123 Main St, Miami Beach"
                         disabled={isPending || isDeleting}
                       />

--- a/apps/web/src/components/itinerary/edit-event-dialog.tsx
+++ b/apps/web/src/components/itinerary/edit-event-dialog.tsx
@@ -429,7 +429,7 @@ export function EditEventDialog({
                           form.setValue("locationLon", null);
                         }}
                         onSelect={(result) => {
-                          field.onChange(result.displayName);
+                          field.onChange(result.shortName);
                           form.setValue("locationLat", result.lat);
                           form.setValue("locationLon", result.lon);
                         }}

--- a/apps/web/src/components/itinerary/itinerary-header.tsx
+++ b/apps/web/src/components/itinerary/itinerary-header.tsx
@@ -45,6 +45,8 @@ interface ItineraryHeaderProps {
   hideFab?: boolean;
   tripStartDate?: string | null | undefined;
   tripEndDate?: string | null | undefined;
+  tripLat?: number | null;
+  tripLon?: number | null;
 }
 
 export function ItineraryHeader({
@@ -62,6 +64,8 @@ export function ItineraryHeader({
   hideFab,
   tripStartDate,
   tripEndDate,
+  tripLat,
+  tripLon,
 }: ItineraryHeaderProps) {
   const [isCreateEventOpen, setIsCreateEventOpen] = useState(false);
   const [isCreateAccommodationOpen, setIsCreateAccommodationOpen] =
@@ -184,6 +188,8 @@ export function ItineraryHeader({
         timezone={selectedTimezone}
         tripStartDate={tripStartDate}
         tripEndDate={tripEndDate}
+        tripLat={tripLat ?? null}
+        tripLon={tripLon ?? null}
       />
       <CreateAccommodationDialog
         open={isCreateAccommodationOpen}
@@ -192,6 +198,8 @@ export function ItineraryHeader({
         timezone={selectedTimezone}
         tripStartDate={tripStartDate}
         tripEndDate={tripEndDate}
+        tripLat={tripLat ?? null}
+        tripLon={tripLon ?? null}
       />
       <CreateMemberTravelDialog
         open={isCreateMemberTravelOpen}

--- a/apps/web/src/components/itinerary/itinerary-view.tsx
+++ b/apps/web/src/components/itinerary/itinerary-view.tsx
@@ -307,6 +307,8 @@ export function ItineraryView({
           timezone={timezone}
           tripStartDate={trip?.startDate || null}
           tripEndDate={trip?.endDate || null}
+          tripLat={trip?.destinationLat}
+          tripLon={trip?.destinationLon}
         />
         <CreateAccommodationDialog
           open={isCreateAccommodationOpen}
@@ -315,6 +317,8 @@ export function ItineraryView({
           timezone={timezone}
           tripStartDate={trip?.startDate || null}
           tripEndDate={trip?.endDate || null}
+          tripLat={trip?.destinationLat}
+          tripLon={trip?.destinationLon}
         />
         <DeletedItemsDialog
           open={isDeletedItemsOpen}
@@ -344,6 +348,8 @@ export function ItineraryView({
         {...(hideFab != null ? { hideFab } : {})}
         tripStartDate={trip?.startDate || null}
         tripEndDate={trip?.endDate || null}
+        tripLat={trip?.destinationLat ?? null}
+        tripLon={trip?.destinationLon ?? null}
       />
 
       {/* Content */}

--- a/apps/web/src/components/trip/create-trip-dialog.tsx
+++ b/apps/web/src/components/trip/create-trip-dialog.tsx
@@ -278,7 +278,7 @@ export function CreateTripDialog({
                               form.setValue("destinationLon", null);
                             }}
                             onSelect={(result) => {
-                              field.onChange(result.displayName);
+                              field.onChange(result.shortName);
                               form.setValue("destinationLat", result.lat);
                               form.setValue("destinationLon", result.lon);
                             }}

--- a/apps/web/src/components/trip/create-trip-dialog.tsx
+++ b/apps/web/src/components/trip/create-trip-dialog.tsx
@@ -28,7 +28,6 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { LocationInput } from "@/components/ui/location-input";
-import { Textarea } from "@/components/ui/textarea";
 import {
   Select,
   SelectContent,
@@ -36,13 +35,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
 import { ImageUpload } from "@/components/trip/image-upload";
 import { ThemePicker } from "@/components/trip/theme-picker";
 import { FontPicker } from "@/components/trip/font-picker";
 import { useThemePreview } from "@/hooks/use-theme-preview";
-import { CollapsibleSection } from "@/components/ui/collapsible-section";
 import { DatePicker } from "@/components/ui/date-picker";
 import { Loader2 } from "lucide-react";
 import { TIMEZONES } from "@/lib/constants";
@@ -124,7 +122,6 @@ export function CreateTripDialog({
       "destination",
       "startDate",
       "endDate",
-      "timezone",
     ];
 
     const isStep1Valid = await form.trigger(step1Fields);
@@ -340,104 +337,37 @@ export function CreateTripDialog({
                     />
                   </div>
 
-                  {/* More options (collapsed by default) */}
-                  <CollapsibleSection label="More options">
-                    <div className="space-y-4">
-                      {/* Timezone */}
-                      <FormField
-                        control={form.control}
-                        name="timezone"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel className="text-base font-semibold text-foreground">
-                              Trip timezone
-                              <span className="text-destructive ml-1">*</span>
-                            </FormLabel>
-                            <Select
-                              onValueChange={field.onChange}
-                              value={field.value}
-                            >
-                              <FormControl>
-                                <SelectTrigger
-                                  ref={field.ref}
-                                  onBlur={field.onBlur}
-                                  className="h-12 text-base rounded-md"
-                                  aria-required="true"
-                                >
-                                  <SelectValue />
-                                </SelectTrigger>
-                              </FormControl>
-                              <SelectContent>
-                                {TIMEZONES.map((tz) => (
-                                  <SelectItem key={tz.value} value={tz.value}>
-                                    {tz.label}
-                                  </SelectItem>
-                                ))}
-                              </SelectContent>
-                            </Select>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-
-                      {/* Description */}
-                      <FormField
-                        control={form.control}
-                        name="description"
-                        render={({ field }) => {
-                          const charCount = field.value?.length || 0;
-                          const showCounter = charCount >= 1600;
-
-                          return (
-                            <FormItem>
-                              <FormLabel className="text-base font-semibold text-foreground">
-                                Description
-                              </FormLabel>
-                              <FormControl>
-                                <Textarea
-                                  placeholder="Tell your group about this trip..."
-                                  className="h-32 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md resize-none"
-                                  disabled={isPending}
-                                  {...field}
-                                  value={field.value || ""}
-                                />
-                              </FormControl>
-                              {showCounter && (
-                                <div className="text-xs text-muted-foreground text-right">
-                                  {charCount} / 2000 characters
-                                </div>
-                              )}
-                              <FormMessage />
-                            </FormItem>
-                          );
-                        }}
-                      />
-
-                      {/* Allow Members to Add Events */}
-                      <FormField
-                        control={form.control}
-                        name="allowMembersToAddEvents"
-                        render={({ field }) => (
-                          <FormItem className="flex flex-row items-center space-x-3 space-y-0">
-                            <FormControl>
-                              <Checkbox
-                                checked={field.value ?? true}
-                                onCheckedChange={field.onChange}
-                                ref={field.ref}
-                                onBlur={field.onBlur}
-                                name={field.name}
-                                disabled={isPending}
-                                aria-label="Allow members to add events"
-                              />
-                            </FormControl>
-                            <FormLabel className="text-base font-semibold text-foreground cursor-pointer">
-                              Allow members to add events
-                            </FormLabel>
-                          </FormItem>
-                        )}
-                      />
-                    </div>
-                  </CollapsibleSection>
+                  {/* Description */}
+                  <FormField
+                    control={form.control}
+                    name="description"
+                    render={({ field }) => {
+                      const charCount = field.value?.length || 0;
+                      const showCounter = charCount >= 1600;
+                      return (
+                        <FormItem>
+                          <FormLabel className="text-base font-semibold text-foreground">
+                            Description
+                          </FormLabel>
+                          <FormControl>
+                            <Textarea
+                              placeholder="Tell your group about this trip..."
+                              className="h-32 text-base border-input focus-visible:border-ring focus-visible:ring-ring rounded-md resize-none"
+                              disabled={isPending}
+                              {...field}
+                              value={field.value || ""}
+                            />
+                          </FormControl>
+                          {showCounter && (
+                            <div className="text-xs text-muted-foreground text-right">
+                              {charCount} / 2000 characters
+                            </div>
+                          )}
+                          <FormMessage />
+                        </FormItem>
+                      );
+                    }}
+                  />
 
                   {/* Continue Button */}
                   <div className="flex justify-end pt-4">

--- a/apps/web/src/components/trip/create-trip-dialog.tsx
+++ b/apps/web/src/components/trip/create-trip-dialog.tsx
@@ -93,12 +93,15 @@ export function CreateTripDialog({
   const watchedThemeId = form.watch("themeId");
   const watchedThemeFont = form.watch("themeFont");
 
+  // Theme preview is intentionally disabled during creation — applying a theme
+  // to the dashboard page while picking for a new trip is disorienting.
+  // The theme takes effect when the user navigates to the trip after creation.
   useThemePreview({
     themeId: watchedThemeId ?? null,
     themeFont: watchedThemeFont ?? null,
     initialThemeId: null,
     initialThemeFont: null,
-    enabled: open,
+    enabled: false,
   });
 
   // Auto-suggest font when theme changes and no font is set yet

--- a/apps/web/src/components/trip/edit-trip-dialog.tsx
+++ b/apps/web/src/components/trip/edit-trip-dialog.tsx
@@ -54,6 +54,7 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { DatePicker } from "@/components/ui/date-picker";
+import { CollapsibleSection } from "@/components/ui/collapsible-section";
 import { Trash2, Loader2 } from "lucide-react";
 import { TIMEZONES } from "@/lib/constants";
 import { useState } from "react";
@@ -140,8 +141,7 @@ export function EditTripDialog({
       {
         onSuccess: (updatedTrip) => {
           const timezoneChanged = updatedTrip.preferredTimezone !== trip.preferredTimezone;
-          const timezoneDetectionFailed = destinationChanged && !updatedTrip.timezoneAutoUpdated && !timezoneChanged;
-          if (destinationChanged && (timezoneChanged || timezoneDetectionFailed)) {
+          if (destinationChanged && (timezoneChanged || !updatedTrip.timezoneAutoUpdated)) {
             setPendingTimezone(updatedTrip.preferredTimezone);
             setTimezoneConfirm({
               timezone: updatedTrip.preferredTimezone,
@@ -468,6 +468,47 @@ export function EditTripDialog({
                   </FormItem>
                 )}
               />
+
+              {/* More options */}
+              <CollapsibleSection label="More options">
+                <FormField
+                  control={form.control}
+                  name="timezone"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="text-base font-semibold text-foreground">
+                        Trip timezone
+                      </FormLabel>
+                      <Select
+                        onValueChange={field.onChange}
+                        value={field.value ?? ""}
+                        disabled={isPending || isDeleting}
+                      >
+                        <FormControl>
+                          <SelectTrigger
+                            ref={field.ref}
+                            onBlur={field.onBlur}
+                            className="h-12 text-base rounded-md"
+                          >
+                            <SelectValue />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {TIMEZONES.map((tz) => (
+                            <SelectItem key={tz.value} value={tz.value}>
+                              {tz.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormDescription className="text-sm text-muted-foreground">
+                        All trip times will be shown in this timezone
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </CollapsibleSection>
 
               {/* Submit Button */}
               <div className="flex justify-end pt-4">

--- a/apps/web/src/components/trip/edit-trip-dialog.tsx
+++ b/apps/web/src/components/trip/edit-trip-dialog.tsx
@@ -140,7 +140,8 @@ export function EditTripDialog({
       {
         onSuccess: (updatedTrip) => {
           const timezoneChanged = updatedTrip.preferredTimezone !== trip.preferredTimezone;
-          if (destinationChanged && timezoneChanged) {
+          const timezoneDetectionFailed = destinationChanged && !updatedTrip.timezoneAutoUpdated && !timezoneChanged;
+          if (destinationChanged && (timezoneChanged || timezoneDetectionFailed)) {
             setPendingTimezone(updatedTrip.preferredTimezone);
             setTimezoneConfirm({
               timezone: updatedTrip.preferredTimezone,
@@ -218,7 +219,7 @@ export function EditTripDialog({
                 <p className="text-sm text-muted-foreground">
                   {timezoneConfirm.detected
                     ? "We detected a new timezone for your destination. Confirm or change it below."
-                    : "We couldn't detect a timezone for your destination. Please select the correct one."}
+                    : "We couldn't detect a timezone for your new destination. Your previous timezone is shown below — confirm it's still correct or select a new one."}
                 </p>
               </div>
 
@@ -371,48 +372,6 @@ export function EditTripDialog({
                 />
               </div>
 
-              {/* Timezone */}
-              <FormField
-                control={form.control}
-                name="timezone"
-                render={({ field }) => {
-                  return (
-                    <FormItem>
-                      <FormLabel className="text-base font-semibold text-foreground">
-                        Trip timezone
-                        <span className="text-destructive ml-1">*</span>
-                      </FormLabel>
-                      <Select
-                        onValueChange={field.onChange}
-                        value={field.value ?? ""}
-                        disabled={isPending || isDeleting}
-                      >
-                        <FormControl>
-                          <SelectTrigger
-                            ref={field.ref}
-                            onBlur={field.onBlur}
-                            className="h-12 text-base rounded-md"
-                            aria-required="true"
-                          >
-                            <SelectValue />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          {TIMEZONES.map((tz) => (
-                            <SelectItem key={tz.value} value={tz.value}>
-                              {tz.label}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <FormDescription className="text-sm text-muted-foreground">
-                        All trip times will be shown in this timezone
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  );
-                }}
-              />
 
               {/* Description */}
               <FormField

--- a/apps/web/src/components/trip/edit-trip-dialog.tsx
+++ b/apps/web/src/components/trip/edit-trip-dialog.tsx
@@ -139,7 +139,8 @@ export function EditTripDialog({
       { tripId: trip.id, data },
       {
         onSuccess: (updatedTrip) => {
-          if (destinationChanged) {
+          const timezoneChanged = updatedTrip.preferredTimezone !== trip.preferredTimezone;
+          if (destinationChanged && timezoneChanged) {
             setPendingTimezone(updatedTrip.preferredTimezone);
             setTimezoneConfirm({
               timezone: updatedTrip.preferredTimezone,

--- a/apps/web/src/components/trip/edit-trip-dialog.tsx
+++ b/apps/web/src/components/trip/edit-trip-dialog.tsx
@@ -54,9 +54,8 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { DatePicker } from "@/components/ui/date-picker";
-import { CollapsibleSection } from "@/components/ui/collapsible-section";
 import { Trash2, Loader2 } from "lucide-react";
-import { TIMEZONES } from "@/lib/constants";
+import { TIMEZONES, getTimezoneLabel } from "@/lib/constants";
 import { useState } from "react";
 
 interface EditTripDialogProps {
@@ -469,46 +468,25 @@ export function EditTripDialog({
                 )}
               />
 
-              {/* More options */}
-              <CollapsibleSection label="More options">
-                <FormField
-                  control={form.control}
-                  name="timezone"
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel className="text-base font-semibold text-foreground">
-                        Trip timezone
-                      </FormLabel>
-                      <Select
-                        onValueChange={field.onChange}
-                        value={field.value ?? ""}
-                        disabled={isPending || isDeleting}
-                      >
-                        <FormControl>
-                          <SelectTrigger
-                            ref={field.ref}
-                            onBlur={field.onBlur}
-                            className="h-12 text-base rounded-md"
-                          >
-                            <SelectValue />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          {TIMEZONES.map((tz) => (
-                            <SelectItem key={tz.value} value={tz.value}>
-                              {tz.label}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <FormDescription className="text-sm text-muted-foreground">
-                        All trip times will be shown in this timezone
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </CollapsibleSection>
+              {/* Timezone */}
+              <div className="flex items-center justify-between py-1">
+                <div>
+                  <p className="text-base font-semibold text-foreground">Trip timezone</p>
+                  <p className="text-sm text-muted-foreground">{getTimezoneLabel(trip.preferredTimezone)}</p>
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={isPending || isDeleting}
+                  onClick={() => {
+                    setPendingTimezone(trip.preferredTimezone);
+                    setTimezoneConfirm({ timezone: trip.preferredTimezone, detected: false });
+                  }}
+                >
+                  Change
+                </Button>
+              </div>
 
               {/* Submit Button */}
               <div className="flex justify-end pt-4">

--- a/apps/web/src/components/trip/edit-trip-dialog.tsx
+++ b/apps/web/src/components/trip/edit-trip-dialog.tsx
@@ -312,7 +312,7 @@ export function EditTripDialog({
                           form.setValue("destinationLon", null);
                         }}
                         onSelect={(result) => {
-                          field.onChange(result.displayName);
+                          field.onChange(result.shortName);
                           form.setValue("destinationLat", result.lat);
                           form.setValue("destinationLon", result.lon);
                         }}

--- a/apps/web/src/components/trip/mobile/panels/info-panel.tsx
+++ b/apps/web/src/components/trip/mobile/panels/info-panel.tsx
@@ -495,6 +495,8 @@ export function InfoPanel({
           }}
           accommodation={editingAccommodation}
           timezone={timezone}
+          tripLat={trip.destinationLat}
+          tripLon={trip.destinationLon}
         />
       )}
 

--- a/apps/web/src/components/ui/location-input.tsx
+++ b/apps/web/src/components/ui/location-input.tsx
@@ -99,7 +99,7 @@ export function LocationInput({
         <Command shouldFilter={false}>
           <CommandList>
             <CommandEmpty>No results found.</CommandEmpty>
-            {suggestions.map((suggestion) => (
+            {suggestions.slice(0, 5).map((suggestion) => (
               <CommandItem
                 key={suggestion.placeId}
                 value={suggestion.displayName}

--- a/apps/web/src/components/ui/location-input.tsx
+++ b/apps/web/src/components/ui/location-input.tsx
@@ -101,7 +101,7 @@ export function LocationInput({
             <CommandEmpty>No results found.</CommandEmpty>
             {suggestions.map((suggestion) => (
               <CommandItem
-                key={`${suggestion.lat}-${suggestion.lon}`}
+                key={suggestion.placeId}
                 value={suggestion.displayName}
                 onSelect={() => handleSelect(suggestion)}
                 className="flex items-start gap-2 py-2 px-3 cursor-pointer"

--- a/apps/web/src/components/ui/location-input.tsx
+++ b/apps/web/src/components/ui/location-input.tsx
@@ -26,6 +26,7 @@ interface LocationInputProps {
   value: string;
   onChange: (value: string) => void;
   onSelect?: (result: LocationSuggestion) => void;
+  context?: { lat: number; lon: number } | null;
   placeholder?: string;
   disabled?: boolean;
   className?: string;
@@ -37,6 +38,7 @@ export function LocationInput({
   value,
   onChange,
   onSelect,
+  context,
   placeholder,
   disabled,
   className,
@@ -50,7 +52,7 @@ export function LocationInput({
     setQuery(value);
   }, [value]);
 
-  const { data: suggestions = [] } = useLocationAutocomplete(query);
+  const { data: suggestions = [] } = useLocationAutocomplete(query, context);
 
   const hasSuggestions = suggestions.length > 0;
 

--- a/apps/web/src/components/ui/location-input.tsx
+++ b/apps/web/src/components/ui/location-input.tsx
@@ -65,8 +65,8 @@ export function LocationInput({
   };
 
   const handleSelect = (suggestion: LocationSuggestion) => {
-    setQuery(suggestion.displayName);
-    onChange(suggestion.displayName);
+    setQuery(suggestion.shortName);
+    onChange(suggestion.shortName);
     onSelect?.(suggestion);
     setOpen(false);
     inputRef.current?.blur();

--- a/apps/web/src/hooks/use-location-autocomplete.ts
+++ b/apps/web/src/hooks/use-location-autocomplete.ts
@@ -5,6 +5,7 @@ import { useQuery, keepPreviousData } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/api";
 
 export interface LocationSuggestion {
+  placeId: string;
   displayName: string;
   displayPlace: string;
   displayAddress: string;

--- a/apps/web/src/hooks/use-location-autocomplete.ts
+++ b/apps/web/src/hooks/use-location-autocomplete.ts
@@ -22,15 +22,20 @@ function useDebounce(value: string, delay: number): string {
   return debouncedValue;
 }
 
-export function useLocationAutocomplete(query: string) {
+export function useLocationAutocomplete(
+  query: string,
+  context?: { lat: number; lon: number } | null,
+) {
   const debouncedQuery = useDebounce(query, 300);
 
   return useQuery<LocationSuggestion[]>({
-    queryKey: ["locations", "autocomplete", debouncedQuery],
-    queryFn: () =>
-      apiRequest<LocationSuggestion[]>(
-        `/locations/autocomplete?q=${encodeURIComponent(debouncedQuery)}`,
-      ),
+    queryKey: ["locations", "autocomplete", debouncedQuery, context?.lat, context?.lon],
+    queryFn: () => {
+      const params = new URLSearchParams({ q: debouncedQuery });
+      if (context?.lat != null) params.set("lat", String(context.lat));
+      if (context?.lon != null) params.set("lon", String(context.lon));
+      return apiRequest<LocationSuggestion[]>(`/locations/autocomplete?${params}`);
+    },
     enabled: debouncedQuery.length >= 2,
     staleTime: 5 * 60 * 1000,
     placeholderData: keepPreviousData,

--- a/apps/web/src/hooks/use-location-autocomplete.ts
+++ b/apps/web/src/hooks/use-location-autocomplete.ts
@@ -6,6 +6,7 @@ import { apiRequest } from "@/lib/api";
 
 export interface LocationSuggestion {
   placeId: string;
+  shortName: string;
   displayName: string;
   displayPlace: string;
   displayAddress: string;

--- a/apps/web/tests/e2e/trip-journey.spec.ts
+++ b/apps/web/tests/e2e/trip-journey.spec.ts
@@ -59,8 +59,6 @@ test.describe("Trip Journey", () => {
       await tripDetail.destinationInput.fill(tripDestination);
       await pickDate(page, tripDetail.startDateButton, "2026-10-12");
       await pickDate(page, tripDetail.endDateButton, "2026-10-14");
-      // Description is inside collapsed "More options" section
-      await page.getByText("More options").click();
       await tripDetail.descriptionInput.fill(tripDescription);
       await snap(page, "05-create-trip-step1");
       await tripDetail.continueButton.click();


### PR DESCRIPTION
## Summary

Follow-up polish to #131 based on testing and code review:

**Autocomplete quality**
- `accept-language=en` — eliminates Japanese/non-English cities crowding out English results (fixes "MIT" showing Mito, Japan)
- `dedupe=1` + server-side Set filter — eliminates duplicate place_id entries causing React key warnings
- Limit 5→10 from API, slice to 5 in dropdown — better recall without scrollbar
- `shortName` field: constructs "Cambridge, Massachusetts" / "Eiffel Tower, Paris" instead of storing the full verbose `displayName`
- `placeId` as React key — reliable unique key per result
- `viewbox` biasing toward trip destination for event/accommodation searches (±1° box, ~110km)

**Timezone UX**
- Show confirmation whenever destination changes AND (timezone changed OR detection failed) — previously silent when free-text entry couldn't be geocoded
- Skip confirmation when destination changes but timezone resolves identically (e.g. Paris → Lyon)
- Edit trip form: replace timezone collapsible with inline display + "Change" button that opens the existing confirmation view
- Create trip step 1: remove "More options" — timezone auto-detected, description kept visible, allow-members defaults to true
- Disable theme preview during creation (was leaking into dashboard)

**Code quality**
- Full `LocationIQResult` type from actual API response shape
- `timezoneDetectionFailed` condition simplified
- Timezone context wired to `EditAccommodationDialog` in `trip-detail-shell` and `info-panel`

## Test plan
- [ ] Searching "MIT" returns MIT Lincoln Laboratory and Kendall/MIT
- [ ] No duplicate key warnings in console
- [ ] Selecting a location in a Paris trip shows Paris-area results first
- [ ] Stored location shows "Cambridge, Massachusetts" not the verbose string
- [ ] Editing destination to an unrecognized place shows timezone confirmation
- [ ] Editing destination to same-timezone place skips confirmation
- [ ] Create trip step 1 has no More options dropdown
- [ ] Theme picker in step 2 doesn't change dashboard colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)