### PR TITLE
feat: sticky PR review comment + inline feedback for OpenCode workflow

### DIFF
--- a/.github/GITHUB_ACTIONS_SETUP.md
+++ b/.github/GITHUB_ACTIONS_SETUP.md
@@ -191,6 +191,46 @@ pnpm --filter @tripful/web exec playwright test --grep @smoke
 - 40 commits to main x 7 min = 280 minutes/month
 - **Total: ~360 minutes/month** (well within free tier)
 
+## OpenCode PR Review Workflow
+
+An automated AI code review powered by **OpenCode** and **DeepSeek V4 Flash** via the OpenCode Go subscription. Every pull request gets reviewed for code quality, security, and project convention compliance — running in parallel alongside the CI pipeline.
+
+### Triggers
+
+- PR `opened`, `synchronize`, `reopened` — reviews on each update
+- PR `ready_for_review` — reviews when a draft is marked ready
+- **Draft PRs are skipped** (no noise while work is in progress)
+
+### Required Secret
+
+| Secret | Source | Notes |
+|--------|--------|-------|
+| `OPENCODE_API_KEY` | [opencode.ai/auth](https://opencode.ai/auth) | OpenCode Go subscription key (~$10/month, ~31,650 requests/5h window for DeepSeek V4 Flash) |
+
+### Setup
+
+1. Subscribe to **OpenCode Go** at [opencode.ai/auth](https://opencode.ai/auth) to get an API key
+2. In GitHub repo, go to **Settings** → **Secrets and variables** → **Actions**
+3. Add a new repository secret: `OPENCODE_API_KEY` with your subscription key
+4. The `GITHUB_TOKEN` is auto-provided by the Actions runner (no setup needed)
+
+The workflow is ready to use — no additional configuration required.
+
+### What It Reviews
+
+- Code quality and TypeScript safety
+- Security: auth flows, cookie handling, secrets exposure
+- Database query patterns (Drizzle ORM)
+- Tailwind v4 constraints (`@theme` colors must be hex, never `hsl()`)
+- Shared package import conventions (`@journiful/shared/schemas` only)
+- React/Fastify best practices specific to this project
+
+The review is posted as a PR comment with actionable feedback. It is **advisory only** — not a required status check.
+
+### Workflow File
+
+`.github/workflows/opencode-review.yml`
+
 ## Workflow File Location
 
 `.github/workflows/ci.yml`

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -1,0 +1,139 @@
+name: OpenCode PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Post in-progress sticky comment
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          header: opencode-review
+          recreate: true
+          message: |
+            <!-- opencode-review-marker -->
+
+            ## 🔄 AI Review in Progress
+
+            **Commit**: `${{ github.event.pull_request.head.sha }}`
+            **Started**: ${{ github.event.pull_request.updated_at }}
+
+            ---
+            _Reviewing changes..._
+
+      - uses: anomalyco/opencode/github@latest
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: opencode-go/deepseek-v4-flash
+          use_github_token: true
+          prompt: |
+            You are reviewing a pull request for the Journiful project — a collaborative trip planning platform.
+
+            Tech stack: Fastify 5 (API), Next.js 16 (Web), React 19, Drizzle ORM + PostgreSQL 16, Tailwind CSS v4, shadcn/ui, TanStack Query v5.
+
+            ---
+
+            ## Phase 1 — Hide the OpenCode working comment
+
+            Find and minimize the "[Working...]" comment this action just posted:
+            ```bash
+            WORKING_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+              --jq 'map(select(.body | contains("[Working..."))) | .[0].id')
+            gh api "repos/${{ github.repository }}/issues/comments/$WORKING_ID/minimize" --method PUT
+            ```
+
+            ## Phase 2 — Review the diff
+
+            Fetch the base branch and examine changes:
+            ```bash
+            git fetch origin "${{ github.event.pull_request.base.ref }}" --depth=50
+            git diff "origin/${{ github.event.pull_request.base.ref }}...HEAD"
+            ```
+
+            Focus on:
+            - Code quality and TypeScript safety
+            - Security: auth flows, cookie handling, secrets exposure
+            - Database query patterns (Drizzle ORM usage)
+            - Tailwind v4 constraints: @theme colors MUST be hex, never hsl()
+            - Shared package imports: use @journiful/shared/schemas, never relative paths with file extensions
+            - React best practices: proper RSC boundaries, async data patterns, metadata conventions
+            - Fastify best practices: route → controller → service pattern, proper error handling
+
+            ## Phase 3 — Post inline review comments
+
+            For each issue found, post an INLINE comment on the specific line using:
+            ```bash
+            gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments" \
+              --method POST \
+              -f body="🔴 Critical / 🟡 Warning / 🔵 Suggestion: Your specific feedback here" \
+              -f commit_id="$(git rev-parse HEAD)" \
+              -f path="path/to/file.ts" \
+              -f line=<line_number> \
+              -f side="RIGHT"
+            ```
+            - Use `side: RIGHT` and line numbers from the NEW file (not the diff position).
+            - Prepend each comment with the severity emoji.
+            - Be specific — reference variable names, function names, exact issues.
+            - Only post comments for actual issues. Do not post "looks good" or empty comments.
+
+            ## Phase 4 — Update the sticky verdict comment
+
+            Find the review comment and update it with the final verdict:
+            ```bash
+            STICKY_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+              --jq 'map(select(.body | contains("<!-- opencode-review-marker -->"))) | .[0].id')
+            COMMIT=$(git rev-parse --short HEAD)
+            NOW=$(date -u '+%Y-%m-%d %H:%M UTC')
+
+            # Count severity levels from any inline comments you posted
+            CRITICAL=...  # count of 🔴
+            WARNING=...   # count of 🟡
+            SUGGESTION=... # count of 🔵
+
+            # Determine verdict
+            if [ "$CRITICAL" -gt 0 ]; then
+              VERDICT="⚠️ **Request Changes**"
+            elif [ "$WARNING" -gt 0 ]; then
+              VERDICT="💬 **Comment**"
+            else
+              VERDICT="✅ **Approve**"
+            fi
+
+            gh api "repos/${{ github.repository }}/issues/comments/$STICKY_ID" \
+              --method PATCH \
+              -f body="<!-- opencode-review-marker -->
+
+            $VERDICT
+
+            **Commit**: \`$COMMIT\`
+            **Completed**: $NOW
+
+            ### Issues Found
+            🔴 $CRITICAL critical &nbsp;|&nbsp; 🟡 $WARNING warning &nbsp;|&nbsp; 🔵 $SUGGESTION suggestion
+
+            ### Summary
+            <Replace with a 2-3 sentence summary of the review findings.>
+
+            ---
+            *Automated review by [OpenCode](https://opencode.ai)*"
+            ```

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -119,7 +119,15 @@ jobs:
             ### Issues Found
             🔴 0 critical &nbsp;|&nbsp; 🟡 2 warnings &nbsp;|&nbsp; 🔵 1 suggestion
 
-            2-3 sentence summary of findings.
+            <details>
+            <summary>View details</summary>
+
+            <!-- One bullet per issue posted, grouped by severity -->
+            - 🔴 **Critical**: one-liner about the issue
+            - 🟡 **Warning**: one-liner about the issue
+            - 🔵 **Suggestion**: one-liner about the issue
+
+            </details>
 
             ---
             *Automated review by [OpenCode](https://opencode.ai)*

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Post in-progress sticky comment
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           STICKY_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
             --jq 'map(select(.body | contains("<!-- opencode-review-marker -->"))) | last | .id')
@@ -58,6 +60,7 @@ jobs:
         shell: bash
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           # CI is non-interactive — permission prompts would block indefinitely
           opencode run \
@@ -125,6 +128,8 @@ jobs:
 
       - name: Update sticky verdict comment
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           STICKY_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
             --jq 'map(select(.body | contains("<!-- opencode-review-marker -->"))) | last | .id')

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -129,7 +129,6 @@ jobs:
 
           if [ ! -f /tmp/review-comments.json ] || [ "$(jq 'length' /tmp/review-comments.json)" -eq 0 ]; then
             echo "No comments to post"
-            echo "[]" > /tmp/comment-urls.json
             exit 0
           fi
 
@@ -162,29 +161,11 @@ jobs:
 
           echo "$REVIEW_PAYLOAD" > /tmp/review-payload.json
 
-          # Batch POST review and capture review ID
-          REVIEW_ID=$(gh api "repos/$REPO/pulls/${{ github.event.pull_request.number }}/reviews" \
+          # Batch POST review
+          gh api "repos/$REPO/pulls/${{ github.event.pull_request.number }}/reviews" \
             --method POST \
             --input /tmp/review-payload.json \
-            --jq '.id')
-
-          echo "Posted review #$REVIEW_ID, waiting for comments to index..."
-
-          # Poll until comments appear or max retries
-          for i in $(seq 1 10); do
-            sleep 2
-            COUNT=$(gh api "repos/$REPO/pulls/${{ github.event.pull_request.number }}/comments?per_page=50" \
-              --jq '[.[] | select(.pull_request_review_id == '$REVIEW_ID')] | length')
-            if [ "$COUNT" -gt 0 ]; then
-              echo "Found $COUNT comment(s) after ${i}x2s"
-              break
-            fi
-          done
-
-          # GET comments and extract html_urls in order
-          gh api "repos/$REPO/pulls/${{ github.event.pull_request.number }}/comments?per_page=50" \
-            --jq '[.[] | select(.pull_request_review_id == '$REVIEW_ID')] | sort_by(.id) | map({html_url})' \
-            > /tmp/comment-urls.json
+            --jq '.id' > /dev/null
 
       - name: Update sticky verdict
         shell: bash
@@ -213,27 +194,20 @@ jobs:
             VERDICT="✅ **Approve**"
           fi
 
-          # Build details block with hyperlinks (index-based, same order as comment-urls.json)
+          # Build details block from review data
           DETAILS=""
-          if [ -f /tmp/comment-urls.json ] && jq -e '. | type == "array"' /tmp/comment-urls.json > /dev/null 2>&1; then
-            while read -r item; do
-              IDX=$(echo "$item" | jq -r '.index')
-              LABEL=$(echo "$item" | jq -r '.value.label')
-              SUMMARY=$(echo "$item" | jq -r '.value.summary')
+          while read -r item; do
+            LABEL=$(echo "$item" | jq -r '.label')
+            SUMMARY=$(echo "$item" | jq -r '.summary')
 
-              URL=$(jq -r "try .[$IDX].html_url // \"\"" /tmp/comment-urls.json 2>/dev/null)
+            case "$LABEL" in
+              blocking) EMOJI="🛑"; TITLE="Blocking" ;;
+              suggestion) EMOJI="💡"; TITLE="Suggestion" ;;
+              nit) EMOJI="✏️"; TITLE="Nit" ;;
+            esac
 
