### PR TITLE
Switch location autocomplete from LocationIQ to Foursquare

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -73,9 +73,9 @@ VAPID_SUBJECT=mailto:hello@journiful.app
 # Get your affiliate ID from https://www.booking.com/affiliate-program/v2/index.html
 # BOOKING_AFFILIATE_ID=your-affiliate-id
 
-# LocationIQ Autocomplete (optional -- location autocomplete returns empty if not set)
-# Sign up at https://locationiq.com (free tier: 5,000 req/day)
-# LOCATIONIQ_API_KEY=your-locationiq-key
+# Foursquare Autocomplete (required - throws error if not set)
+# Sign up at https://studio.foursquare.com (free tier available)
+# FOURSQUARE_API_KEY=your-foursquare-key
 
 # Comma-separated phone numbers for auto-admin promotion (E.164 format, e.g., +1234567890)
 ADMIN_PHONE_NUMBERS=

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -98,8 +98,8 @@ const envSchema = z.object({
   // Booking.com Affiliate (optional — suggestions hidden if not set)
   BOOKING_AFFILIATE_ID: z.string().default(""),
 
-  // LocationIQ (optional — autocomplete returns empty if not set)
-  LOCATIONIQ_API_KEY: z.string().default(""),
+  // Foursquare (optional — autocomplete returns empty if not set)
+  FOURSQUARE_API_KEY: z.string().default(""),
 
   ADMIN_PHONE_NUMBERS: z
     .string()

--- a/apps/api/src/routes/location.routes.ts
+++ b/apps/api/src/routes/location.routes.ts
@@ -108,7 +108,7 @@ export async function locationRoutes(fastify: FastifyInstance) {
       try {
         const params = new URLSearchParams({
           query: q,
-          limit: "10",
+          limit: "20",
         });
 
         if (lat != null && lon != null) {
@@ -150,9 +150,17 @@ export async function locationRoutes(fastify: FastifyInstance) {
               };
             } else if (r.type === "geo" && r.geo) {
               const geo = r.geo;
+              const geoParts = r.text.primary.split(",").map((p: string) => p.trim());
+              const geoShortName =
+                geo.cc === "US"
+                  ? r.text.primary
+                  : geoParts.length >= 3
+                    ? `${geoParts[0]}, ${geoParts[geoParts.length - 1]}`
+                    : r.text.primary;
+
               return {
                 placeId: geo.name,
-                shortName: r.text.primary,
+                shortName: geoShortName,
                 displayName: geo.name,
                 displayPlace: geo.name,
                 displayAddress: r.text.secondary,

--- a/apps/api/src/routes/location.routes.ts
+++ b/apps/api/src/routes/location.routes.ts
@@ -134,11 +134,14 @@ export async function locationRoutes(fastify: FastifyInstance) {
 
         const data = (await response.json()) as FoursquareAutocompleteResponse;
 
+        const seen = new Set<string>();
         return data.results
           .filter((r) => (r.type === "place" && r.place) || r.type === "geo")
           .map((r) => {
             if (r.type === "place" && r.place) {
               const place = r.place;
+              if (seen.has(place.fsq_place_id)) return null;
+              seen.add(place.fsq_place_id);
               return {
                 placeId: place.fsq_place_id,
                 shortName: formatPlaceShortName(place),
@@ -150,6 +153,9 @@ export async function locationRoutes(fastify: FastifyInstance) {
               };
             } else if (r.type === "geo" && r.geo) {
               const geo = r.geo;
+              if (seen.has(geo.name)) return null;
+              seen.add(geo.name);
+              if (!geo.center?.latitude || !geo.center?.longitude) return null;
               const geoParts = r.text.primary.split(",").map((p: string) => p.trim());
               const geoShortName =
                 geo.cc === "US"

--- a/apps/api/src/routes/location.routes.ts
+++ b/apps/api/src/routes/location.routes.ts
@@ -76,12 +76,15 @@ type FoursquareAutocompleteResponse = {
   results: FoursquareResult[];
 };
 
-function buildShortName(text: FoursquareText): string {
-  const primary = text.primary;
-  const secondary = text.secondary;
-  const parts = secondary.split(",").map((p) => p.trim());
-  const lastPart = parts[parts.length - 1];
-  return lastPart && lastPart !== primary ? `${primary}, ${lastPart}` : primary;
+function formatPlaceShortName(place: FoursquarePlace): string {
+  const city = place.location.locality || "";
+  const region = place.location.region || "";
+  const country = place.location.country || "";
+
+  if (country === "US") {
+    return city && region ? `${city}, ${region}` : city || place.name;
+  }
+  return city && region ? `${city}, ${region}` : city || place.name;
 }
 
 export async function locationRoutes(fastify: FastifyInstance) {
@@ -138,7 +141,7 @@ export async function locationRoutes(fastify: FastifyInstance) {
               const place = r.place;
               return {
                 placeId: place.fsq_place_id,
-                shortName: buildShortName(r.text),
+                shortName: formatPlaceShortName(place),
                 displayName: place.name,
                 displayPlace: place.location.locality || place.name,
                 displayAddress: place.location.formatted_address || r.text.secondary,

--- a/apps/api/src/routes/location.routes.ts
+++ b/apps/api/src/routes/location.routes.ts
@@ -21,45 +21,67 @@ const locationSuggestionSchema = z.object({
 
 const autocompleteResponseSchema = z.array(locationSuggestionSchema);
 
-type LocationIQAddress = {
-  name?: string;
-  house_number?: string;
-  road?: string;
-  suburb?: string;
-  city?: string;
-  town?: string;
-  village?: string;
-  county?: string;
-  state?: string;
-  postcode?: string;
-  country?: string;
-  country_code?: string;
+type FoursquareText = {
+  primary: string;
+  secondary: string;
+  highlight: Array<{ start: number; length: number }>;
 };
 
-type LocationIQResult = {
-  place_id: string;
-  osm_id: string;
-  osm_type: string;
-  lat: string;
-  lon: string;
-  boundingbox: [string, string, string, string];
-  class: string;
+type FoursquareLocation = {
+  address: string;
+  locality: string;
+  region: string;
+  postcode: string;
+  country: string;
+  formatted_address: string;
+};
+
+type FoursquarePlace = {
+  fsq_place_id: string;
+  latitude: number;
+  longitude: number;
+  categories: Array<{
+    fsq_category_id: string;
+    name: string;
+    short_name: string;
+    plural_name: string;
+    icon: { prefix: string; suffix: string };
+  }>;
+  distance: number;
+  location: FoursquareLocation;
+  name: string;
+};
+
+type FoursquareGeo = {
+  name: string;
+  center: { latitude: number; longitude: number };
+  bounds: {
+    ne: { latitude: number; longitude: number };
+    sw: { latitude: number; longitude: number };
+  };
+  cc: string;
   type: string;
-  display_name: string;
-  display_place?: string;
-  display_address?: string;
-  address?: LocationIQAddress;
 };
 
-function buildShortName(r: LocationIQResult): string {
-  const place = r.display_place ?? r.display_name;
-  const addr = r.address;
-  if (!addr) return place;
-  const city = addr.city ?? addr.town ?? addr.village ?? addr.suburb;
-  const region = addr.country_code === "us" ? addr.state : addr.country;
-  // Use city as secondary if it differs from the place name, otherwise use region
-  const secondary = city && city !== place ? city : region;
-  return [place, secondary].filter(Boolean).join(", ");
+type FoursquareResult = {
+  type: "search" | "place" | "geo";
+  text: FoursquareText;
+  link: string;
+  place?: FoursquarePlace;
+  search?: { query: string };
+  geo?: FoursquareGeo;
+};
+
+type FoursquareAutocompleteResponse = {
+  results: FoursquareResult[];
+};
+
+function buildShortName(text: FoursquareText): string {
+  const primary = text.primary;
+  const secondary = text.secondary;
+  const parts = secondary.split(",").map((p) => p.trim());
+  const lastPart = parts[parts.length - 1];
+  return lastPart && lastPart !== primary ? `${primary}, ${lastPart}` : primary;
 }
 
 export async function locationRoutes(fastify: FastifyInstance) {
@@ -74,40 +96,70 @@ export async function locationRoutes(fastify: FastifyInstance) {
     },
     async (request, reply) => {
       const { q, lat, lon } = request.query;
-      const key = request.server.config.LOCATIONIQ_API_KEY;
+      const key = request.server.config.FOURSQUARE_API_KEY;
 
-      if (!key) return reply.send([]);
+      if (!key) {
+        throw new Error("FOURSQUARE_API_KEY is not configured");
+      }
 
       try {
-        const DELTA = 1; // ~110km bounding box
-        const viewbox =
-          lat != null && lon != null
-            ? `&viewbox=${lon + DELTA},${lat + DELTA},${lon - DELTA},${lat - DELTA}`
-            : "";
-        const url = `https://api.locationiq.com/v1/autocomplete?key=${encodeURIComponent(key)}&q=${encodeURIComponent(q)}&limit=10&normalizecity=1&dedupe=1&accept-language=en${viewbox}`;
+        const params = new URLSearchParams({
+          query: q,
+          limit: "10",
+        });
+
+        if (lat != null && lon != null) {
+          params.set("ll", `${lat},${lon}`);
+          params.set("radius", "50000");
+        }
+
+        const url = `https://places-api.foursquare.com/autocomplete?${params}`;
         const controller = new AbortController();
         const timeout = setTimeout(() => controller.abort(), 3000);
-        const response = await fetch(url, { signal: controller.signal });
+
+        const response = await fetch(url, {
+          signal: controller.signal,
+          headers: {
+            Authorization: `Bearer ${key}`,
+            "X-Places-Api-Version": "2025-06-17",
+            Accept: "application/json",
+          },
+        });
+
         clearTimeout(timeout);
         if (!response.ok) return reply.send([]);
 
-        const data = (await response.json()) as LocationIQResult[];
-        const seen = new Set<string>();
-        return data
-          .filter((r) => {
-            if (seen.has(r.place_id)) return false;
-            seen.add(r.place_id);
-            return true;
+        const data = (await response.json()) as FoursquareAutocompleteResponse;
+
+        return data.results
+          .filter((r) => (r.type === "place" && r.place) || r.type === "geo")
+          .map((r) => {
+            if (r.type === "place" && r.place) {
+              const place = r.place;
+              return {
+                placeId: place.fsq_place_id,
+                shortName: buildShortName(r.text),
+                displayName: place.name,
+                displayPlace: place.location.locality || place.name,
+                displayAddress: place.location.formatted_address || r.text.secondary,
+                lat: place.latitude,
+                lon: place.longitude,
+              };
+            } else if (r.type === "geo" && r.geo) {
+              const geo = r.geo;
+              return {
+                placeId: geo.name,
+                shortName: r.text.primary,
+                displayName: geo.name,
+                displayPlace: geo.name,
+                displayAddress: r.text.secondary,
+                lat: geo.center.latitude,
+                lon: geo.center.longitude,
+              };
+            }
+            return null;
           })
-          .map((r) => ({
-            placeId: r.place_id,
-            shortName: buildShortName(r),
-            displayName: r.display_name,
-            displayPlace: r.display_place ?? r.display_name,
-            displayAddress: r.display_address ?? "",
-            lat: parseFloat(r.lat),
-            lon: parseFloat(r.lon),
-          }));
+          .filter(Boolean);
       } catch {
         return reply.send([]);
       }


### PR DESCRIPTION
## Summary

- Replaced LocationIQ API with Foursquare Places Autocomplete API
- Updated environment variable from `LOCATIONIQ_API_KEY` to `FOURSQUARE_API_KEY`
- Added error throwing when API key is not configured (instead of silent empty response)
- Now returns both geo (cities) and place (business) results

## Changes

- `apps/api/src/config/env.ts` - Replace env var
- `apps/api/src/routes/location.routes.ts` - Rewrite to use Foursquare API
- `apps/api/.env.example` - Update documentation

## Testing

- Verified local API returns results for "lisbon" query
- Railway variable `FOURSQUARE_API_KEY` already set in production