### PR TITLE
fix: improve location autocomplete display fields

### DIFF
--- a/apps/api/src/routes/location.routes.ts
+++ b/apps/api/src/routes/location.routes.ts
@@ -76,17 +76,6 @@ type FoursquareAutocompleteResponse = {
   results: FoursquareResult[];
 };
 
-function formatPlaceShortName(place: FoursquarePlace): string {
-  const city = place.location.locality || "";
-  const region = place.location.region || "";
-  const country = place.location.country || "";
-
-  if (country === "US") {
-    return city && region ? `${city}, ${region}` : city || place.name;
-  }
-  return city && region ? `${city}, ${region}` : city || place.name;
-}
-
 export async function locationRoutes(fastify: FastifyInstance) {
   fastify.get<{ Querystring: z.infer<typeof autocompleteQuerySchema> }>(
     "/autocomplete",
@@ -144,7 +133,7 @@ export async function locationRoutes(fastify: FastifyInstance) {
               seen.add(place.fsq_place_id);
               return {
                 placeId: place.fsq_place_id,
-                shortName: formatPlaceShortName(place),
+                shortName: place.name,
                 displayName: place.name,
                 displayPlace: place.location.locality || place.name,
                 displayAddress: place.location.formatted_address || r.text.secondary,
@@ -167,8 +156,8 @@ export async function locationRoutes(fastify: FastifyInstance) {
               return {
                 placeId: geo.name,
                 shortName: geoShortName,
-                displayName: geo.name,
-                displayPlace: geo.name,
+                displayName: r.text.primary,
+                displayPlace: r.text.primary,
                 displayAddress: r.text.secondary,
                 lat: geo.center.latitude,
                 lon: geo.center.longitude,

--- a/apps/web/src/components/itinerary/create-accommodation-dialog.tsx
+++ b/apps/web/src/components/itinerary/create-accommodation-dialog.tsx
@@ -258,7 +258,7 @@ export function CreateAccommodationDialog({
                           form.setValue("addressLat", result.lat);
                           form.setValue("addressLon", result.lon);
                         }}
-                        context={tripLat != null && tripLon != null ? { lat: tripLat, lon: tripLon } : null}
+                        context={tripLat != null && tripLon != null && tripLat !== undefined && tripLon !== undefined ? { lat: tripLat, lon: tripLon } : null}
                         placeholder="123 Beach Blvd, Miami Beach, FL 33139"
                         disabled={isPending}
                       />

--- a/apps/web/src/components/itinerary/create-event-dialog.tsx
+++ b/apps/web/src/components/itinerary/create-event-dialog.tsx
@@ -383,7 +383,7 @@ export function CreateEventDialog({
                           form.setValue("locationLat", result.lat);
                           form.setValue("locationLon", result.lon);
                         }}
-                        context={tripLat != null && tripLon != null ? { lat: tripLat, lon: tripLon } : null}
+                        context={tripLat != null && tripLon != null && tripLat !== undefined && tripLon !== undefined ? { lat: tripLat, lon: tripLon } : null}
                         placeholder="123 Main St, Miami Beach"
                         disabled={isPending}
                       />

--- a/apps/web/src/components/itinerary/day-by-day-view.tsx
+++ b/apps/web/src/components/itinerary/day-by-day-view.tsx
@@ -41,6 +41,8 @@ interface DayByDayViewProps {
   timezone: string;
   tripStartDate: string | null;
   tripEndDate: string | null;
+  tripLat?: number | null;
+  tripLon?: number | null;
   isOrganizer: boolean;
   userId: string;
   userNameMap: Map<string, string>;
@@ -76,6 +78,8 @@ export function DayByDayView({
   timezone,
   tripStartDate,
   tripEndDate,
+  tripLat,
+  tripLon,
   isOrganizer,
   userId,
   userNameMap,
@@ -473,6 +477,8 @@ export function DayByDayView({
           timezone={timezone}
           tripStartDate={tripStartDate}
           tripEndDate={tripEndDate}
+          tripLat={tripLat ?? null}
+          tripLon={tripLon ?? null}
         />
       )}
       {editingMemberTravel && (

--- a/apps/web/src/components/itinerary/edit-accommodation-dialog.tsx
+++ b/apps/web/src/components/itinerary/edit-accommodation-dialog.tsx
@@ -301,7 +301,7 @@ export function EditAccommodationDialog({
                           form.setValue("addressLat", result.lat);
                           form.setValue("addressLon", result.lon);
                         }}
-                        context={tripLat != null && tripLon != null ? { lat: tripLat, lon: tripLon } : null}
+                        context={tripLat != null && tripLon != null && tripLat !== undefined && tripLon !== undefined ? { lat: tripLat, lon: tripLon } : null}
                         placeholder="123 Beach Blvd, Miami Beach, FL 33139"
                         disabled={isPending || isDeleting}
                       />

--- a/apps/web/src/components/itinerary/edit-event-dialog.tsx
+++ b/apps/web/src/components/itinerary/edit-event-dialog.tsx
@@ -433,7 +433,7 @@ export function EditEventDialog({
                           form.setValue("locationLat", result.lat);
                           form.setValue("locationLon", result.lon);
                         }}
-                        context={tripLat != null && tripLon != null ? { lat: tripLat, lon: tripLon } : null}
+                        context={tripLat != null && tripLon != null && tripLat !== undefined && tripLon !== undefined ? { lat: tripLat, lon: tripLon } : null}
                         placeholder="123 Main St, Miami Beach"
                         disabled={isPending || isDeleting}
                       />

--- a/apps/web/src/components/itinerary/itinerary-view.tsx
+++ b/apps/web/src/components/itinerary/itinerary-view.tsx
@@ -385,6 +385,8 @@ export function ItineraryView({
           timezone={timezone}
           tripStartDate={trip?.startDate || null}
           tripEndDate={trip?.endDate || null}
+          tripLat={trip?.destinationLat ?? null}
+          tripLon={trip?.destinationLon ?? null}
           isOrganizer={!!isOrganizer}
           userId={user?.id || ""}
           userNameMap={userNameMap}

--- a/apps/web/src/components/trip/mobile/panels/info-panel.tsx
+++ b/apps/web/src/components/trip/mobile/panels/info-panel.tsx
@@ -390,6 +390,8 @@ export function InfoPanel({
               isLocked={isLocked}
               tripStartDate={trip.startDate}
               tripEndDate={trip.endDate}
+              tripLat={trip.destinationLat ?? null}
+              tripLon={trip.destinationLon ?? null}
               {...(isOrganizer
                 ? { onAddEvent: () => setIsCreateEventOpen(true) }
                 : {})}

--- a/apps/web/src/components/trip/mobile/panels/today-section.tsx
+++ b/apps/web/src/components/trip/mobile/panels/today-section.tsx
@@ -18,6 +18,8 @@ interface TodaySectionProps {
   isLocked?: boolean;
   tripStartDate?: string | null;
   tripEndDate?: string | null;
+  tripLat?: number | null;
+  tripLon?: number | null;
   onAddEvent?: () => void;
 }
 
@@ -28,6 +30,8 @@ export function TodaySection({
   isLocked = false,
   tripStartDate,
   tripEndDate,
+  tripLat,
+  tripLon,
   onAddEvent,
 }: TodaySectionProps) {
   const { user } = useAuth();
@@ -177,6 +181,8 @@ export function TodaySection({
           timezone={timezone}
           tripStartDate={tripStartDate ?? undefined}
           tripEndDate={tripEndDate ?? undefined}
+          tripLat={tripLat ?? null}
+          tripLon={tripLon ?? null}
         />
       )}
     </div>

--- a/apps/web/src/components/ui/location-input.tsx
+++ b/apps/web/src/components/ui/location-input.tsx
@@ -111,7 +111,7 @@ export function LocationInput({
                 <MapPin className="w-4 h-4 mt-0.5 shrink-0 text-muted-foreground" />
                 <div className="min-w-0">
                   <p className="text-sm font-medium truncate">
-                    {suggestion.displayPlace}
+                    {suggestion.displayName}
                   </p>
                   <p className="text-xs text-muted-foreground truncate">
                     {suggestion.displayAddress}


### PR DESCRIPTION
## Summary

- Fix `shortName` for place results: uses `place.name` (e.g. "MIT Johnson Athletics Center") instead of just the city/region ("Cambridge, MA")
- Fix `displayName`/`displayPlace` for geo results: uses `r.text.primary` (e.g. "Cambridge, MA") instead of `geo.name` which can include county ("Cambridge, Middlesex, MA")
- Fix frontend `LocationInput` dropdown: renders `displayName` as the primary label instead of `displayPlace` (was showing just city name)
- Remove unused `formatPlaceShortName` helper