-              case "$LABEL" in
-                blocking) EMOJI="🛑"; TITLE="Blocking" ;;
-                suggestion) EMOJI="💡"; TITLE="Suggestion" ;;
-                nit) EMOJI="✏️"; TITLE="Nit" ;;
-              esac
-
-              if [ -n "$URL" ]; then
-                DETAILS+="- ${EMOJI} **${TITLE}:** [${SUMMARY}](${URL})"$'\n'
-              fi
-            done < <(jq -c 'to_entries | .[]' /tmp/review-comments.json 2>/dev/null)
-          fi
+            DETAILS+="- ${EMOJI} **${TITLE}:** ${SUMMARY}"$'\n'
+          done < <(jq -c '.[]' /tmp/review-comments.json 2>/dev/null)
 
           # Find and update marker comment
           STICKY_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -141,8 +141,8 @@ jobs:
                 line: .line,
                 side: "RIGHT",
                 body: ("<details markdown=\"1\">\n<summary>" +
-                  (if .label == "blocking" then "🛑" elif .label == "suggestion" then "💡" else "✏️" end) + " **" +
-                  ((.label | .[0:1] | ascii_upcase) + .label[1:]) + ":** " + .summary +
+                  (if .label == "blocking" then "🛑" elif .label == "suggestion" then "💡" else "✏️" end) + " " +
+                  ((.label | .[0:1] | ascii_upcase) + .label[1:]) + ": " + .summary +
                   "</summary>\n\n" +
                   "- **Commit**: [" + $commit[0:7] + "](https://github.com/" + $repo + "/commit/" + $commit + ")\n" +
                   "- **Issue**: " + .description + "\n\n" +

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -24,18 +24,6 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Debug info
-        shell: bash
-        run: |
-          echo "::debug::Repository: ${{ github.repository }}"
-          echo "::debug::PR number: ${{ github.event.pull_request.number }}"
-          echo "::debug::Base ref: ${{ github.event.pull_request.base.ref }}"
-          echo "::debug::Head SHA: ${{ github.event.pull_request.head.sha }}"
-          echo "::debug::Run ID: ${{ github.run_id }}"
-          echo "::debug::Run URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          echo "::debug::Marker: <!-- opencode-review-marker -->"
-          echo "I AM ALIVE"
-
       - name: Install opencode
         shell: bash
         run: curl -fsSL https://opencode.ai/install | bash

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -134,7 +134,8 @@ jobs:
             <Replace with a 2-3 sentence summary of the review findings.>
 
             ---
-            *Automated review by [OpenCode](https://opencode.ai)*"
+            *Automated review by [OpenCode](https://opencode.ai)*
+<!-- Sticky Pull Request Commentopencode-review -->"
 
             ## Phase 5 — Clean up extra top-level comments
 

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -74,7 +74,7 @@ jobs:
 
             ## Phase 1 — Review the diff
 
-            Fetch the base branch and examine changes:
+            Fetch the base branch and examine all changes:
             \`\`\`bash
             git fetch origin \"${{ github.event.pull_request.base.ref }}\" --depth=50
             git diff \"origin/${{ github.event.pull_request.base.ref }}...HEAD\"
@@ -89,61 +89,169 @@ jobs:
             - React best practices: proper RSC boundaries, async data patterns, metadata conventions
             - Fastify best practices: route → controller → service pattern, proper error handling
 
-            ## Phase 2 — Post inline review comments
+            ## Phase 2 — Write review data
 
-            For each issue found, post an INLINE comment on the specific line using:
+            For each issue found, add an entry to the JSON array. Determine \`line\` from the new file line number (the \`+start\` in \`@@ ... +start,count @@\` hunk headers).
+
+            Write the full JSON array to \`/tmp/review-comments.json\`:
             \`\`\`bash
-            gh api \"repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments\" \
-              --method POST \
-              -f body=\"🔴 Critical / 🟡 Warning / 🔵 Suggestion: Your specific feedback here\" \
-              -f commit_id=\"\$(git rev-parse HEAD)\" \
-              -f path=\"path/to/file.ts\" \
-              -f line=<line_number> \
-              -f side=\"RIGHT\"
+            cat > /tmp/review-comments.json << 'ENDOFFILE'
+            [
+              {
+                \"label\": \"blocking\",
+                \"path\": \"path/to/file.ts\",
+                \"line\": 42,
+                \"summary\": \"One-line title of the issue\",
+                \"description\": \"Longer explanation of the issue and why it matters\",
+                \"suggested_change\": \"\`\`\`ts\\ncode that fixes the issue\\n\`\`\`\"
+              }
+            ]
+            ENDOFFILE
             \`\`\`
-            - Use \`side: RIGHT\` and line numbers from the NEW file (not the diff position).
-            - Prepend each comment with the severity emoji.
-            - Be specific — reference variable names, function names, exact issues.
-            - Only post comments for actual issues. Do not post \"looks good\" or empty comments.
 
-            After posting all inline comments, render the full verdict comment body to /tmp/verdict-body:
-            \`\`\`bash
-            cat > /tmp/verdict-body << EOF
-            <!-- opencode-review-marker -->
+            Rules:
+            - \`label\`: \`blocking\` (🛑 blocks approval), \`suggestion\` (💡 improvement), \`nit\` (✏️ preference)
+            - Only include entries for actual issues. Write \`[]\` if none found.
+            - \`path\` is relative to repo root
+            - \`line\` is the new file line number (from \`@@ +start,count\`)
+            - \`summary\` one line, max 80 chars
+            - \`description\` detailed explanation
+            - \`suggested_change\` includes the full code fence with language tag
+            - Use \`\\n\` for newlines inside the JSON string"
 
-            ## ✅ **Approved** (or ❌ **Changes Requested** / ✔️ **Approved with Comments**)
-
-            **Commit**: \\\`\$(git rev-parse --short HEAD)\\\`
-            **Completed**: \$(date -u '+%Y-%m-%d %H:%M UTC')
-
-            ### Issues Found
-            🔴 0 critical &nbsp;|&nbsp; 🟡 2 warnings &nbsp;|&nbsp; 🔵 1 suggestion
-
-            <details>
-            <summary>View details</summary>
-
-            <!-- One bullet per issue posted, grouped by severity -->
-            - 🔴 **Critical**: one-liner about the issue
-            - 🟡 **Warning**: one-liner about the issue
-            - 🔵 **Suggestion**: one-liner about the issue
-
-            </details>
-
-            ---
-            *Automated review by [OpenCode](https://opencode.ai)*
-            EOF
-            \`\`\`"
-
-      - name: Update sticky verdict comment
+      - name: Post inline comments
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
+          COMMIT=$(git rev-parse HEAD)
+
+          if [ ! -f /tmp/review-comments.json ] || [ "$(jq 'length' /tmp/review-comments.json)" -eq 0 ]; then
+            echo "No comments to post"
+            echo "[]" > /tmp/comment-urls.json
+            exit 0
+          fi
+
+          # Build comments array with rendered bodies
+          PAYLOAD=$(jq -c --arg commit "$COMMIT" '
+            [
+              .[] | {
+                path: .path,
+                line: .line,
+                side: "RIGHT",
+                body: ("<summary>" +
+                  (if .label == "blocking" then "🛑" elif .label == "suggestion" then "💡" else "✏️" end) + " " +
+                  (.label | ascii_upcase) + ": " + .summary +
+                  "</summary>\n<details>\n\n" +
+                  "- **Commit**: `" + $commit + "`\n" +
+                  "- **Issue**: " + .description + "\n\n" +
+                  "- **Suggested Change**:\n\n" +
+                  .suggested_change + "\n\n" +
+                  "</details>"
+                  )
+              }
+            ]' /tmp/review-comments.json)
+
+          # Build full review payload
+          REVIEW_PAYLOAD=$(jq -n --arg commit "$COMMIT" --argjson comments "$PAYLOAD" '{
+            commit_id: $commit,
+            event: "COMMENT",
+            comments: $comments
+          }')
+
+          echo "$REVIEW_PAYLOAD" > /tmp/review-payload.json
+
+          # Batch POST review
+          gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
+            --method POST \
+            --input /tmp/review-payload.json
+
+          # GET comments to capture html_urls
+          gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments" \
+            --jq '[.[] | select(.commit_id == "'"$COMMIT"'") | {path, line, side, html_url}]' \
+            > /tmp/comment-urls.json
+
+      - name: Update sticky verdict
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          COMMIT=$(git rev-parse --short HEAD)
+          NOW=$(date -u '+%Y-%m-%d %H:%M UTC')
+
+          if [ ! -f /tmp/review-comments.json ]; then
+            echo "No review data found, skipping verdict"
+            exit 0
+          fi
+
+          # Count by label
+          BLOCKING=$(jq '[.[] | select(.label == "blocking")] | length' /tmp/review-comments.json)
+          SUGGESTION=$(jq '[.[] | select(.label == "suggestion")] | length' /tmp/review-comments.json)
+          NIT=$(jq '[.[] | select(.label == "nit")] | length' /tmp/review-comments.json)
+
+          # Determine verdict
+          if [ "$BLOCKING" -gt 0 ]; then
+            VERDICT="🛑 **Request Changes**"
+          elif [ "$SUGGESTION" -gt 0 ] || [ "$NIT" -gt 0 ]; then
+            VERDICT="💬 **Comment**"
+          else
+            VERDICT="✅ **Approve**"
+          fi
+
+          # Build details block with hyperlinks
+          DETAILS=""
+          if [ -f /tmp/comment-urls.json ]; then
+            while read -r row; do
+              PATH_FIELD=$(echo "$row" | jq -r '.path')
+              LINE_FIELD=$(echo "$row" | jq -r '.line')
+              LABEL=$(echo "$row" | jq -r '.label')
+              SUMMARY=$(echo "$row" | jq -r '.summary')
+
+              URL=$(jq -r --arg path "$PATH_FIELD" --argjson line "$LINE_FIELD" \
+                '.[] | select(.path == $path and .line == $line) | .html_url' \
+                /tmp/comment-urls.json)
+
+              case "$LABEL" in
+                blocking) EMOJI="🛑" ;;
+                suggestion) EMOJI="💡" ;;
+                nit) EMOJI="✏️" ;;
+              esac
+
+              if [ -n "$URL" ] && [ "$URL" != "null" ]; then
+                DETAILS+="- ${EMOJI} [${LABEL}: ${SUMMARY}](${URL})"$'\n'
+              else
+                DETAILS+="- ${EMOJI} ${LABEL}: ${SUMMARY}"$'\n'
+              fi
+            done < <(jq -c '.[]' /tmp/review-comments.json)
+          fi
+
+          # Find and update marker comment
           STICKY_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
             --jq 'map(select(.body | contains("<!-- opencode-review-marker -->"))) | last | .id')
 
-          if [ -n "$STICKY_ID" ] && [ -f /tmp/verdict-body ]; then
+          BODY="<!-- opencode-review-marker -->
+
+          ## $VERDICT
+
+          **Commit**: \`$COMMIT\`
+          **Completed**: $NOW
+
+          ### Issues Found
+          🛑 $BLOCKING blocking &nbsp;|&nbsp; 💡 $SUGGESTION suggestion &nbsp;|&nbsp; ✏️ $NIT nit
+
+          <details>
+          <summary>View details</summary>
+
+          $DETAILS
+          </details>
+
+          ---
+          *Automated review by [OpenCode](https://opencode.ai)*"
+
+          if [ -n "$STICKY_ID" ]; then
             gh api "repos/${{ github.repository }}/issues/comments/$STICKY_ID" \
               --method PATCH \
-              -f body=@/tmp/verdict-body
+              -f body="$BODY"
           fi

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -232,7 +232,7 @@ jobs:
 
           ## $VERDICT
 
-          **Commit**: \`$COMMIT\`
+          **Commit**: $COMMIT
           **Run**: [#${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
           ### Issues Found

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -124,7 +124,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          COMMIT=$(git rev-parse HEAD)
+          COMMIT_FULL=$(git rev-parse HEAD)
+          REPO="${{ github.repository }}"
 
           if [ ! -f /tmp/review-comments.json ] || [ "$(jq 'length' /tmp/review-comments.json)" -eq 0 ]; then
             echo "No comments to post"
@@ -133,27 +134,27 @@ jobs:
           fi
 
           # Build comments array with rendered bodies
-          PAYLOAD=$(jq -c --arg commit "$COMMIT" '
+          PAYLOAD=$(jq -c --arg commit "$COMMIT_FULL" --arg repo "$REPO" '
             [
               .[] | {
                 path: .path,
                 line: .line,
                 side: "RIGHT",
                 body: ("<details markdown=\"1\">\n<summary>" +
-                  (if .label == "blocking" then "🛑" elif .label == "suggestion" then "💡" else "✏️" end) + " " +
-                  (.label | ascii_upcase) + ": " + .summary +
+                  (if .label == "blocking" then "🛑" elif .label == "suggestion" then "💡" else "✏️" end) + " **" +
+                  ((.label | .[0:1] | ascii_upcase) + .label[1:]) + ":** " + .summary +
                   "</summary>\n\n" +
-                  "- **Commit**: `" + $commit + "`\n" +
+                  "- **Commit**: [" + $commit[0:7] + "](https://github.com/" + $repo + "/commit/" + $commit + ")\n" +
                   "- **Issue**: " + .description + "\n\n" +
                   "- **Suggested Change**:\n\n" +
                   .suggested_change + "\n\n" +
                   "</details>"
-                  )
+                )
               }
             ]' /tmp/review-comments.json)
 
           # Build full review payload
-          REVIEW_PAYLOAD=$(jq -n --arg commit "$COMMIT" --argjson comments "$PAYLOAD" '{
+          REVIEW_PAYLOAD=$(jq -n --arg commit "$COMMIT_FULL" --argjson comments "$PAYLOAD" '{
             commit_id: $commit,
             event: "COMMENT",
             comments: $comments
@@ -161,14 +162,17 @@ jobs:
 
           echo "$REVIEW_PAYLOAD" > /tmp/review-payload.json
 
-          # Batch POST review
-          gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
+          # Batch POST review and capture review ID
+          REVIEW_ID=$(gh api "repos/$REPO/pulls/${{ github.event.pull_request.number }}/reviews" \
             --method POST \
-            --input /tmp/review-payload.json
+            --input /tmp/review-payload.json \
+            --jq '.id')
 
-          # GET comments to capture html_urls
-          gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments" \
-            --jq '[.[] | select(.commit_id == "'"$COMMIT"'") | {path, line, side, html_url}]' \
+          sleep 3
+
+          # GET comments filtered by review ID (reliable, no path/line matching)
+          gh api "repos/$REPO/pulls/${{ github.event.pull_request.number }}/comments?sort=created&direction=desc&per_page=50" \
+            --jq '[.[] | select(.pull_request_review_id == '$REVIEW_ID')] | sort_by(.id) | map({html_url})' \
             > /tmp/comment-urls.json
 
       - name: Update sticky verdict
@@ -198,31 +202,26 @@ jobs:
             VERDICT="✅ **Approve**"
           fi
 
-          # Build details block with hyperlinks
+          # Build details block with hyperlinks (index-based, same order as comment-urls.json)
           DETAILS=""
           if [ -f /tmp/comment-urls.json ]; then
-            while read -r row; do
-              PATH_FIELD=$(echo "$row" | jq -r '.path')
-              LINE_FIELD=$(echo "$row" | jq -r '.line')
-              LABEL=$(echo "$row" | jq -r '.label')
-              SUMMARY=$(echo "$row" | jq -r '.summary')
+            while read -r item; do
+              IDX=$(echo "$item" | jq -r '.index')
+              LABEL=$(echo "$item" | jq -r '.value.label')
+              SUMMARY=$(echo "$item" | jq -r '.value.summary')
 
-              URL=$(jq -r --arg path "$PATH_FIELD" --argjson line "$LINE_FIELD" \
-                '.[] | select(.path == $path and .line == $line) | .html_url' \
-                /tmp/comment-urls.json)
+              URL=$(jq -r ".[$IDX].html_url" /tmp/comment-urls.json)
 
               case "$LABEL" in
-                blocking) EMOJI="🛑" ;;
-                suggestion) EMOJI="💡" ;;
-                nit) EMOJI="✏️" ;;
+                blocking) EMOJI="🛑"; TITLE="Blocking" ;;
+                suggestion) EMOJI="💡"; TITLE="Suggestion" ;;
+                nit) EMOJI="✏️"; TITLE="Nit" ;;
               esac
 
               if [ -n "$URL" ] && [ "$URL" != "null" ]; then
-                DETAILS+="- ${EMOJI} [${LABEL}: ${SUMMARY}](${URL})"$'\n'
-              else
-                DETAILS+="- ${EMOJI} ${LABEL}: ${SUMMARY}"$'\n'
+                DETAILS+="- ${EMOJI} **${TITLE}:** [${SUMMARY}](${URL})"$'\n'
               fi
-            done < <(jq -c '.[]' /tmp/review-comments.json)
+            done < <(jq -c 'to_entries | .[]' /tmp/review-comments.json)
           fi
 
           # Find and update marker comment

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -32,6 +32,28 @@ jobs:
         shell: bash
         run: echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
 
+      - name: Post in-progress sticky comment
+        shell: bash
+        run: |
+          STICKY_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            --jq 'map(select(.body | contains("<!-- opencode-review-marker -->"))) | last | .id')
+          NOW=$(date -u '+%Y-%m-%d %H:%M UTC')
+          BODY="<!-- opencode-review-marker -->
+
+          ## 🔄 AI Review in Progress
+
+          **Commit**: $(git rev-parse --short HEAD)
+          **Started**: $NOW
+
+          ---
+          _Reviewing changes..._"
+
+          if [ -n "$STICKY_ID" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/$STICKY_ID" --method PATCH -f body="$BODY"
+          else
+            gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" --method POST -f body="$BODY"
+          fi
+
       - name: Run opencode review
         shell: bash
         env:
@@ -47,31 +69,7 @@ jobs:
 
             ---
 
-            ## Phase 1 — Post the in-progress sticky comment
-
-            Find an existing marker comment and update it, or create one if none exists:
-            \`\`\`bash
-            STICKY_ID=\$(gh api \"repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments\" \
-              --jq 'map(select(.body | contains(\"<!-- opencode-review-marker -->\"))) | last | .id')
-            NOW=\$(date -u '+%Y-%m-%d %H:%M UTC')
-            BODY=\"<!-- opencode-review-marker -->
-
-            ## 🔄 AI Review in Progress
-
-            **Commit**: \$(git rev-parse --short HEAD)
-            **Started**: \$NOW
-
-            ---
-            _Reviewing changes..._\"
-
-            if [ -n \"\$STICKY_ID\" ]; then
-              gh api \"repos/${{ github.repository }}/issues/comments/\$STICKY_ID\" --method PATCH -f body=\"\$BODY\"
-            else
-              gh api \"repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments\" --method POST -f body=\"\$BODY\"
-            fi
-            \`\`\`
-
-            ## Phase 2 — Review the diff
+            ## Phase 1 — Review the diff
 
             Fetch the base branch and examine changes:
             \`\`\`bash
@@ -88,7 +86,7 @@ jobs:
             - React best practices: proper RSC boundaries, async data patterns, metadata conventions
             - Fastify best practices: route → controller → service pattern, proper error handling
 
-            ## Phase 3 — Post inline review comments
+            ## Phase 2 — Post inline review comments
 
             For each issue found, post an INLINE comment on the specific line using:
             \`\`\`bash
@@ -103,49 +101,43 @@ jobs:
             - Use \`side: RIGHT\` and line numbers from the NEW file (not the diff position).
             - Prepend each comment with the severity emoji.
             - Be specific — reference variable names, function names, exact issues.
-            - Only post comments for actual issues. Do not post \"looks good\" or empty comments.
+            - Only post comments for actual issues. Do not post \"looks good\" or empty comments."
 
-            ## Phase 4 — Update the sticky verdict comment
+      - name: Update sticky verdict comment
+        shell: bash
+        run: |
+          COMMIT=$(git rev-parse --short HEAD)
+          NOW=$(date -u '+%Y-%m-%d %H:%M UTC')
 
-            Find the review comment and update it with the final verdict:
-            \`\`\`bash
-            STICKY_ID=\$(gh api \"repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments\" \
-              --jq 'map(select(.body | contains(\"<!-- opencode-review-marker -->\"))) | last | .id')
-            COMMIT=\$(git rev-parse --short HEAD)
-            NOW=\$(date -u '+%Y-%m-%d %H:%M UTC')
+          CRITICAL=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments" \
+            --jq '[.[] | select(.commit_id == "'"$COMMIT"'" and (.body | startswith("🔴")))] | length')
+          WARNING=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments" \
+            --jq '[.[] | select(.commit_id == "'"$COMMIT"'" and (.body | startswith("🟡")))] | length')
+          SUGGESTION=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments" \
+            --jq '[.[] | select(.commit_id == "'"$COMMIT"'" and (.body | startswith("🔵")))] | length')
 
-            # Count severity levels from inline comments you posted against this commit
-            CRITICAL=\$(gh api \"repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments\" \
-              --jq '[.[] | select(.commit_id == "'\$COMMIT'" and (.body | startswith(\"🔴\")))] | length')
-            WARNING=\$(gh api \"repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments\" \
-              --jq '[.[] | select(.commit_id == "'\$COMMIT'" and (.body | startswith(\"🟡\")))] | length')
-            SUGGESTION=\$(gh api \"repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments\" \
-              --jq '[.[] | select(.commit_id == "'\$COMMIT'" and (.body | startswith(\"🔵\")))] | length')
+          if [ "$CRITICAL" -gt 0 ]; then
+            VERDICT="❌ **Changes Requested**"
+          elif [ "$WARNING" -gt 0 ]; then
+            VERDICT="✔️ **Approved with Comments**"
+          else
+            VERDICT="✅ **Approved**"
+          fi
 
-            # Determine verdict
-            if [ \"\$CRITICAL\" -gt 0 ]; then
-              VERDICT=\"❌ **Changes Requested**\"
-            elif [ \"\$WARNING\" -gt 0 ]; then
-              VERDICT=\"✔️ **Approved with Comments**\"
-            else
-              VERDICT=\"✅ **Approved**\"
-            fi
+          STICKY_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            --jq 'map(select(.body | contains("<!-- opencode-review-marker -->"))) | last | .id')
 
-            gh api \"repos/${{ github.repository }}/issues/comments/\$STICKY_ID\" \
-              --method PATCH \
-              -f body=\"<!-- opencode-review-marker -->
+          gh api "repos/${{ github.repository }}/issues/comments/$STICKY_ID" \
+            --method PATCH \
+            -f body="<!-- opencode-review-marker -->
 
-            ## \$VERDICT
+          ## $VERDICT
 
-            **Commit**: \\\`\$COMMIT\\\`
-            **Completed**: \$NOW
+          **Commit**: \`$COMMIT\`
+          **Completed**: $NOW
 
-            ### Issues Found
-            🔴 \$CRITICAL critical &nbsp;|&nbsp; 🟡 \$WARNING warning &nbsp;|&nbsp; 🔵 \$SUGGESTION suggestion
+          ### Issues Found
+          🔴 $CRITICAL critical &nbsp;|&nbsp; 🟡 $WARNING warning &nbsp;|&nbsp; 🔵 $SUGGESTION suggestion
 
-            ### Summary
-            <Replace with a 2-3 sentence summary of the review findings.>
-
-            ---
-            *Automated review by [OpenCode](https://opencode.ai)*\"
-            \`\`\`"
+          ---
+          *Automated review by [OpenCode](https://opencode.ai)*"

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -19,8 +19,6 @@ jobs:
   review:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -35,9 +33,10 @@ jobs:
 
       - name: Post in-progress sticky comment
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          API_ISSUE="repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}"
-          STICKY_ID=$(gh api "$API_ISSUE/comments" \
+          STICKY_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
             --jq 'map(select(.body | contains("<!-- opencode-review-marker -->"))) | last | .id')
           BODY="<!-- opencode-review-marker -->
 
@@ -50,9 +49,9 @@ jobs:
           _Reviewing changes..._"
 
           if [ -n "$STICKY_ID" ]; then
-            gh api "$API_ISSUE/comments/$STICKY_ID" --method PATCH -f body="$BODY"
+            gh api "repos/${{ github.repository }}/issues/comments/$STICKY_ID" --method PATCH -f body="$BODY"
           else
-            gh api "$API_ISSUE/comments" --method POST -f body="$BODY"
+            gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" --method POST -f body="$BODY"
           fi
 
       - name: Run opencode review
@@ -118,6 +117,8 @@ jobs:
 
       - name: Post inline comments
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           [ -f /tmp/review-comments.json ] || exit 0
@@ -159,21 +160,20 @@ jobs:
 
       - name: Update sticky verdict
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           [ -f /tmp/review-comments.json ] || exit 0
 
-          API_ISSUE="repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}"
           COMMIT=$(git rev-parse --short HEAD)
 
-          # Count by label — single jq call
           read BLOCKING SUGGESTION NIT <<< $(jq -r '[
             (map(select(.label == "blocking")) | length),
             (map(select(.label == "suggestion")) | length),
             (map(select(.label == "nit")) | length)
           ] | join(" ")' /tmp/review-comments.json)
 
-          # Determine verdict
           if [ "$BLOCKING" -gt 0 ]; then
             VERDICT="🛑 **Request Changes**"
           elif [ "$SUGGESTION" -gt 0 ] || [ "$NIT" -gt 0 ]; then
@@ -182,7 +182,6 @@ jobs:
             VERDICT="✅ **Approve**"
           fi
 
-          # Build details
           DETAILS=""
           while read -r item; do
             LABEL=$(echo "$item" | jq -r '.label')
@@ -195,10 +194,10 @@ jobs:
             DETAILS+="- ${EMOJI} **${TITLE}:** ${SUMMARY}"$'\n'
           done < <(jq -c '.[]' /tmp/review-comments.json 2>/dev/null)
 
-          STICKY_ID=$(gh api "$API_ISSUE/comments" \
+          STICKY_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
             --jq 'map(select(.body | contains("<!-- opencode-review-marker -->"))) | last | .id')
 
-          gh api "$API_ISSUE/comments/$STICKY_ID" --method PATCH -f body="<!-- opencode-review-marker -->
+          gh api "repos/${{ github.repository }}/issues/comments/$STICKY_ID" --method PATCH -f body="<!-- opencode-review-marker -->
 
           ## $VERDICT
 

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -142,7 +142,7 @@ jobs:
                 body: ("<summary>" +
                   (if .label == "blocking" then "🛑" elif .label == "suggestion" then "💡" else "✏️" end) + " " +
                   (.label | ascii_upcase) + ": " + .summary +
-                  "</summary>\n<details>\n\n" +
+                  "</summary>\n<details markdown=\"1\">\n\n" +
                   "- **Commit**: `" + $commit + "`\n" +
                   "- **Issue**: " + .description + "\n\n" +
                   "- **Suggested Change**:\n\n" +
@@ -239,7 +239,7 @@ jobs:
           ### Issues Found
           🛑 $BLOCKING blocking &nbsp;|&nbsp; 💡 $SUGGESTION suggestion &nbsp;|&nbsp; ✏️ $NIT nit
 
-          <details>
+          <details markdown="1">
           <summary>View details</summary>
 
           $DETAILS

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -204,13 +204,13 @@ jobs:
 
           # Build details block with hyperlinks (index-based, same order as comment-urls.json)
           DETAILS=""
-          if [ -f /tmp/comment-urls.json ]; then
+          if [ -f /tmp/comment-urls.json ] && jq -e '. | type == "array"' /tmp/comment-urls.json > /dev/null 2>&1; then
             while read -r item; do
               IDX=$(echo "$item" | jq -r '.index')
               LABEL=$(echo "$item" | jq -r '.value.label')
               SUMMARY=$(echo "$item" | jq -r '.value.summary')
 
-              URL=$(jq -r ".[$IDX].html_url" /tmp/comment-urls.json)
+              URL=$(jq -r "try .[$IDX].html_url // \"\"" /tmp/comment-urls.json 2>/dev/null)
 
               case "$LABEL" in
                 blocking) EMOJI="🛑"; TITLE="Blocking" ;;
@@ -218,10 +218,10 @@ jobs:
                 nit) EMOJI="✏️"; TITLE="Nit" ;;
               esac
 
-              if [ -n "$URL" ] && [ "$URL" != "null" ]; then
+              if [ -n "$URL" ]; then
                 DETAILS+="- ${EMOJI} **${TITLE}:** [${SUMMARY}](${URL})"$'\n'
               fi
-            done < <(jq -c 'to_entries | .[]' /tmp/review-comments.json)
+            done < <(jq -c 'to_entries | .[]' /tmp/review-comments.json 2>/dev/null)
           fi
 
           # Find and update marker comment

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -13,13 +13,14 @@ permissions:
   pull-requests: write
 
 env:
-  GH_TOKEN: ${{ github.token }}
   OPENCODE_MODEL: opencode-go/deepseek-v4-flash
 
 jobs:
   review:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -143,13 +143,4 @@ jobs:
 
             ---
             *Automated review by [OpenCode](https://opencode.ai)*\"
-            \`\`\`
-
-            ## Phase 5 — Clean up extra top-level comments
-
-            Delete any github-actions[bot] issue comments that don't contain the \`<!-- opencode-review-marker -->\` marker:
-            \`\`\`bash
-            gh api \"repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments\" \
-              --jq 'map(select(.body | contains(\"<!-- opencode-review-marker -->\") | not) | .id) | .[]' \
-              | xargs -I{} gh api \"repos/${{ github.repository }}/issues/comments/{}\" --method DELETE
             \`\`\`"

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -43,7 +43,8 @@ jobs:
 
           ## 🔄 AI Review in Progress
 
-          **Commit**: $(git rev-parse --short HEAD) | **[Run #${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})**
+          **Commit**: $(git rev-parse --short HEAD)
+          **Run**: [${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
           ---
           _Reviewing changes..._"
@@ -177,7 +178,6 @@ jobs:
         run: |
           set -euo pipefail
           COMMIT=$(git rev-parse --short HEAD)
-          NOW=$(date -u '+%Y-%m-%d %H:%M UTC')
 
           if [ ! -f /tmp/review-comments.json ]; then
             echo "No review data found, skipping verdict"
@@ -233,7 +233,8 @@ jobs:
 
           ## $VERDICT
 
-          **Commit**: \`$COMMIT\` | **[Run #${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})**
+          **Commit**: \`$COMMIT\`
+          **Run**: [${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
           ### Issues Found
           🛑 $BLOCKING blocking &nbsp;|&nbsp; 💡 $SUGGESTION suggestion &nbsp;|&nbsp; ✏️ $NIT nit

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -150,7 +150,7 @@ jobs:
                   (if .label == "blocking" then "🛑" elif .label == "suggestion" then "💡" else "✏️" end) + " " +
                   ((.label | .[0:1] | ascii_upcase) + .label[1:]) + ": " + .summary +
                   "</summary>\n\n" +
-                  "**Review**: " + $review + "\n\n" +
+                  "**Review**: " + $review + "\n" +
                   "**Commit**: [" + $commit[0:7] + "](https://github.com/" + $repo + "/commit/" + $commit + ")\n\n" +
                   "**Issue**: " + .description + "\n\n" +
                   "**Suggested Change**:\n\n" +

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -39,13 +39,11 @@ jobs:
         run: |
           STICKY_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
             --jq 'map(select(.body | contains("<!-- opencode-review-marker -->"))) | last | .id')
-          NOW=$(date -u '+%Y-%m-%d %H:%M UTC')
           BODY="<!-- opencode-review-marker -->
 
           ## 🔄 AI Review in Progress
 
-          **Commit**: $(git rev-parse --short HEAD)
-          **Started**: $NOW
+          **Commit**: $(git rev-parse --short HEAD) | **[Run #${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})**
 
           ---
           _Reviewing changes..._"
@@ -235,8 +233,7 @@ jobs:
 
           ## $VERDICT
 
-          **Commit**: \`$COMMIT\`
-          **Completed**: $NOW
+          **Commit**: \`$COMMIT\` | **[Run #${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})**
 
           ### Issues Found
           🛑 $BLOCKING blocking &nbsp;|&nbsp; 💡 $SUGGESTION suggestion &nbsp;|&nbsp; ✏️ $NIT nit

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -12,12 +12,14 @@ permissions:
   contents: read
   pull-requests: write
 
+env:
+  GH_TOKEN: ${{ github.token }}
+  OPENCODE_MODEL: opencode-go/deepseek-v4-flash
+
 jobs:
   review:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
-    env:
-      OPENCODE_MODEL: opencode-go/deepseek-v4-flash
     steps:
       - uses: actions/checkout@v6
         with:
@@ -26,18 +28,15 @@ jobs:
 
       - name: Install opencode
         shell: bash
-        run: curl -fsSL https://opencode.ai/install | bash
-
-      - name: Add opencode to PATH
-        shell: bash
-        run: echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
+        run: |
+          curl -fsSL https://opencode.ai/install | bash
+          echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
 
       - name: Post in-progress sticky comment
         shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
-          STICKY_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+          API_ISSUE="repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}"
+          STICKY_ID=$(gh api "$API_ISSUE/comments" \
             --jq 'map(select(.body | contains("<!-- opencode-review-marker -->"))) | last | .id')
           BODY="<!-- opencode-review-marker -->
 
@@ -50,18 +49,16 @@ jobs:
           _Reviewing changes..._"
 
           if [ -n "$STICKY_ID" ]; then
-            gh api "repos/${{ github.repository }}/issues/comments/$STICKY_ID" --method PATCH -f body="$BODY"
+            gh api "$API_ISSUE/comments/$STICKY_ID" --method PATCH -f body="$BODY"
           else
-            gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" --method POST -f body="$BODY"
+            gh api "$API_ISSUE/comments" --method POST -f body="$BODY"
           fi
 
       - name: Run opencode review
         shell: bash
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-          GH_TOKEN: ${{ github.token }}
         run: |
-          # CI is non-interactive — permission prompts would block indefinitely
           opencode run \
             --model ${{ env.OPENCODE_MODEL }} \
             --dangerously-skip-permissions \
@@ -120,20 +117,16 @@ jobs:
 
       - name: Post inline comments
         shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          COMMIT_FULL=$(git rev-parse HEAD)
+          [ -f /tmp/review-comments.json ] || exit 0
+          [ "$(jq 'length' /tmp/review-comments.json)" -gt 0 ] || exit 0
+
+          COMMIT=$(git rev-parse HEAD)
           REPO="${{ github.repository }}"
+          PR="${{ github.event.pull_request.number }}"
 
-          if [ ! -f /tmp/review-comments.json ] || [ "$(jq 'length' /tmp/review-comments.json)" -eq 0 ]; then
-            echo "No comments to post"
-            exit 0
-          fi
-
-          # Build comments array with rendered bodies
-          PAYLOAD=$(jq -c --arg commit "$COMMIT_FULL" --arg repo "$REPO" '
+          PAYLOAD=$(jq -c --arg commit "$COMMIT" --arg repo "$REPO" '
             [
               .[] | {
                 path: .path,
@@ -152,8 +145,7 @@ jobs:
               }
             ]' /tmp/review-comments.json)
 
-          # Build full review payload
-          REVIEW_PAYLOAD=$(jq -n --arg commit "$COMMIT_FULL" --argjson comments "$PAYLOAD" '{
+          REVIEW_PAYLOAD=$(jq -n --arg commit "$COMMIT" --argjson comments "$PAYLOAD" '{
             commit_id: $commit,
             event: "COMMENT",
             comments: $comments
@@ -161,29 +153,24 @@ jobs:
 
           echo "$REVIEW_PAYLOAD" > /tmp/review-payload.json
 
-          # Batch POST review
-          gh api "repos/$REPO/pulls/${{ github.event.pull_request.number }}/reviews" \
-            --method POST \
-            --input /tmp/review-payload.json \
-            --jq '.id' > /dev/null
+          gh api "repos/$REPO/pulls/$PR/reviews" \
+            --method POST --input /tmp/review-payload.json > /dev/null
 
       - name: Update sticky verdict
         shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          [ -f /tmp/review-comments.json ] || exit 0
+
+          API_ISSUE="repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}"
           COMMIT=$(git rev-parse --short HEAD)
 
-          if [ ! -f /tmp/review-comments.json ]; then
-            echo "No review data found, skipping verdict"
-            exit 0
-          fi
-
-          # Count by label
-          BLOCKING=$(jq '[.[] | select(.label == "blocking")] | length' /tmp/review-comments.json)
-          SUGGESTION=$(jq '[.[] | select(.label == "suggestion")] | length' /tmp/review-comments.json)
-          NIT=$(jq '[.[] | select(.label == "nit")] | length' /tmp/review-comments.json)
+          # Count by label — single jq call
+          read BLOCKING SUGGESTION NIT <<< $(jq -r '[
+            (map(select(.label == "blocking")) | length),
+            (map(select(.label == "suggestion")) | length),
+            (map(select(.label == "nit")) | length)
+          ] | join(" ")' /tmp/review-comments.json)
 
           # Determine verdict
           if [ "$BLOCKING" -gt 0 ]; then
@@ -194,26 +181,23 @@ jobs:
             VERDICT="✅ **Approve**"
           fi
 
-          # Build details block from review data
+          # Build details
           DETAILS=""
           while read -r item; do
             LABEL=$(echo "$item" | jq -r '.label')
             SUMMARY=$(echo "$item" | jq -r '.summary')
-
             case "$LABEL" in
               blocking) EMOJI="🛑"; TITLE="Blocking" ;;
               suggestion) EMOJI="💡"; TITLE="Suggestion" ;;
               nit) EMOJI="✏️"; TITLE="Nit" ;;
             esac
-
             DETAILS+="- ${EMOJI} **${TITLE}:** ${SUMMARY}"$'\n'
           done < <(jq -c '.[]' /tmp/review-comments.json 2>/dev/null)
 
-          # Find and update marker comment
-          STICKY_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+          STICKY_ID=$(gh api "$API_ISSUE/comments" \
             --jq 'map(select(.body | contains("<!-- opencode-review-marker -->"))) | last | .id')
 
-          BODY="<!-- opencode-review-marker -->
+          gh api "$API_ISSUE/comments/$STICKY_ID" --method PATCH -f body="<!-- opencode-review-marker -->
 
           ## $VERDICT
 
@@ -223,7 +207,7 @@ jobs:
           ### Issues Found
           🛑 $BLOCKING blocking &nbsp;|&nbsp; 💡 $SUGGESTION suggestion &nbsp;|&nbsp; ✏️ $NIT nit
 
-          <details markdown="1">
+          <details markdown=\"1\">
           <summary>View details</summary>
 
           $DETAILS
@@ -231,9 +215,3 @@ jobs:
 
           ---
           *Automated review by [OpenCode](https://opencode.ai)*"
-
-          if [ -n "$STICKY_ID" ]; then
-            gh api "repos/${{ github.repository }}/issues/comments/$STICKY_ID" \
-              --method PATCH \
-              -f body="$BODY"
-          fi

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -135,4 +135,21 @@ jobs:
 
             ---
             *Automated review by [OpenCode](https://opencode.ai)*"
+
+            ## Phase 5 — Clean up extra top-level comments
+
+            The OpenCode action may have posted extra top-level summary comments. Delete any `github-actions[bot]` issue comments that don't contain the `<!-- opencode-review-marker -->` marker:
+            ```bash
+            gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+              --jq 'map(select(.body | contains("<!-- opencode-review-marker -->") | not) | .id) | .[]' \
+              | xargs -I{} gh api "repos/${{ github.repository }}/issues/comments/{}" --method DELETE
             ```
+
+      - name: Clean up extra bot comments
+        shell: bash
+        run: |
+          gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            --jq 'map(select(.body | contains("<!-- opencode-review-marker -->") | not) | .id) | .[]' \
+            | xargs -I{} gh api "repos/${{ github.repository }}/issues/comments/{}" --method DELETE || true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -168,10 +168,21 @@ jobs:
             --input /tmp/review-payload.json \
             --jq '.id')
 
-          sleep 3
+          echo "Posted review #$REVIEW_ID, waiting for comments to index..."
 
-          # GET comments filtered by review ID (reliable, no path/line matching)
-          gh api "repos/$REPO/pulls/${{ github.event.pull_request.number }}/comments?sort=created&direction=desc&per_page=50" \
+          # Poll until comments appear or max retries
+          for i in $(seq 1 10); do
+            sleep 2
+            COUNT=$(gh api "repos/$REPO/pulls/${{ github.event.pull_request.number }}/comments?per_page=50" \
+              --jq '[.[] | select(.pull_request_review_id == '$REVIEW_ID')] | length')
+            if [ "$COUNT" -gt 0 ]; then
+              echo "Found $COUNT comment(s) after ${i}x2s"
+              break
+            fi
+          done
+
+          # GET comments and extract html_urls in order
+          gh api "repos/$REPO/pulls/${{ github.event.pull_request.number }}/comments?per_page=50" \
             --jq '[.[] | select(.pull_request_review_id == '$REVIEW_ID')] | sort_by(.id) | map({html_url})' \
             > /tmp/comment-urls.json
 

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -9,7 +9,6 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  id-token: write
   contents: read
   pull-requests: write
 
@@ -112,18 +111,18 @@ jobs:
 
             # Determine verdict
             if [ "$CRITICAL" -gt 0 ]; then
-              VERDICT="⚠️ **Request Changes**"
+              VERDICT="❌ **Changes Requested**"
             elif [ "$WARNING" -gt 0 ]; then
-              VERDICT="💬 **Comment**"
+              VERDICT="✔️ **Approved with Comments**"
             else
-              VERDICT="✅ **Approve**"
+              VERDICT="✅ **Approved**"
             fi
 
             gh api "repos/${{ github.repository }}/issues/comments/$STICKY_ID" \
               --method PATCH \
               -f body="<!-- opencode-review-marker -->
 
-            $VERDICT
+            ## $VERDICT
 
             **Commit**: \`$COMMIT\`
             **Completed**: $NOW

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -103,55 +103,34 @@ jobs:
             - Be specific — reference variable names, function names, exact issues.
             - Only post comments for actual issues. Do not post \"looks good\" or empty comments.
 
-            After posting all inline comments, write a 2-3 sentence summary to /tmp/review-summary:
+            After posting all inline comments, render the full verdict comment body to /tmp/verdict-body:
             \`\`\`bash
-            cat > /tmp/review-summary << 'EOF'
-            Replace with 2-3 sentences summarizing the review findings.
+            cat > /tmp/verdict-body << EOF
+            <!-- opencode-review-marker -->
+
+            ## ✅ **Approved** (or ❌ **Changes Requested** / ✔️ **Approved with Comments**)
+
+            **Commit**: \\\`\$(git rev-parse --short HEAD)\\\`
+            **Completed**: \$(date -u '+%Y-%m-%d %H:%M UTC')
+
+            ### Issues Found
+            🔴 0 critical &nbsp;|&nbsp; 🟡 2 warnings &nbsp;|&nbsp; 🔵 1 suggestion
+
+            2-3 sentence summary of findings.
+
+            ---
+            *Automated review by [OpenCode](https://opencode.ai)*
             EOF
             \`\`\`"
 
       - name: Update sticky verdict comment
         shell: bash
         run: |
-          COMMIT=$(git rev-parse --short HEAD)
-          NOW=$(date -u '+%Y-%m-%d %H:%M UTC')
-
-          CRITICAL=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments" \
-            --jq '[.[] | select(.commit_id == "'"$COMMIT"'" and (.body | startswith("🔴")))] | length')
-          WARNING=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments" \
-            --jq '[.[] | select(.commit_id == "'"$COMMIT"'" and (.body | startswith("🟡")))] | length')
-          SUGGESTION=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments" \
-            --jq '[.[] | select(.commit_id == "'"$COMMIT"'" and (.body | startswith("🔵")))] | length')
-
-          if [ "$CRITICAL" -gt 0 ]; then
-            VERDICT="❌ **Changes Requested**"
-          elif [ "$WARNING" -gt 0 ]; then
-            VERDICT="✔️ **Approved with Comments**"
-          else
-            VERDICT="✅ **Approved**"
-          fi
-
-           SUMMARY=""
-          if [ -f /tmp/review-summary ]; then
-            SUMMARY=$(cat /tmp/review-summary)
-          fi
-
           STICKY_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
             --jq 'map(select(.body | contains("<!-- opencode-review-marker -->"))) | last | .id')
 
-          gh api "repos/${{ github.repository }}/issues/comments/$STICKY_ID" \
-            --method PATCH \
-            -f body="<!-- opencode-review-marker -->
-
-          ## $VERDICT
-
-          **Commit**: \`$COMMIT\`
-          **Completed**: $NOW
-
-          ### Issues Found
-          🔴 $CRITICAL critical &nbsp;|&nbsp; 🟡 $WARNING warning &nbsp;|&nbsp; 🔵 $SUGGESTION suggestion
-
-          $SUMMARY
-
-          ---
-          *Automated review by [OpenCode](https://opencode.ai)*"
+          if [ -n "$STICKY_ID" ] && [ -f /tmp/verdict-body ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/$STICKY_ID" \
+              --method PATCH \
+              -f body=@/tmp/verdict-body
+          fi

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -232,7 +232,7 @@ jobs:
 
           ## $VERDICT
 
-          **Commit**: $COMMIT
+          **Commit**: [$COMMIT](${{ github.server_url }}/${{ github.repository }}/commit/$COMMIT)
           **Run**: [#${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
           ### Issues Found

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -16,6 +16,8 @@ jobs:
   review:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    env:
+      OPENCODE_MODEL: opencode-go/deepseek-v4-flash
     steps:
       - uses: actions/checkout@v6
         with:
@@ -36,8 +38,9 @@ jobs:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # CI is non-interactive — permission prompts would block indefinitely
           opencode run \
-            --model opencode-go/deepseek-v4-flash \
+            --model ${{ env.OPENCODE_MODEL }} \
             --dangerously-skip-permissions \
             "You are reviewing a pull request for the Journiful project — a collaborative trip planning platform.
 
@@ -113,9 +116,9 @@ jobs:
             NOW=\$(date -u '+%Y-%m-%d %H:%M UTC')
 
             # Count severity levels from any inline comments you posted
-            CRITICAL=...  # count of 🔴
-            WARNING=...   # count of 🟡
-            SUGGESTION=... # count of 🔵
+            CRITICAL=0  # count of 🔴
+            WARNING=0   # count of 🟡
+            SUGGESTION=0 # count of 🔵
 
             # Determine verdict
             if [ \"\$CRITICAL\" -gt 0 ]; then

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -36,7 +36,6 @@ jobs:
         shell: bash
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # CI is non-interactive — permission prompts would block indefinitely
           opencode run \
@@ -115,10 +114,13 @@ jobs:
             COMMIT=\$(git rev-parse --short HEAD)
             NOW=\$(date -u '+%Y-%m-%d %H:%M UTC')
 
-            # Count severity levels from any inline comments you posted
-            CRITICAL=0  # count of 🔴
-            WARNING=0   # count of 🟡
-            SUGGESTION=0 # count of 🔵
+            # Count severity levels from inline comments you posted against this commit
+            CRITICAL=\$(gh api \"repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments\" \
+              --jq '[.[] | select(.commit_id == "'\$COMMIT'" and (.body | startswith(\"🔴\")))] | length')
+            WARNING=\$(gh api \"repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments\" \
+              --jq '[.[] | select(.commit_id == "'\$COMMIT'" and (.body | startswith(\"🟡\")))] | length')
+            SUGGESTION=\$(gh api \"repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments\" \
+              --jq '[.[] | select(.commit_id == "'\$COMMIT'" and (.body | startswith(\"🔵\")))] | length')
 
             # Determine verdict
             if [ \"\$CRITICAL\" -gt 0 ]; then

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -47,18 +47,12 @@ jobs:
 
             ## Phase 1 — Post the in-progress sticky comment
 
-            Delete any previous review comment (from a prior run) and post a fresh in-progress one:
+            Find an existing marker comment and update it, or create one if none exists:
             \`\`\`bash
-            PREV_ID=\$(gh api \"repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments\" \
-              --jq 'map(select(.body | contains(\"<!-- opencode-review-marker -->\"))) | .[0].id')
-            if [ -n \"\$PREV_ID\" ]; then
-              gh api \"repos/${{ github.repository }}/issues/comments/\$PREV_ID\" --method DELETE
-            fi
-
+            STICKY_ID=\$(gh api \"repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments\" \
+              --jq 'map(select(.body | contains(\"<!-- opencode-review-marker -->\"))) | last | .id')
             NOW=\$(date -u '+%Y-%m-%d %H:%M UTC')
-            gh api \"repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments\" \
-              --method POST \
-              -f body=\"<!-- opencode-review-marker -->
+            BODY=\"<!-- opencode-review-marker -->
 
             ## 🔄 AI Review in Progress
 
@@ -67,6 +61,12 @@ jobs:
 
             ---
             _Reviewing changes..._\"
+
+            if [ -n \"\$STICKY_ID\" ]; then
+              gh api \"repos/${{ github.repository }}/issues/comments/\$STICKY_ID\" --method PATCH -f body=\"\$BODY\"
+            else
+              gh api \"repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments\" --method POST -f body=\"\$BODY\"
+            fi
             \`\`\`
 
             ## Phase 2 — Review the diff

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -44,7 +44,7 @@ jobs:
           ## 🔄 AI Review in Progress
 
           **Commit**: $(git rev-parse --short HEAD)
-          **Run**: [${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          **Run**: [#${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
           ---
           _Reviewing changes..._"
@@ -139,10 +139,10 @@ jobs:
                 path: .path,
                 line: .line,
                 side: "RIGHT",
-                body: ("<summary>" +
+                body: ("<details markdown=\"1\">\n<summary>" +
                   (if .label == "blocking" then "🛑" elif .label == "suggestion" then "💡" else "✏️" end) + " " +
                   (.label | ascii_upcase) + ": " + .summary +
-                  "</summary>\n<details markdown=\"1\">\n\n" +
+                  "</summary>\n\n" +
                   "- **Commit**: `" + $commit + "`\n" +
                   "- **Issue**: " + .description + "\n\n" +
                   "- **Suggested Change**:\n\n" +
@@ -234,7 +234,7 @@ jobs:
           ## $VERDICT
 
           **Commit**: \`$COMMIT\`
-          **Run**: [${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          **Run**: [#${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
           ### Issues Found
           🛑 $BLOCKING blocking &nbsp;|&nbsp; 💡 $SUGGESTION suggestion &nbsp;|&nbsp; ✏️ $NIT nit

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -22,15 +22,24 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - uses: anomalyco/opencode/github@latest
+      - name: Install opencode
+        shell: bash
+        run: curl -fsSL https://opencode.ai/install | bash
+
+      - name: Add opencode to PATH
+        shell: bash
+        run: echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
+
+      - name: Run opencode review
+        shell: bash
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          model: opencode-go/deepseek-v4-flash
-          use_github_token: true
-          prompt: |
-            You are reviewing a pull request for the Journiful project — a collaborative trip planning platform.
+        run: |
+          opencode run \
+            --model opencode-go/deepseek-v4-flash \
+            --dangerously-skip-permissions \
+            "You are reviewing a pull request for the Journiful project — a collaborative trip planning platform.
 
             Tech stack: Fastify 5 (API), Next.js 16 (Web), React 19, Drizzle ORM + PostgreSQL 16, Tailwind CSS v4, shadcn/ui, TanStack Query v5.
 
@@ -38,44 +47,35 @@ jobs:
 
             ## Phase 1 — Post the in-progress sticky comment
 
-            First, hide the OpenCode "[Working...]" comment:
-            ```bash
-            WORKING_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-              --jq 'map(select(.body | contains("[Working..."))) | .[0].id')
-            if [ -n "$WORKING_ID" ]; then
-              gh api "repos/${{ github.repository }}/issues/comments/$WORKING_ID/minimize" --method PUT
-            fi
-            ```
-
-            Then, delete any previous review comment (from a prior run) and post a fresh in-progress one:
-            ```bash
-            PREV_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-              --jq 'map(select(.body | contains("<!-- opencode-review-marker -->"))) | .[0].id')
-            if [ -n "$PREV_ID" ]; then
-              gh api "repos/${{ github.repository }}/issues/comments/$PREV_ID" --method DELETE
+            Delete any previous review comment (from a prior run) and post a fresh in-progress one:
+            \`\`\`bash
+            PREV_ID=\$(gh api \"repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments\" \
+              --jq 'map(select(.body | contains(\"<!-- opencode-review-marker -->\"))) | .[0].id')
+            if [ -n \"\$PREV_ID\" ]; then
+              gh api \"repos/${{ github.repository }}/issues/comments/\$PREV_ID\" --method DELETE
             fi
 
-            NOW=$(date -u '+%Y-%m-%d %H:%M UTC')
-            gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            NOW=\$(date -u '+%Y-%m-%d %H:%M UTC')
+            gh api \"repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments\" \
               --method POST \
-              -f body="<!-- opencode-review-marker -->
+              -f body=\"<!-- opencode-review-marker -->
 
             ## 🔄 AI Review in Progress
 
-            **Commit**: $(git rev-parse --short HEAD)
-            **Started**: $NOW
+            **Commit**: \$(git rev-parse --short HEAD)
+            **Started**: \$NOW
 
             ---
-            _Reviewing changes..._"
-            ```
+            _Reviewing changes..._\"
+            \`\`\`
 
             ## Phase 2 — Review the diff
 
             Fetch the base branch and examine changes:
-            ```bash
-            git fetch origin "${{ github.event.pull_request.base.ref }}" --depth=50
-            git diff "origin/${{ github.event.pull_request.base.ref }}...HEAD"
-            ```
+            \`\`\`bash
+            git fetch origin \"${{ github.event.pull_request.base.ref }}\" --depth=50
+            git diff \"origin/${{ github.event.pull_request.base.ref }}...HEAD\"
+            \`\`\`
 
             Focus on:
             - Code quality and TypeScript safety
@@ -89,28 +89,28 @@ jobs:
             ## Phase 3 — Post inline review comments
 
             For each issue found, post an INLINE comment on the specific line using:
-            ```bash
-            gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments" \
+            \`\`\`bash
+            gh api \"repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments\" \
               --method POST \
-              -f body="🔴 Critical / 🟡 Warning / 🔵 Suggestion: Your specific feedback here" \
-              -f commit_id="$(git rev-parse HEAD)" \
-              -f path="path/to/file.ts" \
+              -f body=\"🔴 Critical / 🟡 Warning / 🔵 Suggestion: Your specific feedback here\" \
+              -f commit_id=\"\$(git rev-parse HEAD)\" \
+              -f path=\"path/to/file.ts\" \
               -f line=<line_number> \
-              -f side="RIGHT"
-            ```
-            - Use `side: RIGHT` and line numbers from the NEW file (not the diff position).
+              -f side=\"RIGHT\"
+            \`\`\`
+            - Use \`side: RIGHT\` and line numbers from the NEW file (not the diff position).
             - Prepend each comment with the severity emoji.
             - Be specific — reference variable names, function names, exact issues.
-            - Only post comments for actual issues. Do not post "looks good" or empty comments.
+            - Only post comments for actual issues. Do not post \"looks good\" or empty comments.
 
             ## Phase 4 — Update the sticky verdict comment
 
             Find the review comment and update it with the final verdict:
-            ```bash
-            STICKY_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-              --jq 'map(select(.body | contains("<!-- opencode-review-marker -->"))) | last | .id')
-            COMMIT=$(git rev-parse --short HEAD)
-            NOW=$(date -u '+%Y-%m-%d %H:%M UTC')
+            \`\`\`bash
+            STICKY_ID=\$(gh api \"repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments\" \
+              --jq 'map(select(.body | contains(\"<!-- opencode-review-marker -->\"))) | last | .id')
+            COMMIT=\$(git rev-parse --short HEAD)
+            NOW=\$(date -u '+%Y-%m-%d %H:%M UTC')
 
             # Count severity levels from any inline comments you posted
             CRITICAL=...  # count of 🔴
@@ -118,46 +118,38 @@ jobs:
             SUGGESTION=... # count of 🔵
 
             # Determine verdict
-            if [ "$CRITICAL" -gt 0 ]; then
-              VERDICT="❌ **Changes Requested**"
-            elif [ "$WARNING" -gt 0 ]; then
-              VERDICT="✔️ **Approved with Comments**"
+            if [ \"\$CRITICAL\" -gt 0 ]; then
+              VERDICT=\"❌ **Changes Requested**\"
+            elif [ \"\$WARNING\" -gt 0 ]; then
+              VERDICT=\"✔️ **Approved with Comments**\"
             else
-              VERDICT="✅ **Approved**"
+              VERDICT=\"✅ **Approved**\"
             fi
 
-            gh api "repos/${{ github.repository }}/issues/comments/$STICKY_ID" \
+            gh api \"repos/${{ github.repository }}/issues/comments/\$STICKY_ID\" \
               --method PATCH \
-              -f body="<!-- opencode-review-marker -->
+              -f body=\"<!-- opencode-review-marker -->
 
-            ## $VERDICT
+            ## \$VERDICT
 
-            **Commit**: \`$COMMIT\`
-            **Completed**: $NOW
+            **Commit**: \\\`\$COMMIT\\\`
+            **Completed**: \$NOW
 
             ### Issues Found
-            🔴 $CRITICAL critical &nbsp;|&nbsp; 🟡 $WARNING warning &nbsp;|&nbsp; 🔵 $SUGGESTION suggestion
+            🔴 \$CRITICAL critical &nbsp;|&nbsp; 🟡 \$WARNING warning &nbsp;|&nbsp; 🔵 \$SUGGESTION suggestion
 
             ### Summary
             <Replace with a 2-3 sentence summary of the review findings.>
 
             ---
-            *Automated review by [OpenCode](https://opencode.ai)*"
+            *Automated review by [OpenCode](https://opencode.ai)*\"
+            \`\`\`
 
             ## Phase 5 — Clean up extra top-level comments
 
-            The OpenCode action may have posted extra top-level summary comments. Delete any `github-actions[bot]` issue comments that don't contain the `<!-- opencode-review-marker -->` marker:
-            ```bash
-            gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-              --jq 'map(select(.body | contains("<!-- opencode-review-marker -->") | not) | .id) | .[]' \
-              | xargs -I{} gh api "repos/${{ github.repository }}/issues/comments/{}" --method DELETE
-            ```
-
-      - name: Clean up extra bot comments
-        shell: bash
-        run: |
-          gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-            --jq 'map(select(.body | contains("<!-- opencode-review-marker -->") | not) | .id) | .[]' \
-            | xargs -I{} gh api "repos/${{ github.repository }}/issues/comments/{}" --method DELETE || true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            Delete any github-actions[bot] issue comments that don't contain the \`<!-- opencode-review-marker -->\` marker:
+            \`\`\`bash
+            gh api \"repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments\" \
+              --jq 'map(select(.body | contains(\"<!-- opencode-review-marker -->\") | not) | .id) | .[]' \
+              | xargs -I{} gh api \"repos/${{ github.repository }}/issues/comments/{}\" --method DELETE
+            \`\`\`"

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -24,6 +24,18 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      - name: Debug info
+        shell: bash
+        run: |
+          echo "::debug::Repository: ${{ github.repository }}"
+          echo "::debug::PR number: ${{ github.event.pull_request.number }}"
+          echo "::debug::Base ref: ${{ github.event.pull_request.base.ref }}"
+          echo "::debug::Head SHA: ${{ github.event.pull_request.head.sha }}"
+          echo "::debug::Run ID: ${{ github.run_id }}"
+          echo "::debug::Run URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          echo "::debug::Marker: <!-- opencode-review-marker -->"
+          echo "I AM ALIVE"
+
       - name: Install opencode
         shell: bash
         run: curl -fsSL https://opencode.ai/install | bash

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -144,9 +144,9 @@ jobs:
                   (if .label == "blocking" then "🛑" elif .label == "suggestion" then "💡" else "✏️" end) + " " +
                   ((.label | .[0:1] | ascii_upcase) + .label[1:]) + ": " + .summary +
                   "</summary>\n\n" +
-                  "- **Commit**: [" + $commit[0:7] + "](https://github.com/" + $repo + "/commit/" + $commit + ")\n" +
-                  "- **Issue**: " + .description + "\n\n" +
-                  "- **Suggested Change**:\n\n" +
+                  "**Commit**: [" + $commit[0:7] + "](https://github.com/" + $repo + "/commit/" + $commit + ")\n\n" +
+                  "**Issue**: " + .description + "\n\n" +
+                  "**Suggested Change**:\n\n" +
                   .suggested_change + "\n\n" +
                   "</details>"
                 )

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -22,22 +22,6 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Post in-progress sticky comment
-        uses: marocchino/sticky-pull-request-comment@v3
-        with:
-          header: opencode-review
-          recreate: true
-          message: |
-            <!-- opencode-review-marker -->
-
-            ## 🔄 AI Review in Progress
-
-            **Commit**: `${{ github.event.pull_request.head.sha }}`
-            **Started**: ${{ github.event.pull_request.updated_at }}
-
-            ---
-            _Reviewing changes..._
-
       - uses: anomalyco/opencode/github@latest
         env:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
@@ -52,13 +36,37 @@ jobs:
 
             ---
 
-            ## Phase 1 — Hide the OpenCode working comment
+            ## Phase 1 — Post the in-progress sticky comment
 
-            Find and minimize the "[Working...]" comment this action just posted:
+            First, hide the OpenCode "[Working...]" comment:
             ```bash
             WORKING_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
               --jq 'map(select(.body | contains("[Working..."))) | .[0].id')
-            gh api "repos/${{ github.repository }}/issues/comments/$WORKING_ID/minimize" --method PUT
+            if [ -n "$WORKING_ID" ]; then
+              gh api "repos/${{ github.repository }}/issues/comments/$WORKING_ID/minimize" --method PUT
+            fi
+            ```
+
+            Then, delete any previous review comment (from a prior run) and post a fresh in-progress one:
+            ```bash
+            PREV_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+              --jq 'map(select(.body | contains("<!-- opencode-review-marker -->"))) | .[0].id')
+            if [ -n "$PREV_ID" ]; then
+              gh api "repos/${{ github.repository }}/issues/comments/$PREV_ID" --method DELETE
+            fi
+
+            NOW=$(date -u '+%Y-%m-%d %H:%M UTC')
+            gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+              --method POST \
+              -f body="<!-- opencode-review-marker -->
+
+            ## 🔄 AI Review in Progress
+
+            **Commit**: $(git rev-parse --short HEAD)
+            **Started**: $NOW
+
+            ---
+            _Reviewing changes..._"
             ```
 
             ## Phase 2 — Review the diff
@@ -100,7 +108,7 @@ jobs:
             Find the review comment and update it with the final verdict:
             ```bash
             STICKY_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-              --jq 'map(select(.body | contains("<!-- opencode-review-marker -->"))) | .[0].id')
+              --jq 'map(select(.body | contains("<!-- opencode-review-marker -->"))) | last | .id')
             COMMIT=$(git rev-parse --short HEAD)
             NOW=$(date -u '+%Y-%m-%d %H:%M UTC')
 
@@ -134,8 +142,7 @@ jobs:
             <Replace with a 2-3 sentence summary of the review findings.>
 
             ---
-            *Automated review by [OpenCode](https://opencode.ai)*
-<!-- Sticky Pull Request Commentopencode-review -->"
+            *Automated review by [OpenCode](https://opencode.ai)*"
 
             ## Phase 5 — Clean up extra top-level comments
 

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -38,10 +38,21 @@ jobs:
         run: |
           STICKY_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
             --jq 'map(select(.body | contains("<!-- opencode-review-marker -->"))) | last | .id')
+
+          REVIEW_NUM=1
+          if [ -n "$STICKY_ID" ]; then
+            PREV=$(gh api "repos/${{ github.repository }}/issues/comments/$STICKY_ID" \
+              --jq '.body' | grep -oP '<!-- opencode-review-count: \K\d+' || echo 0)
+            REVIEW_NUM=$((PREV + 1))
+          fi
+          echo "$REVIEW_NUM" > /tmp/review-count
+
           BODY="<!-- opencode-review-marker -->
+          <!-- opencode-review-count: $REVIEW_NUM -->
 
           ## 🔄 AI Review in Progress
 
+          **Review**: $REVIEW_NUM
           **Commit**: $(git rev-parse --short HEAD)
           **Run**: [#${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
@@ -127,8 +138,9 @@ jobs:
           COMMIT=$(git rev-parse HEAD)
           REPO="${{ github.repository }}"
           PR="${{ github.event.pull_request.number }}"
+          REVIEW=$(cat /tmp/review-count 2>/dev/null || echo 1)
 
-          PAYLOAD=$(jq -c --arg commit "$COMMIT" --arg repo "$REPO" '
+          PAYLOAD=$(jq -c --arg commit "$COMMIT" --arg repo "$REPO" --arg review "$REVIEW" '
             [
               .[] | {
                 path: .path,
@@ -138,6 +150,7 @@ jobs:
                   (if .label == "blocking" then "🛑" elif .label == "suggestion" then "💡" else "✏️" end) + " " +
                   ((.label | .[0:1] | ascii_upcase) + .label[1:]) + ": " + .summary +
                   "</summary>\n\n" +
+                  "**Review**: " + $review + "\n\n" +
                   "**Commit**: [" + $commit[0:7] + "](https://github.com/" + $repo + "/commit/" + $commit + ")\n\n" +
                   "**Issue**: " + .description + "\n\n" +
                   "**Suggested Change**:\n\n" +
@@ -167,6 +180,7 @@ jobs:
           [ -f /tmp/review-comments.json ] || exit 0
 
           COMMIT=$(git rev-parse --short HEAD)
+          REVIEW=$(cat /tmp/review-count 2>/dev/null || echo 1)
 
           read BLOCKING SUGGESTION NIT <<< $(jq -r '[
             (map(select(.label == "blocking")) | length),
@@ -198,9 +212,11 @@ jobs:
             --jq 'map(select(.body | contains("<!-- opencode-review-marker -->"))) | last | .id')
 
           gh api "repos/${{ github.repository }}/issues/comments/$STICKY_ID" --method PATCH -f body="<!-- opencode-review-marker -->
+          <!-- opencode-review-count: $REVIEW -->
 
           ## $VERDICT
 
+          **Review**: $REVIEW
           **Commit**: [$COMMIT](${{ github.server_url }}/${{ github.repository }}/commit/$COMMIT)
           **Run**: [#${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 

--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -101,7 +101,14 @@ jobs:
             - Use \`side: RIGHT\` and line numbers from the NEW file (not the diff position).
             - Prepend each comment with the severity emoji.
             - Be specific — reference variable names, function names, exact issues.
-            - Only post comments for actual issues. Do not post \"looks good\" or empty comments."
+            - Only post comments for actual issues. Do not post \"looks good\" or empty comments.
+
+            After posting all inline comments, write a 2-3 sentence summary to /tmp/review-summary:
+            \`\`\`bash
+            cat > /tmp/review-summary << 'EOF'
+            Replace with 2-3 sentences summarizing the review findings.
+            EOF
+            \`\`\`"
 
       - name: Update sticky verdict comment
         shell: bash
@@ -124,6 +131,11 @@ jobs:
             VERDICT="✅ **Approved**"
           fi
 
+           SUMMARY=""
+          if [ -f /tmp/review-summary ]; then
+            SUMMARY=$(cat /tmp/review-summary)
+          fi
+
           STICKY_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
             --jq 'map(select(.body | contains("<!-- opencode-review-marker -->"))) | last | .id')
 
@@ -138,6 +150,8 @@ jobs:
 
           ### Issues Found
           🔴 $CRITICAL critical &nbsp;|&nbsp; 🟡 $WARNING warning &nbsp;|&nbsp; 🔵 $SUGGESTION suggestion
+
+          $SUMMARY
 
           ---
           *Automated review by [OpenCode](https://opencode.ai)*"

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -2,8 +2,6 @@
 import { ensureJWTSecret } from "./config/jwt.js";
 ensureJWTSecret();
 
-console.log("I AM ALIVE");
-
 import closeWithGrace from "close-with-grace";
 import { buildApp } from "./app.js";
 import { env } from "./config/env.js";

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -2,6 +2,8 @@
 import { ensureJWTSecret } from "./config/jwt.js";
 ensureJWTSecret();
 
+console.log("I AM ALIVE");
+
 import closeWithGrace from "close-with-grace";
 import { buildApp } from "./app.js";
 import { env } from "./config/env.js";


### PR DESCRIPTION
## Summary
- Adds `marocchino/sticky-pull-request-comment@v3` for verdict comment lifecycle (creates once, updates in-place on subsequent pushes)
- LLM posts **inline review comments** on specific code lines via `gh api` (not just a single summary comment)
- Shows "Review in Progress" status with commit SHA and UTC timestamp before review starts
- Updates sticky comment with final verdict (✅ Approve / ⚠️ Request Changes / 💬 Comment) and severity counts
- Minimizes the OpenCode-generated `[Working...]` comment to reduce noise
- Adds `ready_for_review` trigger and `fetch-depth: 0` for full diff context

## How it works
1. **Phase 1** (GHA step): `marocchino/sticky-pull-request-comment` posts "🔄 Review in Progress" with commit/timestamp
2. **Phase 2** (OpenCode step): The LLM reviews the diff, posts inline comments on issues, then updates the sticky comment with the verdict