### PR TITLE
feat: redesign Discover POI cards with Google Photos backgrounds & 6-category taxonomy

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -102,6 +102,10 @@ export async function buildApp(
   const app = Fastify({
     ...opts.fastify,
     trustProxy: env.TRUST_PROXY ?? false,
+    // Google Places photo resource names (places/{id}/photos/{ref}) are ~350-500
+    // chars, exceeding find-my-way's default 100-char param limit. Without this,
+    // every /locations/photos/:photoRef request fails with FST_ERR_MAX_PARAM_LENGTH (414).
+    maxParamLength: 2000,
     ajv: {
       customOptions: {
         useDefaults: true,

--- a/apps/api/src/db/migrations/0040_flaky_thanos.sql
+++ b/apps/api/src/db/migrations/0040_flaky_thanos.sql
@@ -1,0 +1,3 @@
+ALTER TYPE "public"."event_type" ADD VALUE 'wellness' BEFORE 'misc';--> statement-breakpoint
+ALTER TYPE "public"."event_type" ADD VALUE 'shopping' BEFORE 'misc';--> statement-breakpoint
+ALTER TYPE "public"."event_type" ADD VALUE 'lodging' BEFORE 'misc';

--- a/apps/api/src/db/migrations/meta/0040_snapshot.json
+++ b/apps/api/src/db/migrations/meta/0040_snapshot.json
@@ -1,0 +1,3236 @@
+{
+  "id": "c65c77f3-80de-4d82-9f4f-8b03d952cf3e",
+  "prevId": "f4d4672e-573b-486d-8b9d-ef465c0c6e7a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accommodations": {
+      "name": "accommodations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_lat": {
+          "name": "address_lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_lon": {
+          "name": "address_lon",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "check_in": {
+          "name": "check_in",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "check_out": {
+          "name": "check_out",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "links": {
+          "name": "links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accommodations_trip_id_idx": {
+          "name": "accommodations_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_created_by_idx": {
+          "name": "accommodations_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_check_in_idx": {
+          "name": "accommodations_check_in_idx",
+          "columns": [
+            {
+              "expression": "check_in",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_deleted_at_idx": {
+          "name": "accommodations_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_trip_id_deleted_at_idx": {
+          "name": "accommodations_trip_id_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "accommodations_trip_id_not_deleted_idx": {
+          "name": "accommodations_trip_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"accommodations\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "accommodations_trip_id_trips_id_fk": {
+          "name": "accommodations_trip_id_trips_id_fk",
+          "tableFrom": "accommodations",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accommodations_created_by_users_id_fk": {
+          "name": "accommodations_created_by_users_id_fk",
+          "tableFrom": "accommodations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "accommodations_deleted_by_users_id_fk": {
+          "name": "accommodations_deleted_by_users_id_fk",
+          "tableFrom": "accommodations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_attempts": {
+      "name": "auth_attempts",
+      "schema": "",
+      "columns": {
+        "phone_number": {
+          "name": "phone_number",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_failed_at": {
+          "name": "last_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blacklisted_tokens": {
+      "name": "blacklisted_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "jti": {
+          "name": "jti",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blacklisted_tokens_expires_at_idx": {
+          "name": "blacklisted_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blacklisted_tokens_user_id_users_id_fk": {
+          "name": "blacklisted_tokens_user_id_users_id_fk",
+          "tableFrom": "blacklisted_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "blacklisted_tokens_jti_unique": {
+          "name": "blacklisted_tokens_jti_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "jti"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_lat": {
+          "name": "location_lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_lon": {
+          "name": "location_lon",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "all_day": {
+          "name": "all_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "links": {
+          "name": "links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_trip_id_idx": {
+          "name": "events_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_created_by_idx": {
+          "name": "events_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_start_time_idx": {
+          "name": "events_start_time_idx",
+          "columns": [
+            {
+              "expression": "start_time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_deleted_at_idx": {
+          "name": "events_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_trip_id_deleted_at_idx": {
+          "name": "events_trip_id_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_trip_id_not_deleted_idx": {
+          "name": "events_trip_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_trip_id_trips_id_fk": {
+          "name": "events_trip_id_trips_id_fk",
+          "tableFrom": "events",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_created_by_users_id_fk": {
+          "name": "events_created_by_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_deleted_by_users_id_fk": {
+          "name": "events_deleted_by_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flight_cache": {
+      "name": "flight_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "flight_number": {
+          "name": "flight_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "flight_cache_flight_number_date_unique": {
+          "name": "flight_cache_flight_number_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "flight_number",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitee_phone": {
+          "name": "invitee_phone",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invitations_trip_id_idx": {
+          "name": "invitations_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitations_invitee_phone_idx": {
+          "name": "invitations_invitee_phone_idx",
+          "columns": [
+            {
+              "expression": "invitee_phone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitations_trip_id_trips_id_fk": {
+          "name": "invitations_trip_id_trips_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_id_users_id_fk": {
+          "name": "invitations_inviter_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitations_trip_phone_unique": {
+          "name": "invitations_trip_phone_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trip_id",
+            "invitee_phone"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member_travel": {
+      "name": "member_travel",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "travel_type": {
+          "name": "travel_type",
+          "type": "member_travel_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flight_number": {
+          "name": "flight_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_travel_trip_id_idx": {
+          "name": "member_travel_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_member_id_idx": {
+          "name": "member_travel_member_id_idx",
+          "columns": [
+            {
+              "expression": "member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_time_idx": {
+          "name": "member_travel_time_idx",
+          "columns": [
+            {
+              "expression": "time",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_deleted_at_idx": {
+          "name": "member_travel_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_member_id_deleted_at_idx": {
+          "name": "member_travel_member_id_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_trip_id_deleted_at_idx": {
+          "name": "member_travel_trip_id_deleted_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_travel_trip_id_not_deleted_idx": {
+          "name": "member_travel_trip_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"member_travel\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_travel_trip_id_trips_id_fk": {
+          "name": "member_travel_trip_id_trips_id_fk",
+          "tableFrom": "member_travel",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_travel_member_id_members_id_fk": {
+          "name": "member_travel_member_id_members_id_fk",
+          "tableFrom": "member_travel",
+          "tableTo": "members",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_travel_deleted_by_users_id_fk": {
+          "name": "member_travel_deleted_by_users_id_fk",
+          "tableFrom": "member_travel",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "rsvp_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'no_response'"
+        },
+        "is_organizer": {
+          "name": "is_organizer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "share_phone": {
+          "name": "share_phone",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "calendar_excluded": {
+          "name": "calendar_excluded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "members_trip_id_idx": {
+          "name": "members_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "members_user_id_idx": {
+          "name": "members_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "members_trip_id_is_organizer_idx": {
+          "name": "members_trip_id_is_organizer_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_organizer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "members_trip_id_trips_id_fk": {
+          "name": "members_trip_id_trips_id_fk",
+          "tableFrom": "members",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "members_user_id_users_id_fk": {
+          "name": "members_user_id_users_id_fk",
+          "tableFrom": "members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "members_trip_user_unique": {
+          "name": "members_trip_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trip_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.message_reactions": {
+      "name": "message_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "message_reactions_message_id_idx": {
+          "name": "message_reactions_message_id_idx",
+          "columns": [
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_reactions_user_id_idx": {
+          "name": "message_reactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "message_reactions_message_id_messages_id_fk": {
+          "name": "message_reactions_message_id_messages_id_fk",
+          "tableFrom": "message_reactions",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_reactions_user_id_users_id_fk": {
+          "name": "message_reactions_user_id_users_id_fk",
+          "tableFrom": "message_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "message_reactions_message_user_emoji_unique": {
+          "name": "message_reactions_message_user_emoji_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "message_id",
+            "user_id",
+            "emoji"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "edited_at": {
+          "name": "edited_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "messages_trip_id_created_at_idx": {
+          "name": "messages_trip_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_parent_id_idx": {
+          "name": "messages_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_author_id_idx": {
+          "name": "messages_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_trip_toplevel_idx": {
+          "name": "messages_trip_toplevel_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"messages\".\"parent_id\" IS NULL AND \"messages\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_trip_id_not_deleted_idx": {
+          "name": "messages_trip_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"messages\".\"deleted_at\" IS NULL AND \"messages\".\"parent_id\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_trip_id_trips_id_fk": {
+          "name": "messages_trip_id_trips_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_author_id_users_id_fk": {
+          "name": "messages_author_id_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_parent_id_messages_id_fk": {
+          "name": "messages_parent_id_messages_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_deleted_by_users_id_fk": {
+          "name": "messages_deleted_by_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "deleted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.muted_members": {
+      "name": "muted_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted_by": {
+          "name": "muted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "muted_members_trip_id_trips_id_fk": {
+          "name": "muted_members_trip_id_trips_id_fk",
+          "tableFrom": "muted_members",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "muted_members_user_id_users_id_fk": {
+          "name": "muted_members_user_id_users_id_fk",
+          "tableFrom": "muted_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "muted_members_muted_by_users_id_fk": {
+          "name": "muted_members_muted_by_users_id_fk",
+          "tableFrom": "muted_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "muted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "muted_members_trip_user_unique": {
+          "name": "muted_members_trip_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trip_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_preferences": {
+      "name": "notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "daily_itinerary": {
+          "name": "daily_itinerary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "trip_messages": {
+          "name": "trip_messages",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notification_preferences_user_id_users_id_fk": {
+          "name": "notification_preferences_user_id_users_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_preferences_trip_id_trips_id_fk": {
+          "name": "notification_preferences_trip_id_trips_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_preferences_user_trip_unique": {
+          "name": "notification_preferences_user_trip_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "trip_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_created_at_idx": {
+          "name": "notifications_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_id_created_at_desc_idx": {
+          "name": "notifications_user_id_created_at_desc_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"notifications\".\"read_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_trip_user_created_at_idx": {
+          "name": "notifications_trip_user_created_at_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_trip_id_trips_id_fk": {
+          "name": "notifications_trip_id_trips_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_participants": {
+      "name": "payment_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_amount": {
+          "name": "share_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_participants_payment_id_idx": {
+          "name": "payment_participants_payment_id_idx",
+          "columns": [
+            {
+              "expression": "payment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_participants_user_id_idx": {
+          "name": "payment_participants_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_participants_guest_id_idx": {
+          "name": "payment_participants_guest_id_idx",
+          "columns": [
+            {
+              "expression": "guest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_participants_payment_id_payments_id_fk": {
+          "name": "payment_participants_payment_id_payments_id_fk",
+          "tableFrom": "payment_participants",
+          "tableTo": "payments",
+          "columnsFrom": [
+            "payment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payment_participants_user_id_users_id_fk": {
+          "name": "payment_participants_user_id_users_id_fk",
+          "tableFrom": "payment_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payment_participants_guest_id_trip_guests_id_fk": {
+          "name": "payment_participants_guest_id_trip_guests_id_fk",
+          "tableFrom": "payment_participants",
+          "tableTo": "trip_guests",
+          "columnsFrom": [
+            "guest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guest_id": {
+          "name": "guest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_by": {
+          "name": "deleted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payments_trip_id_not_deleted_idx": {
+          "name": "payments_trip_id_not_deleted_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"payments\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_user_id_idx": {
+          "name": "payments_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payments_guest_id_idx": {
+          "name": "payments_guest_id_idx",
+          "columns": [
+            {
+              "expression": "guest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payments_trip_id_trips_id_fk": {
+          "name": "payments_trip_id_trips_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payments_user_id_users_id_fk": {
+          "name": "payments_user_id_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payments_guest_id_trip_guests_id_fk": {
+          "name": "payments_guest_id_trip_guests_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "trip_guests",
+          "columnsFrom": [
+            "guest_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "payments_created_by_users_id_fk": {
+          "name": "payments_created_by_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.poi_cache": {
+      "name": "poi_cache",
+      "schema": "",
+      "columns": {
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_lat": {
+          "name": "search_lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_lon": {
+          "name": "search_lon",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_location": {
+          "name": "search_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "suggestions": {
+          "name": "suggestions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "poi_cache_trip_id_trips_id_fk": {
+          "name": "poi_cache_trip_id_trips_id_fk",
+          "tableFrom": "poi_cache",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'vapid'"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_subscriptions_user_id_idx": {
+          "name": "push_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_id_users_id_fk": {
+          "name": "push_subscriptions_user_id_users_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_subscriptions_endpoint_unique": {
+          "name": "push_subscriptions_endpoint_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "endpoint"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rate_limit_entries": {
+      "name": "rate_limit_entries",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rate_limit_entries_expires_at_idx": {
+          "name": "rate_limit_entries_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sent_reminders": {
+      "name": "sent_reminders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sent_reminders_type_ref_idx": {
+          "name": "sent_reminders_type_ref_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sent_reminders_user_id_users_id_fk": {
+          "name": "sent_reminders_user_id_users_id_fk",
+          "tableFrom": "sent_reminders",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sent_reminders_type_ref_user_unique": {
+          "name": "sent_reminders_type_ref_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "type",
+            "reference_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trip_guests": {
+      "name": "trip_guests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trip_guests_trip_id_idx": {
+          "name": "trip_guests_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trip_guests_trip_id_trips_id_fk": {
+          "name": "trip_guests_trip_id_trips_id_fk",
+          "tableFrom": "trip_guests",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_guests_created_by_users_id_fk": {
+          "name": "trip_guests_created_by_users_id_fk",
+          "tableFrom": "trip_guests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trip_photos": {
+      "name": "trip_photos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "caption": {
+          "name": "caption",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "photo_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trip_photos_trip_id_idx": {
+          "name": "trip_photos_trip_id_idx",
+          "columns": [
+            {
+              "expression": "trip_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trip_photos_uploaded_by_idx": {
+          "name": "trip_photos_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trip_photos_trip_id_trips_id_fk": {
+          "name": "trip_photos_trip_id_trips_id_fk",
+          "tableFrom": "trip_photos",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "trip_photos_uploaded_by_users_id_fk": {
+          "name": "trip_photos_uploaded_by_users_id_fk",
+          "tableFrom": "trip_photos",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trips": {
+      "name": "trips",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination": {
+          "name": "destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "destination_lat": {
+          "name": "destination_lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_lon": {
+          "name": "destination_lon",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "destination_display_name": {
+          "name": "destination_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preferred_timezone": {
+          "name": "preferred_timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_id": {
+          "name": "theme_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "theme_font": {
+          "name": "theme_font",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allow_members_to_add_events": {
+          "name": "allow_members_to_add_events",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_all_members": {
+          "name": "show_all_members",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancelled": {
+          "name": "cancelled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trips_created_by_idx": {
+          "name": "trips_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trips_created_by_users_id_fk": {
+          "name": "trips_created_by_users_id_fk",
+          "tableFrom": "trips",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_photo_url": {
+          "name": "profile_photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handles": {
+          "name": "handles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature_unit": {
+          "name": "temperature_unit",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'celsius'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "calendar_token": {
+          "name": "calendar_token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_at": {
+          "name": "sms_consent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sms_consent_version": {
+          "name": "sms_consent_version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "users_phone_number_idx": {
+          "name": "users_phone_number_idx",
+          "columns": [
+            {
+              "expression": "phone_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_phone_number_unique": {
+          "name": "users_phone_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "phone_number"
+          ]
+        },
+        "users_calendar_token_unique": {
+          "name": "users_calendar_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "calendar_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.weather_cache": {
+      "name": "weather_cache",
+      "schema": "",
+      "columns": {
+        "trip_id": {
+          "name": "trip_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "weather_cache_trip_id_trips_id_fk": {
+          "name": "weather_cache_trip_id_trips_id_fk",
+          "tableFrom": "weather_cache",
+          "tableTo": "trips",
+          "columnsFrom": [
+            "trip_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.event_type": {
+      "name": "event_type",
+      "schema": "public",
+      "values": [
+        "travel",
+        "food_and_drink",
+        "arts_and_entertainment",
+        "outdoors",
+        "nightlife",
+        "wellness",
+        "shopping",
+        "lodging",
+        "misc"
+      ]
+    },
+    "public.invitation_status": {
+      "name": "invitation_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "declined",
+        "failed"
+      ]
+    },
+    "public.member_travel_type": {
+      "name": "member_travel_type",
+      "schema": "public",
+      "values": [
+        "arrival",
+        "departure"
+      ]
+    },
+    "public.photo_status": {
+      "name": "photo_status",
+      "schema": "public",
+      "values": [
+        "processing",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.rsvp_status": {
+      "name": "rsvp_status",
+      "schema": "public",
+      "values": [
+        "going",
+        "not_going",
+        "maybe",
+        "no_response"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1786210263414,
       "tag": "0039_stiff_stingray",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1787108716812,
+      "tag": "0040_flaky_thanos",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -64,6 +64,8 @@ export const eventTypeEnum = pgEnum("event_type", [
   "arts_and_entertainment",
   "outdoors",
   "nightlife",
+  "wellness",
+  "shopping",
   "misc",
 ]);
 

--- a/apps/api/src/db/schema/index.ts
+++ b/apps/api/src/db/schema/index.ts
@@ -66,6 +66,7 @@ export const eventTypeEnum = pgEnum("event_type", [
   "nightlife",
   "wellness",
   "shopping",
+  "lodging",
   "misc",
 ]);
 

--- a/apps/api/src/db/seed.ts
+++ b/apps/api/src/db/seed.ts
@@ -519,7 +519,7 @@ async function main() {
     lat: number,
     lon: number,
     distance: number,
-    category: "food_and_drink" | "arts_and_entertainment" | "outdoors" | "nightlife",
+    category: "food_and_drink" | "arts_and_entertainment" | "outdoors" | "nightlife" | "wellness" | "shopping",
     subcategory: string,
   ): POISuggestion {
     return {
@@ -536,6 +536,10 @@ async function main() {
       website: null,
       tel: null,
       subcategory,
+      photoName: null,
+      photoAttribution: null,
+      googleMapsUri: null,
+      businessStatus: null,
       eventId: null,
     };
   }
@@ -557,7 +561,7 @@ async function main() {
   const barcelonaPOIs: POISuggestion[] = [
     makeMockPOIs("mock-bcn-001", "Ciudad Condal", "Rambla de Catalunya 18", 41.3895, 2.1656, 1500, "food_and_drink", "Tapas Restaurant"),
     makeMockPOIs("mock-bcn-002", "La Boqueria", "La Rambla 91", 41.3817, 2.1717, 2200, "food_and_drink", "Food Market"),
-    makeMockPOIs("mock-bcn-003", "Can Paixano", "Carrer de la Reina Cristina 7", 41.3801, 2.1834, 2800, "food_and_drink", "Cava Bar"),
+    makeMockPOIs("mock-bcn-003", "Can Paixano", "Carrer de la Reina Cristina 7", 41.3801, 2.1834, 2800, "nightlife", "Cava Bar"),
     makeMockPOIs("mock-bcn-004", "Sagrada Família", "Carrer de Mallorca 401", 41.4036, 2.1744, 3100, "arts_and_entertainment", "Basilica"),
     makeMockPOIs("mock-bcn-005", "Picasso Museum", "Carrer Montcada 15-23", 41.3852, 2.1808, 2400, "arts_and_entertainment", "Art Museum"),
     makeMockPOIs("mock-bcn-006", "Barceloneta Beach", "Passeig Marítim de la Barceloneta", 41.3786, 2.1925, 3500, "outdoors", "Beach"),

--- a/apps/api/src/middleware/rate-limit.middleware.ts
+++ b/apps/api/src/middleware/rate-limit.middleware.ts
@@ -89,6 +89,28 @@ export const defaultRateLimitConfig: RateLimitOptions = {
 };
 
 /**
+ * Rate limiting for the Google Places photo proxy.
+ * 60 requests per minute per IP — photos are public, cached, and
+ * user identity is not available on this unauthenticated route.
+ */
+export const photoProxyRateLimitConfig: RateLimitOptions = {
+  max: 60,
+  timeWindow: "1 minute",
+  keyGenerator: (request) => request.ip,
+  errorResponseBuilder: (_request, context) => {
+    const error = new Error("Too many requests. Please slow down.") as Error & {
+      statusCode: number;
+      code: string;
+      customRateLimitMessage: string;
+    };
+    error.statusCode = context.statusCode;
+    error.code = "RATE_LIMIT_EXCEEDED";
+    error.customRateLimitMessage = "Too many requests. Please slow down.";
+    return error;
+  },
+};
+
+/**
  * Stricter rate limiting for write endpoints (POST/PUT/DELETE).
  * 30 requests per minute per authenticated user (falls back to IP).
  */

--- a/apps/api/src/routes/event.routes.ts
+++ b/apps/api/src/routes/event.routes.ts
@@ -33,7 +33,7 @@ const eventIdParamsSchema = z.object({
 
 // Query string schema for listing events
 const listEventsQuerySchema = z.object({
-  type: z.enum(["travel", "food_and_drink", "arts_and_entertainment", "outdoors", "nightlife", "wellness", "shopping", "misc"]).optional(),
+  type: z.enum(["travel", "food_and_drink", "arts_and_entertainment", "outdoors", "nightlife", "wellness", "shopping", "lodging", "misc"]).optional(),
   includeDeleted: z
     .string()
     .transform((val) => val === "true")

--- a/apps/api/src/routes/event.routes.ts
+++ b/apps/api/src/routes/event.routes.ts
@@ -33,7 +33,7 @@ const eventIdParamsSchema = z.object({
 
 // Query string schema for listing events
 const listEventsQuerySchema = z.object({
-  type: z.enum(["travel", "food_and_drink", "arts_and_entertainment", "outdoors", "nightlife", "misc"]).optional(),
+  type: z.enum(["travel", "food_and_drink", "arts_and_entertainment", "outdoors", "nightlife", "wellness", "shopping", "misc"]).optional(),
   includeDeleted: z
     .string()
     .transform((val) => val === "true")

--- a/apps/api/src/routes/location.routes.ts
+++ b/apps/api/src/routes/location.routes.ts
@@ -236,7 +236,7 @@ export async function locationRoutes(fastify: FastifyInstance) {
         return reply.code(404).send();
       }
 
-      const url = `${GOOGLE_PLACES_BASE}/${encodeURIComponent(photoRef)}/media?key=${key}&maxWidthPx=${w}&maxHeightPx=${h}`;
+      const url = `${GOOGLE_PLACES_BASE}/${photoRef}/media?key=${key}&maxWidthPx=${w}&maxHeightPx=${h}`;
 
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), 5000);

--- a/apps/api/src/routes/location.routes.ts
+++ b/apps/api/src/routes/location.routes.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { authenticate } from "@/middleware/auth.middleware.js";
-import { defaultRateLimitConfig } from "@/middleware/rate-limit.middleware.js";
+import { defaultRateLimitConfig, photoProxyRateLimitConfig } from "@/middleware/rate-limit.middleware.js";
 
 const autocompleteQuerySchema = z.object({
   q: z.string().min(1).max(200),
@@ -209,6 +209,60 @@ export async function locationRoutes(fastify: FastifyInstance) {
             message: "Google Places API request failed",
           },
         });
+      }
+    },
+  );
+
+  fastify.get<{ Params: { photoRef: string }; Querystring: { maxWidthPx?: string; maxHeightPx?: string } }>(
+    "/photos/:photoRef",
+    {
+      preHandler: [fastify.rateLimit(photoProxyRateLimitConfig)],
+    },
+    async (request, reply) => {
+      const { photoRef } = request.params;
+
+      // Validate photo ref format: places/{placeId}/photos/{photoRef}
+      if (!/^places\/[^/]+\/photos\/[^/]+$/.test(photoRef)) {
+        return reply.code(400).send({ error: "Invalid photo reference" });
+      }
+
+      // Parse optional size params
+      const { maxWidthPx, maxHeightPx } = request.query;
+      const w = Math.min(Math.max(parseInt(maxWidthPx ?? "400", 10) || 400, 1), 4800);
+      const h = Math.min(Math.max(parseInt(maxHeightPx ?? "280", 10) || 280, 1), 4800);
+
+      const key = request.server.config.GOOGLE_MAPS_API_KEY;
+      if (!key) {
+        return reply.code(404).send();
+      }
+
+      const url = `${GOOGLE_PLACES_BASE}/${encodeURIComponent(photoRef)}/media?key=${key}&maxWidthPx=${w}&maxHeightPx=${h}`;
+
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 5000);
+
+      try {
+        const response = await fetch(url, { signal: controller.signal });
+        clearTimeout(timeout);
+
+        if (!response.ok || !response.body) {
+          return reply.code(404).send();
+        }
+
+        const contentType = response.headers.get("content-type") ?? "image/jpeg";
+
+        reply.header("Content-Type", contentType);
+        reply.header("Cache-Control", "public, max-age=604800, immutable");
+
+        // Stream the response body using Node.js Readable.fromWeb
+        const { Readable } = await import("stream");
+        return reply.send(Readable.fromWeb(response.body as any));
+      } catch (err: any) {
+        clearTimeout(timeout);
+        if (err?.name === "AbortError") {
+          return reply.code(404).send();
+        }
+        return reply.code(404).send();
       }
     },
   );

--- a/apps/api/src/services/discover.service.ts
+++ b/apps/api/src/services/discover.service.ts
@@ -28,6 +28,9 @@ type GooglePlace = {
   location: { latitude: number; longitude: number };
   types: string[];
   attributions?: string[];
+  photos?: { name: string; authorAttributions?: { displayName?: string; uri?: string; photoUri?: string }[]; widthPx: number; heightPx: number }[];
+  businessStatus?: string;
+  googleMapsUri?: string;
 };
 
 type GoogleSearchNearbyResponse = { places: GooglePlace[] };
@@ -147,7 +150,7 @@ export class DiscoverService implements IDiscoverService {
       }
     }
 
-    // 4 parallel Google Places searchNearby POST calls
+    // 6 parallel Google Places searchNearby POST calls
     const attributionSet = new Set<string>();
 
     const categoryResults = await Promise.all(
@@ -173,7 +176,7 @@ export class DiscoverService implements IDiscoverService {
             headers: {
               "Content-Type": "application/json",
               "X-Goog-Api-Key": this.googleApiKey,
-              "X-Goog-FieldMask": "places.id,places.displayName,places.formattedAddress,places.location,places.types,places.attributions",
+              "X-Goog-FieldMask": "places.id,places.displayName,places.formattedAddress,places.location,places.types,places.attributions,places.photos,places.businessStatus,places.googleMapsUri",
             },
             body,
           });
@@ -351,6 +354,10 @@ export class DiscoverService implements IDiscoverService {
         tel: null,
         subcategory: matchedType ? (googleTypeLabels[matchedType] ?? matchedType) : null,
         eventId: null,
+        photoName: p.photos?.[0]?.name ?? null,
+        photoAttribution: p.photos?.[0]?.authorAttributions?.[0]?.displayName ?? null,
+        googleMapsUri: p.googleMapsUri ?? null,
+        businessStatus: p.businessStatus ?? null,
       };
     };
   }
@@ -382,6 +389,10 @@ export function groupByCategoryOnly(suggestions: POISuggestion[]): Record<POICat
     if (categories[s.category]) {
       categories[s.category].push(s);
     }
+  }
+  // Sort each category by distance ascending (nearest first)
+  for (const cat of POI_CATEGORIES) {
+    categories[cat.id].sort((a, b) => a.distance - b.distance);
   }
   return categories;
 }

--- a/apps/api/src/services/discover.service.ts
+++ b/apps/api/src/services/discover.service.ts
@@ -165,7 +165,10 @@ export class DiscoverService implements IDiscoverService {
                 radius: GOOGLE_RADIUS,
               },
             },
-            includedTypes: cat.googleTypes,
+            // Match on the place's single primary type so multi-type places
+            // (Walmart: department_store + bakery; hotels: lodging + bar/gym)
+            // don't bleed into unrelated categories via secondary types.
+            includedPrimaryTypes: cat.googleTypes,
             maxResultCount: GOOGLE_MAX_RESULTS,
             rankPreference: "POPULARITY",
           });

--- a/apps/api/tests/integration/discover.routes.test.ts
+++ b/apps/api/tests/integration/discover.routes.test.ts
@@ -218,6 +218,8 @@ describe("Discover Routes", () => {
         arts_and_entertainment: [],
         outdoors: [],
         nightlife: [],
+        wellness: [],
+        shopping: [],
       });
 
       // Cleanup
@@ -289,6 +291,10 @@ describe("Discover Routes", () => {
             tel: null,
             subcategory: null,
             eventId: null,
+            photoName: null,
+            photoAttribution: null,
+            googleMapsUri: null,
+            businessStatus: null,
           },
         ],
       });
@@ -313,6 +319,8 @@ describe("Discover Routes", () => {
       expect(body.data.categories.arts_and_entertainment).toEqual([]);
       expect(body.data.categories.outdoors).toEqual([]);
       expect(body.data.categories.nightlife).toEqual([]);
+      expect(body.data.categories.wellness).toEqual([]);
+      expect(body.data.categories.shopping).toEqual([]);
 
       // Cleanup
       await db.delete(poiCache).where(eq(poiCache.tripId, trip.id));

--- a/apps/api/tests/integration/discover.routes.test.ts
+++ b/apps/api/tests/integration/discover.routes.test.ts
@@ -220,6 +220,7 @@ describe("Discover Routes", () => {
         nightlife: [],
         wellness: [],
         shopping: [],
+        lodging: [],
       });
 
       // Cleanup

--- a/apps/api/tests/unit/discover.service.test.ts
+++ b/apps/api/tests/unit/discover.service.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { DiscoverService } from "@/services/discover.service.js";
+import { POI_CATEGORIES } from "@journiful/shared/types";
 import type { POISuggestion, POICategoryKey } from "@journiful/shared/types";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -22,6 +23,10 @@ function makeSuggestion(overrides: Partial<POISuggestion> = {}): POISuggestion {
     tel: null,
     subcategory: null,
     eventId: null,
+    photoName: null,
+    photoAttribution: null,
+    googleMapsUri: null,
+    businessStatus: null,
     ...overrides,
   };
 }
@@ -195,7 +200,7 @@ describe("DiscoverService", () => {
 
       expect(result.source).toBe("google");
       // Should have made 4 fetch calls (cache expired)
-      expect(fetchSpy).toHaveBeenCalledTimes(4);
+      expect(fetchSpy).toHaveBeenCalledTimes(6);
       expect(mockDb.onConflictDoUpdate).toHaveBeenCalled();
     });
   });
@@ -214,7 +219,7 @@ describe("DiscoverService", () => {
       const result = await service.getDiscoverPOIs(TRIP_ID, 48.8566, 2.3522, "Paris");
 
       expect(result.source).toBe("google");
-      expect(fetchSpy).toHaveBeenCalledTimes(4); // 4 category calls (POSTs to searchNearby)
+      expect(fetchSpy).toHaveBeenCalledTimes(6); // 6 category calls (POSTs to searchNearby)
 
       // Should have inserted cache
       expect(mockDb.insert).toHaveBeenCalled();
@@ -229,7 +234,7 @@ describe("DiscoverService", () => {
         expect(opts.method).toBe("POST");
         expect(opts.headers?.["X-Goog-Api-Key"]).toBe("test-google-key");
         expect(opts.headers?.["X-Goog-FieldMask"]).toBe(
-          "places.id,places.displayName,places.formattedAddress,places.location,places.types,places.attributions",
+          "places.id,places.displayName,places.formattedAddress,places.location,places.types,places.attributions,places.photos,places.businessStatus,places.googleMapsUri",
         );
       }
     });
@@ -258,7 +263,7 @@ describe("DiscoverService", () => {
 
       expect(result.source).toBe("google");
       // Should fetch from Google Places (refresh bypasses cache read)
-      expect(fetchSpy).toHaveBeenCalledTimes(4);
+      expect(fetchSpy).toHaveBeenCalledTimes(6);
       expect(mockDb.onConflictDoUpdate).toHaveBeenCalled();
     });
 
@@ -287,7 +292,7 @@ describe("DiscoverService", () => {
       const result = await service.getDiscoverPOIs(TRIP_ID, 48.8566, 2.3522, "Paris", true);
 
       expect(result.source).toBe("google");
-      expect(fetchSpy).toHaveBeenCalledTimes(4);
+      expect(fetchSpy).toHaveBeenCalledTimes(6);
 
       // Insert call should include the converted POI
       const insertedValue = mockDb.values.mock.calls[0]?.[0] as { suggestions: POISuggestion[] };
@@ -435,6 +440,8 @@ describe("DiscoverService", () => {
       expect(result.categories.arts_and_entertainment).toHaveLength(0);
       expect(result.categories.outdoors).toHaveLength(0);
       expect(result.categories.nightlife).toHaveLength(0);
+      expect(result.categories.wellness).toHaveLength(0);
+      expect(result.categories.shopping).toHaveLength(0);
       // Should not have inserted since all empty
       expect(mockDb.insert).not.toHaveBeenCalled();
     });
@@ -544,6 +551,8 @@ describe("DiscoverService", () => {
       expect(result.categories.arts_and_entertainment).toHaveLength(0);
       expect(result.categories.outdoors).toHaveLength(0);
       expect(result.categories.nightlife).toHaveLength(0);
+      expect(result.categories.wellness).toHaveLength(0);
+      expect(result.categories.shopping).toHaveLength(0);
       expect(fetchSpy).not.toHaveBeenCalled();
     });
 
@@ -594,7 +603,7 @@ describe("DiscoverService", () => {
 
       // Should have detected stale cache (Paris coords in cache → London coords passed) and re-fetched
       expect(result.destination).toBe("London, UK");
-      expect(fetchSpy).toHaveBeenCalledTimes(4);
+      expect(fetchSpy).toHaveBeenCalledTimes(6);
       expect(mockLog.info).toHaveBeenCalledWith(
         expect.objectContaining({
           oldLat: 48.8566,
@@ -633,6 +642,152 @@ describe("DiscoverService", () => {
       expect(result.destination).toBe("Paris, France");
       expect(result.categories.food_and_drink).toHaveLength(1);
       expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("category disjointness", () => {
+    it("has no Google type appearing in two categories", () => {
+      const seen = new Map<string, string>();
+      const duplicates: string[] = [];
+
+      for (const cat of POI_CATEGORIES) {
+        for (const t of cat.googleTypes) {
+          if (seen.has(t)) {
+            duplicates.push(`${t} (${seen.get(t)} and ${cat.id})`);
+          } else {
+            seen.set(t, cat.id);
+          }
+        }
+      }
+
+      expect(duplicates).toEqual([]);
+    });
+
+    it('places bar only under nightlife', () => {
+      const barCategories = POI_CATEGORIES
+        .filter((c) => c.googleTypes.includes("bar"))
+        .map((c) => c.id);
+
+      expect(barCategories).toEqual(["nightlife"]);
+    });
+
+    it('places liquor_store in no category', () => {
+      const liquorCategories = POI_CATEGORIES
+        .filter((c) => c.googleTypes.includes("liquor_store"))
+        .map((c) => c.id);
+
+      expect(liquorCategories).toEqual([]);
+    });
+
+    it('places tourist_attraction only under outdoors', () => {
+      const taCategories = POI_CATEGORIES
+        .filter((c) => c.googleTypes.includes("tourist_attraction"))
+        .map((c) => c.id);
+
+      expect(taCategories).toEqual(["outdoors"]);
+    });
+
+    it.each(["zoo", "aquarium", "amusement_park"] as const)(
+      'places %s only under outdoors',
+      (type) => {
+        const categories = POI_CATEGORIES
+          .filter((c) => c.googleTypes.includes(type))
+          .map((c) => c.id);
+
+        expect(categories).toEqual(["outdoors"]);
+      },
+    );
+
+    it('places night_club only under nightlife', () => {
+      const ncCategories = POI_CATEGORIES
+        .filter((c) => c.googleTypes.includes("night_club"))
+        .map((c) => c.id);
+
+      expect(ncCategories).toEqual(["nightlife"]);
+    });
+  });
+
+  describe("distance sorting", () => {
+    it("sorts POIs within each category by distance ascending", async () => {
+      const { groupByCategoryOnly } = await import("@/services/discover.service.js");
+
+      const pois = [
+        makeSuggestion({ category: "food_and_drink", distance: 200, sourceId: "a" }),
+        makeSuggestion({ category: "food_and_drink", distance: 50, sourceId: "b" }),
+        makeSuggestion({ category: "food_and_drink", distance: 1000, sourceId: "c" }),
+        makeSuggestion({ category: "outdoors", distance: 300, sourceId: "d" }),
+        makeSuggestion({ category: "outdoors", distance: 100, sourceId: "e" }),
+      ];
+
+      const result = groupByCategoryOnly(pois);
+
+      expect(result.food_and_drink.map((p) => p.distance)).toEqual([50, 200, 1000]);
+      expect(result.outdoors.map((p) => p.distance)).toEqual([100, 300]);
+      // Other categories should be empty arrays
+      expect(result.arts_and_entertainment).toEqual([]);
+      expect(result.nightlife).toEqual([]);
+      expect(result.wellness).toEqual([]);
+      expect(result.shopping).toEqual([]);
+    });
+  });
+
+  describe("mapGoogleToSuggestion photo fields", () => {
+    it("populates photoName, photoAttribution, googleMapsUri, businessStatus from Google response", () => {
+      const service = new DiscoverService(
+        createMockDb() as any,
+        "test-key",
+        createMockLogger() as any,
+      );
+
+      // Access the private method via type assertion
+      const mapper = (service as any).mapGoogleToSuggestion("nightlife", 41.3874, 2.1686);
+
+      const googlePlace = makeGooglePlace({
+        id: "ChIJTest123",
+        displayName: { text: "Test Bar", languageCode: "en" },
+        types: ["bar"],
+        photos: [
+          {
+            name: "places/ChIJTest123/photos/AUGGfZkK",
+            authorAttributions: [{ displayName: "Jane Doe", uri: "", photoUri: "" }],
+            widthPx: 400,
+            heightPx: 280,
+          },
+        ],
+        businessStatus: "OPERATIONAL",
+        googleMapsUri: "https://maps.google.com/?cid=123",
+      });
+
+      const result = mapper(googlePlace);
+
+      expect(result.photoName).toBe("places/ChIJTest123/photos/AUGGfZkK");
+      expect(result.photoAttribution).toBe("Jane Doe");
+      expect(result.googleMapsUri).toBe("https://maps.google.com/?cid=123");
+      expect(result.businessStatus).toBe("OPERATIONAL");
+    });
+
+    it("returns null photo fields when Google response lacks them", () => {
+      const service = new DiscoverService(
+        createMockDb() as any,
+        "test-key",
+        createMockLogger() as any,
+      );
+
+      const mapper = (service as any).mapGoogleToSuggestion("food_and_drink", 41.3874, 2.1686);
+
+      const googlePlace = makeGooglePlace({
+        id: "ChIJTest456",
+        displayName: { text: "Basic Place", languageCode: "en" },
+        types: ["restaurant"],
+        // No photos, businessStatus, googleMapsUri
+      });
+
+      const result = mapper(googlePlace);
+
+      expect(result.photoName).toBeNull();
+      expect(result.photoAttribution).toBeNull();
+      expect(result.googleMapsUri).toBeNull();
+      expect(result.businessStatus).toBeNull();
     });
   });
 });

--- a/apps/api/tests/unit/discover.service.test.ts
+++ b/apps/api/tests/unit/discover.service.test.ts
@@ -200,7 +200,7 @@ describe("DiscoverService", () => {
 
       expect(result.source).toBe("google");
       // Should have made 4 fetch calls (cache expired)
-      expect(fetchSpy).toHaveBeenCalledTimes(6);
+      expect(fetchSpy).toHaveBeenCalledTimes(7);
       expect(mockDb.onConflictDoUpdate).toHaveBeenCalled();
     });
   });
@@ -219,7 +219,7 @@ describe("DiscoverService", () => {
       const result = await service.getDiscoverPOIs(TRIP_ID, 48.8566, 2.3522, "Paris");
 
       expect(result.source).toBe("google");
-      expect(fetchSpy).toHaveBeenCalledTimes(6); // 6 category calls (POSTs to searchNearby)
+      expect(fetchSpy).toHaveBeenCalledTimes(7); // 7 category calls (POSTs to searchNearby)
 
       // Should have inserted cache
       expect(mockDb.insert).toHaveBeenCalled();
@@ -263,7 +263,7 @@ describe("DiscoverService", () => {
 
       expect(result.source).toBe("google");
       // Should fetch from Google Places (refresh bypasses cache read)
-      expect(fetchSpy).toHaveBeenCalledTimes(6);
+      expect(fetchSpy).toHaveBeenCalledTimes(7);
       expect(mockDb.onConflictDoUpdate).toHaveBeenCalled();
     });
 
@@ -292,7 +292,7 @@ describe("DiscoverService", () => {
       const result = await service.getDiscoverPOIs(TRIP_ID, 48.8566, 2.3522, "Paris", true);
 
       expect(result.source).toBe("google");
-      expect(fetchSpy).toHaveBeenCalledTimes(6);
+      expect(fetchSpy).toHaveBeenCalledTimes(7);
 
       // Insert call should include the converted POI
       const insertedValue = mockDb.values.mock.calls[0]?.[0] as { suggestions: POISuggestion[] };
@@ -603,7 +603,7 @@ describe("DiscoverService", () => {
 
       // Should have detected stale cache (Paris coords in cache → London coords passed) and re-fetched
       expect(result.destination).toBe("London, UK");
-      expect(fetchSpy).toHaveBeenCalledTimes(6);
+      expect(fetchSpy).toHaveBeenCalledTimes(7);
       expect(mockLog.info).toHaveBeenCalledWith(
         expect.objectContaining({
           oldLat: 48.8566,
@@ -671,12 +671,38 @@ describe("DiscoverService", () => {
       expect(barCategories).toEqual(["nightlife"]);
     });
 
-    it('places liquor_store in no category', () => {
+    it('places liquor_store only under shopping', () => {
       const liquorCategories = POI_CATEGORIES
         .filter((c) => c.googleTypes.includes("liquor_store"))
         .map((c) => c.id);
 
-      expect(liquorCategories).toEqual([]);
+      expect(liquorCategories).toEqual(["shopping"]);
+    });
+
+    it('places supermarket only under shopping', () => {
+      const supermarketCategories = POI_CATEGORIES
+        .filter((c) => c.googleTypes.includes("supermarket"))
+        .map((c) => c.id);
+
+      expect(supermarketCategories).toEqual(["shopping"]);
+    });
+
+    it('places grocery_store only under shopping', () => {
+      const groceryCategories = POI_CATEGORIES
+        .filter((c) => c.googleTypes.includes("grocery_store"))
+        .map((c) => c.id);
+
+      expect(groceryCategories).toEqual(["shopping"]);
+    });
+
+    it('places lodging types only under lodging', () => {
+      const lodgingKeys = ["lodging", "hotel", "motel", "guest_house", "hostel", "bed_and_breakfast"];
+      for (const t of lodgingKeys) {
+        const categories = POI_CATEGORIES
+          .filter((c) => c.googleTypes.includes(t))
+          .map((c) => c.id);
+        expect(categories).toEqual(["lodging"]);
+      }
     });
 
     it('places tourist_attraction only under outdoors', () => {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -64,6 +64,12 @@
   --color-event-misc: #14482e;
   --color-event-misc-light: #d8eedf;
   --color-event-misc-border: #8fc4a8;
+  --color-event-wellness: #1e5a4e;
+  --color-event-wellness-light: #d4ece5;
+  --color-event-wellness-border: #87c5b4;
+  --color-event-shopping: #6e2a4a;
+  --color-event-shopping-light: #f0dde7;
+  --color-event-shopping-border: #c790a8;
   --color-accommodation: #3e1a6e;
   --color-accommodation-light: #f0e8f5;
   --color-accommodation-border: #c5aed9;
@@ -129,6 +135,12 @@
   --color-event-misc: #78c8a0;
   --color-event-misc-light: #162e1e;
   --color-event-misc-border: #3a6a50;
+  --color-event-wellness: #5cb89a;
+  --color-event-wellness-light: #142a22;
+  --color-event-wellness-border: #2a5a48;
+  --color-event-shopping: #c77aa0;
+  --color-event-shopping-light: #2a1830;
+  --color-event-shopping-border: #5a3070;
   --color-accommodation: #b88ee8;
   --color-accommodation-light: #251a30;
   --color-accommodation-border: #5a3a80;

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -70,6 +70,9 @@
   --color-event-shopping: #6e2a4a;
   --color-event-shopping-light: #f0dde7;
   --color-event-shopping-border: #c790a8;
+  --color-event-lodging: #3e1a6e;
+  --color-event-lodging-light: #f0e8f5;
+  --color-event-lodging-border: #c5aed9;
   --color-accommodation: #3e1a6e;
   --color-accommodation-light: #f0e8f5;
   --color-accommodation-border: #c5aed9;
@@ -141,6 +144,9 @@
   --color-event-shopping: #c77aa0;
   --color-event-shopping-light: #2a1830;
   --color-event-shopping-border: #5a3070;
+  --color-event-lodging: #b88ee8;
+  --color-event-lodging-light: #251a30;
+  --color-event-lodging-border: #5a3a80;
   --color-accommodation: #b88ee8;
   --color-accommodation-light: #251a30;
   --color-accommodation-border: #5a3a80;

--- a/apps/web/src/components/discover/__tests__/discover-view.test.tsx
+++ b/apps/web/src/components/discover/__tests__/discover-view.test.tsx
@@ -75,6 +75,7 @@ function makeEmptyResponse(): POISuggestionsResponse {
       nightlife: [],
       wellness: [],
       shopping: [],
+      lodging: [],
     },
   };
 }
@@ -152,6 +153,7 @@ function makePopulatedResponse(): POISuggestionsResponse {
       nightlife: [],
       wellness: [],
       shopping: [],
+      lodging: [],
     },
   };
 }

--- a/apps/web/src/components/discover/__tests__/discover-view.test.tsx
+++ b/apps/web/src/components/discover/__tests__/discover-view.test.tsx
@@ -73,6 +73,8 @@ function makeEmptyResponse(): POISuggestionsResponse {
       arts_and_entertainment: [],
       outdoors: [],
       nightlife: [],
+      wellness: [],
+      shopping: [],
     },
   };
 }
@@ -98,6 +100,10 @@ function makePopulatedResponse(): POISuggestionsResponse {
           website: null,
           tel: null,
           subcategory: null,
+          photoName: null,
+          photoAttribution: null,
+          googleMapsUri: null,
+          businessStatus: null,
         },
         {
           sourceId: "fsq-food-2",
@@ -114,6 +120,10 @@ function makePopulatedResponse(): POISuggestionsResponse {
           website: null,
           tel: null,
           subcategory: null,
+          photoName: null,
+          photoAttribution: null,
+          googleMapsUri: null,
+          businessStatus: null,
         },
       ],
       arts_and_entertainment: [
@@ -132,10 +142,16 @@ function makePopulatedResponse(): POISuggestionsResponse {
           website: null,
           tel: null,
           subcategory: null,
+          photoName: null,
+          photoAttribution: null,
+          googleMapsUri: null,
+          businessStatus: null,
         },
       ],
       outdoors: [],
       nightlife: [],
+      wellness: [],
+      shopping: [],
     },
   };
 }
@@ -233,12 +249,14 @@ describe("DiscoverView", () => {
       // The category section <h3> headings should only exist for non-empty categories
       const headings = container.querySelectorAll("h3");
       const headingTexts = Array.from(headings).map((h) => h.textContent);
-      // Outdoors and nightlife are empty — should NOT have h3 headings
+      // Outdoors, nightlife, wellness, and shopping are empty — should NOT have h3 headings
       expect(headingTexts.some((t) => t?.startsWith("Outdoors"))).toBe(false);
       expect(headingTexts.some((t) => t?.startsWith("Nightlife"))).toBe(false);
+      expect(headingTexts.some((t) => t?.startsWith("Wellness"))).toBe(false);
+      expect(headingTexts.some((t) => t?.startsWith("Shopping"))).toBe(false);
       // Non-empty categories DO render their section headings
       expect(headingTexts.some((t) => t?.startsWith("Food & Drink"))).toBe(true);
-      expect(headingTexts.some((t) => t?.startsWith("Arts & Entertainment"))).toBe(true);
+      expect(headingTexts.some((t) => t?.startsWith("Arts & Leisure"))).toBe(true);
     });
   });
 

--- a/apps/web/src/components/discover/__tests__/poi-card.test.tsx
+++ b/apps/web/src/components/discover/__tests__/poi-card.test.tsx
@@ -89,9 +89,11 @@ describe("POICard", () => {
       );
       const bgDiv = container.querySelector('[style*="background-image"]');
       expect(bgDiv).toBeTruthy();
-      expect(bgDiv?.getAttribute("style")).toContain(
-        "/api/locations/photos/places%2Fx%2Fphotos%2Fy",
-      );
+      const style = bgDiv!.getAttribute("style") ?? "";
+      expect(style).toContain("/locations/photos/");
+      expect(style).not.toContain("/api/api");
+      expect(style).toContain("maxWidthPx=400");
+      expect(style).toContain("maxHeightPx=280");
     });
 
     it("does not render background-image when photoName is null", () => {

--- a/apps/web/src/components/discover/__tests__/poi-card.test.tsx
+++ b/apps/web/src/components/discover/__tests__/poi-card.test.tsx
@@ -104,27 +104,29 @@ describe("POICard", () => {
       expect(container.querySelector('[style*="background-image"]')).toBeNull();
     });
 
-    it("has bg-card class as fallback when no photo", () => {
+    it("has postcard frame and bg-card mat as fallback when no photo", () => {
       const poi = makePOI({ photoName: null });
       const { container } = render(
         <POICard poi={poi} onSelect={onSelect} temperatureUnit={celsius} />,
       );
       const button = container.querySelector("button");
-      expect(button?.className).toContain("bg-card");
+      expect(button?.className).toContain("postcard");
+      const mat = container.querySelector(".postcard-mat");
+      expect(mat?.className).toContain("bg-card");
     });
   });
 
   describe("photo attribution", () => {
-    it("renders attribution text when photoAttribution is present", () => {
+    it("renders attribution name when photoAttribution is present", () => {
       const poi = makePOI({ photoAttribution: "Jane Doe" });
       render(<POICard poi={poi} onSelect={onSelect} temperatureUnit={celsius} />);
-      expect(screen.getByText("Photo: Jane Doe")).toBeDefined();
+      expect(screen.getByText("Jane Doe")).toBeDefined();
     });
 
     it("does not render attribution text when photoAttribution is null", () => {
       const poi = makePOI({ photoAttribution: null });
       render(<POICard poi={poi} onSelect={onSelect} temperatureUnit={celsius} />);
-      expect(screen.queryByText(/Photo:/)).toBeNull();
+      expect(screen.queryByText("Jane Doe")).toBeNull();
     });
   });
 
@@ -174,19 +176,20 @@ describe("POICard", () => {
 
   describe("category colour mapping", () => {
     it.each([
-      ["food_and_drink" as POICategoryKey, "border-l-event-food_and_drink"],
-      ["arts_and_entertainment" as POICategoryKey, "border-l-event-arts_and_entertainment"],
-      ["outdoors" as POICategoryKey, "border-l-event-outdoors"],
-      ["nightlife" as POICategoryKey, "border-l-event-nightlife"],
-      ["wellness" as POICategoryKey, "border-l-event-wellness"],
-      ["shopping" as POICategoryKey, "border-l-event-shopping"],
-    ])("renders %s category with correct left border colour", (category, expectedClass) => {
+      ["food_and_drink" as POICategoryKey, "bg-event-food_and_drink"],
+      ["arts_and_entertainment" as POICategoryKey, "bg-event-arts_and_entertainment"],
+      ["outdoors" as POICategoryKey, "bg-event-outdoors"],
+      ["nightlife" as POICategoryKey, "bg-event-nightlife"],
+      ["wellness" as POICategoryKey, "bg-event-wellness"],
+      ["shopping" as POICategoryKey, "bg-event-shopping"],
+      ["lodging" as POICategoryKey, "bg-event-lodging"],
+    ])("renders %s category with correct accent colour", (category, expectedClass) => {
       const poi = makePOI({ category });
       const { container } = render(
         <POICard poi={poi} onSelect={onSelect} temperatureUnit={celsius} />,
       );
-      // The border class is on the accent strip div, not the button
-      const accentStrip = container.querySelector(`.${expectedClass.split(" ").join(".")}`);
+      // The accent class is on the top strip div inside the photo well
+      const accentStrip = container.querySelector(`.${expectedClass}`);
       expect(accentStrip).toBeTruthy();
     });
   });

--- a/apps/web/src/components/discover/__tests__/poi-card.test.tsx
+++ b/apps/web/src/components/discover/__tests__/poi-card.test.tsx
@@ -16,7 +16,14 @@ function makePOI(overrides: Partial<POISuggestion> = {}): POISuggestion {
     popularity: null,
     price: null,
     rating: null,
+    website: null,
+    tel: null,
+    subcategory: null,
     eventId: null,
+    photoName: null,
+    photoAttribution: null,
+    googleMapsUri: null,
+    businessStatus: null,
     ...overrides,
   };
 }
@@ -35,19 +42,6 @@ describe("POICard", () => {
     it("renders the POI name", () => {
       render(<POICard poi={makePOI()} onSelect={onSelect} temperatureUnit={celsius} />);
       expect(screen.getByText("Le Bistro Parisien")).toBeDefined();
-    });
-
-    it("renders the address when provided", () => {
-      render(<POICard poi={makePOI()} onSelect={onSelect} temperatureUnit={celsius} />);
-      expect(screen.getByText("123 Rue de Rivoli, Paris")).toBeDefined();
-    });
-
-    it("renders a placeholder when address is null", () => {
-      const poi = makePOI({ address: null });
-      render(<POICard poi={poi} onSelect={onSelect} temperatureUnit={celsius} />);
-      // Should render an em-dash placeholder to maintain layout height
-      expect(screen.getByText("\u2014")).toBeDefined();
-      expect(screen.queryByText("123 Rue de Rivoli, Paris")).toBeNull();
     });
 
     it("renders distance in meters (< 1000m)", () => {
@@ -74,13 +68,6 @@ describe("POICard", () => {
       expect(screen.getByText("3.1 mi")).toBeDefined();
     });
 
-    it("has a left border class for the correct category", () => {
-      const poi = makePOI({ category: "nightlife" });
-      const { container } = render(<POICard poi={poi} onSelect={onSelect} temperatureUnit={celsius} />);
-      const card = container.querySelector("button");
-      expect(card?.className).toContain("border-l-event-nightlife");
-    });
-
     it("renders subcategory when provided", () => {
       const poi = makePOI({ subcategory: "Italian Restaurant" });
       render(<POICard poi={poi} onSelect={onSelect} temperatureUnit={celsius} />);
@@ -92,14 +79,95 @@ describe("POICard", () => {
       render(<POICard poi={poi} onSelect={onSelect} temperatureUnit={celsius} />);
       expect(screen.queryByText("Italian Restaurant")).toBeNull();
     });
+  });
 
-    it("has a left border class for the correct category", () => {
-      const poi = makePOI({ category: "food_and_drink" });
-      const { container } = render(<POICard poi={poi} onSelect={onSelect} temperatureUnit={celsius} />);
-      const card = container.querySelector("button");
-      expect(card?.className).toContain("border-l-event-food_and_drink");
+  describe("photo background", () => {
+    it("renders background-image when photoName is present", () => {
+      const poi = makePOI({ photoName: "places/x/photos/y" });
+      const { container } = render(
+        <POICard poi={poi} onSelect={onSelect} temperatureUnit={celsius} />,
+      );
+      const bgDiv = container.querySelector('[style*="background-image"]');
+      expect(bgDiv).toBeTruthy();
+      expect(bgDiv?.getAttribute("style")).toContain(
+        "/api/locations/photos/places%2Fx%2Fphotos%2Fy",
+      );
     });
 
+    it("does not render background-image when photoName is null", () => {
+      const poi = makePOI({ photoName: null });
+      const { container } = render(
+        <POICard poi={poi} onSelect={onSelect} temperatureUnit={celsius} />,
+      );
+      expect(container.querySelector('[style*="background-image"]')).toBeNull();
+    });
+
+    it("has bg-card class as fallback when no photo", () => {
+      const poi = makePOI({ photoName: null });
+      const { container } = render(
+        <POICard poi={poi} onSelect={onSelect} temperatureUnit={celsius} />,
+      );
+      const button = container.querySelector("button");
+      expect(button?.className).toContain("bg-card");
+    });
+  });
+
+  describe("photo attribution", () => {
+    it("renders attribution text when photoAttribution is present", () => {
+      const poi = makePOI({ photoAttribution: "Jane Doe" });
+      render(<POICard poi={poi} onSelect={onSelect} temperatureUnit={celsius} />);
+      expect(screen.getByText("Photo: Jane Doe")).toBeDefined();
+    });
+
+    it("does not render attribution text when photoAttribution is null", () => {
+      const poi = makePOI({ photoAttribution: null });
+      render(<POICard poi={poi} onSelect={onSelect} temperatureUnit={celsius} />);
+      expect(screen.queryByText(/Photo:/)).toBeNull();
+    });
+  });
+
+  describe("business status badge", () => {
+    it("renders badge when businessStatus is CLOSED_TEMPORARILY", () => {
+      const poi = makePOI({ businessStatus: "CLOSED_TEMPORARILY" });
+      render(<POICard poi={poi} onSelect={onSelect} temperatureUnit={celsius} />);
+      expect(screen.getByText("CLOSED_TEMPORARILY")).toBeDefined();
+    });
+
+    it("does not render badge when businessStatus is OPERATIONAL", () => {
+      const poi = makePOI({ businessStatus: "OPERATIONAL" });
+      render(<POICard poi={poi} onSelect={onSelect} temperatureUnit={celsius} />);
+      expect(screen.queryByText("OPERATIONAL")).toBeNull();
+    });
+
+    it("does not render badge when businessStatus is null", () => {
+      const poi = makePOI({ businessStatus: null });
+      render(<POICard poi={poi} onSelect={onSelect} temperatureUnit={celsius} />);
+      expect(screen.queryByText("CLOSED_TEMPORARILY")).toBeNull();
+    });
+  });
+
+  describe("aria-label", () => {
+    it("contains the POI name", () => {
+      render(<POICard poi={makePOI()} onSelect={onSelect} temperatureUnit={celsius} />);
+      const button = screen.getByRole("button");
+      expect(button.getAttribute("aria-label")).toContain("Le Bistro Parisien");
+    });
+
+    it("does not include photo attribution hint when null", () => {
+      render(<POICard poi={makePOI()} onSelect={onSelect} temperatureUnit={celsius} />);
+      const button = screen.getByRole("button");
+      expect(button.getAttribute("aria-label")).toBe("Le Bistro Parisien");
+      expect(button.getAttribute("aria-label")).not.toContain("Photo by");
+    });
+
+    it("includes photo attribution when present", () => {
+      const poi = makePOI({ photoAttribution: "Jane Doe" });
+      render(<POICard poi={poi} onSelect={onSelect} temperatureUnit={celsius} />);
+      const button = screen.getByRole("button");
+      expect(button.getAttribute("aria-label")).toBe(
+        "Le Bistro Parisien \u2014 Photo by Jane Doe",
+      );
+    });
   });
 
   describe("category colour mapping", () => {
@@ -108,11 +176,16 @@ describe("POICard", () => {
       ["arts_and_entertainment" as POICategoryKey, "border-l-event-arts_and_entertainment"],
       ["outdoors" as POICategoryKey, "border-l-event-outdoors"],
       ["nightlife" as POICategoryKey, "border-l-event-nightlife"],
+      ["wellness" as POICategoryKey, "border-l-event-wellness"],
+      ["shopping" as POICategoryKey, "border-l-event-shopping"],
     ])("renders %s category with correct left border colour", (category, expectedClass) => {
       const poi = makePOI({ category });
-      const { container } = render(<POICard poi={poi} onSelect={onSelect} temperatureUnit={celsius} />);
-      const card = container.querySelector("button");
-      expect(card?.className).toContain(expectedClass);
+      const { container } = render(
+        <POICard poi={poi} onSelect={onSelect} temperatureUnit={celsius} />,
+      );
+      // The border class is on the accent strip div, not the button
+      const accentStrip = container.querySelector(`.${expectedClass.split(" ").join(".")}`);
+      expect(accentStrip).toBeTruthy();
     });
   });
 

--- a/apps/web/src/components/discover/__tests__/poi-detail-sheet.test.tsx
+++ b/apps/web/src/components/discover/__tests__/poi-detail-sheet.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { POIDetailSheet } from "../poi-detail-sheet";
 import type { POISuggestion, POICategoryKey, TemperatureUnit } from "@journiful/shared/types";
@@ -20,6 +20,10 @@ function makePOI(overrides: Partial<POISuggestion> = {}): POISuggestion {
     website: "https://bistro.example.com",
     tel: "+33 1 23 45 67 89",
     subcategory: "Italian Restaurant",
+    photoName: null,
+    photoAttribution: null,
+    googleMapsUri: null,
+    businessStatus: null,
     ...overrides,
   };
 }
@@ -59,7 +63,7 @@ describe("POIDetailSheet", () => {
       expect(screen.getByText("Le Bistro Parisien")).toBeDefined();
     });
 
-    it("renders the address with a Google Maps link", () => {
+    it("renders the address as plain text, not a link", () => {
       const poi = makePOI({ address: "456 Test St" });
       render(
         <POIDetailSheet
@@ -76,9 +80,10 @@ describe("POIDetailSheet", () => {
           totalPois={1}
         />,
       );
-      const link = screen.getByText("456 Test St").closest("a");
-      expect(link).toBeDefined();
-      expect(link?.getAttribute("href")).toContain("google.com/maps");
+      const addrEl = screen.getByText("456 Test St");
+      expect(addrEl).toBeDefined();
+      // Address should NOT be inside an <a> tag
+      expect(addrEl.closest("a")).toBeNull();
     });
 
     it("renders distance", () => {
@@ -121,7 +126,7 @@ describe("POIDetailSheet", () => {
       expect(link?.getAttribute("href")).toBe("https://example.com");
     });
 
-    it("does not render website section when null", () => {
+    it("does not render website link when null", () => {
       render(
         <POIDetailSheet
           poi={makePOI({ website: null, tel: null })}
@@ -137,12 +142,9 @@ describe("POIDetailSheet", () => {
           totalPois={1}
         />,
       );
-      // No ExternalLink icon should be present since website is null
+      // No <a> elements should exist (address is span, no photo, no website, no tel)
       const links = document.querySelectorAll("a");
-      // Only the GMaps link should exist
-      expect([...links].every((l) => l.href.includes("google.com/maps"))).toBe(
-        true,
-      );
+      expect(links.length).toBe(0);
     });
 
     it("renders tel link when present", () => {
@@ -219,7 +221,6 @@ describe("POIDetailSheet", () => {
           totalPois={1}
         />,
       );
-      // Should render without error
       expect(document.body).toBeDefined();
     });
 
@@ -267,6 +268,221 @@ describe("POIDetailSheet", () => {
       const button = screen.getByRole("button", { name: /create event/i });
       await user.click(button);
       expect(onCreateEvent).toHaveBeenCalledWith(poi);
+    });
+  });
+
+  describe("cover photo hero", () => {
+    it("renders cover hero with backgroundImage when photoName is provided", () => {
+      render(
+        <POIDetailSheet
+          poi={makePOI({ photoName: "places/x/y" })}
+          open={true}
+          onOpenChange={onOpenChange}
+          onCreateEvent={onCreateEvent}
+          temperatureUnit={celsius}
+          onPrev={onPrev}
+          onNext={onNext}
+          hasPrev={false}
+          hasNext={false}
+          poiIndex={0}
+          totalPois={1}
+        />,
+      );
+      const heroLink = screen.getByLabelText(/Open Le Bistro Parisien in Google Maps/i);
+      expect(heroLink).toBeDefined();
+      expect(heroLink.style.backgroundImage).toContain("/api/locations/photos/places%2Fx%2Fy");
+    });
+
+    it("renders muted placeholder when photoName is null", () => {
+      render(
+        <POIDetailSheet
+          poi={makePOI({ photoName: null })}
+          open={true}
+          onOpenChange={onOpenChange}
+          onCreateEvent={onCreateEvent}
+          temperatureUnit={celsius}
+          onPrev={onPrev}
+          onNext={onNext}
+          hasPrev={false}
+          hasNext={false}
+          poiIndex={0}
+          totalPois={1}
+        />,
+      );
+      // No hero <a> link should be present
+      expect(screen.queryByLabelText(/Open.*Google Maps/i)).toBeNull();
+      // The fallback placeholder div should be in the DOM
+      const placeholderDivs = document.querySelectorAll(".aspect-\\[3\\/2\\].bg-muted");
+      expect(placeholderDivs.length).toBeGreaterThanOrEqual(0);
+    });
+
+    it("hero links to googleMapsUri when provided", () => {
+      render(
+        <POIDetailSheet
+          poi={makePOI({ photoName: "places/x/y", googleMapsUri: "https://maps.google.com/place/abc" })}
+          open={true}
+          onOpenChange={onOpenChange}
+          onCreateEvent={onCreateEvent}
+          temperatureUnit={celsius}
+          onPrev={onPrev}
+          onNext={onNext}
+          hasPrev={false}
+          hasNext={false}
+          poiIndex={0}
+          totalPois={1}
+        />,
+      );
+      const heroLink = screen.getByLabelText(/Open Le Bistro Parisien in Google Maps/i);
+      expect(heroLink.getAttribute("href")).toBe("https://maps.google.com/place/abc");
+    });
+
+    it("hero falls back to search URL when googleMapsUri is null", () => {
+      render(
+        <POIDetailSheet
+          poi={makePOI({ photoName: "places/x/y", googleMapsUri: null })}
+          open={true}
+          onOpenChange={onOpenChange}
+          onCreateEvent={onCreateEvent}
+          temperatureUnit={celsius}
+          onPrev={onPrev}
+          onNext={onNext}
+          hasPrev={false}
+          hasNext={false}
+          poiIndex={0}
+          totalPois={1}
+        />,
+      );
+      const heroLink = screen.getByLabelText(/Open Le Bistro Parisien in Google Maps/i);
+      expect(heroLink.getAttribute("href")).toContain("google.com/maps/search");
+    });
+
+    it("chevrons are siblings of hero, not nested inside the <a>", () => {
+      render(
+        <POIDetailSheet
+          poi={makePOI({ photoName: "places/x/y" })}
+          open={true}
+          onOpenChange={onOpenChange}
+          onCreateEvent={onCreateEvent}
+          temperatureUnit={celsius}
+          onPrev={onPrev}
+          onNext={onNext}
+          hasPrev={false}
+          hasNext={false}
+          poiIndex={0}
+          totalPois={1}
+        />,
+      );
+      const heroLink = screen.getByLabelText(/Open Le Bistro Parisien in Google Maps/i);
+      // Chevrons should NOT be children of the hero <a>
+      expect(within(heroLink).queryByRole("button")).toBeNull();
+      // But they should exist in the document at the sibling level
+      expect(screen.getByLabelText("Previous place")).toBeDefined();
+      expect(screen.getByLabelText("Next place")).toBeDefined();
+    });
+  });
+
+  describe("counter position", () => {
+    it("renders counter in bottom section next to Create Event", () => {
+      render(
+        <POIDetailSheet
+          poi={makePOI()}
+          open={true}
+          onOpenChange={onOpenChange}
+          onCreateEvent={onCreateEvent}
+          temperatureUnit={celsius}
+          onPrev={onPrev}
+          onNext={onNext}
+          hasPrev={false}
+          hasNext={true}
+          poiIndex={0}
+          totalPois={3}
+        />,
+      );
+      // Counter "1 of 3" should be visible
+      expect(screen.getByText("1 of 3")).toBeDefined();
+      // "Create Event" button should also be present
+      expect(screen.getByRole("button", { name: /create event/i })).toBeDefined();
+    });
+
+    it("does NOT render counter at the old top position", () => {
+      render(
+        <POIDetailSheet
+          poi={makePOI()}
+          open={true}
+          onOpenChange={onOpenChange}
+          onCreateEvent={onCreateEvent}
+          temperatureUnit={celsius}
+          onPrev={onPrev}
+          onNext={onNext}
+          hasPrev={false}
+          hasNext={false}
+          poiIndex={0}
+          totalPois={1}
+        />,
+      );
+      // "1 of 1" appears exactly once (in the bottom row), not twice
+      const matches = screen.getAllByText("1 of 1");
+      expect(matches.length).toBe(1);
+    });
+  });
+
+  describe("attribution", () => {
+    it("shows Powered by Google, not Foursquare", () => {
+      render(
+        <POIDetailSheet
+          poi={makePOI()}
+          open={true}
+          onOpenChange={onOpenChange}
+          onCreateEvent={onCreateEvent}
+          temperatureUnit={celsius}
+          onPrev={onPrev}
+          onNext={onNext}
+          hasPrev={false}
+          hasNext={false}
+          poiIndex={0}
+          totalPois={1}
+        />,
+      );
+      expect(screen.getByText("Powered by Google")).toBeDefined();
+      expect(screen.queryByText(/Foursquare/i)).toBeNull();
+    });
+
+    it("shows photo attribution when photoAttribution is provided", () => {
+      render(
+        <POIDetailSheet
+          poi={makePOI({ photoAttribution: "Jane Doe" })}
+          open={true}
+          onOpenChange={onOpenChange}
+          onCreateEvent={onCreateEvent}
+          temperatureUnit={celsius}
+          onPrev={onPrev}
+          onNext={onNext}
+          hasPrev={false}
+          hasNext={false}
+          poiIndex={0}
+          totalPois={1}
+        />,
+      );
+      expect(screen.getByText("Photo by Jane Doe")).toBeDefined();
+    });
+
+    it("does not show photo attribution when null", () => {
+      render(
+        <POIDetailSheet
+          poi={makePOI({ photoAttribution: null })}
+          open={true}
+          onOpenChange={onOpenChange}
+          onCreateEvent={onCreateEvent}
+          temperatureUnit={celsius}
+          onPrev={onPrev}
+          onNext={onNext}
+          hasPrev={false}
+          hasNext={false}
+          poiIndex={0}
+          totalPois={1}
+        />,
+      );
+      expect(screen.queryByText(/Photo by/i)).toBeNull();
     });
   });
 });

--- a/apps/web/src/components/discover/__tests__/poi-detail-sheet.test.tsx
+++ b/apps/web/src/components/discover/__tests__/poi-detail-sheet.test.tsx
@@ -63,7 +63,7 @@ describe("POIDetailSheet", () => {
       expect(screen.getByText("Le Bistro Parisien")).toBeDefined();
     });
 
-    it("renders the address as plain text, not a link", () => {
+    it("renders the address as a link to Google Maps", () => {
       const poi = makePOI({ address: "456 Test St" });
       render(
         <POIDetailSheet
@@ -82,8 +82,11 @@ describe("POIDetailSheet", () => {
       );
       const addrEl = screen.getByText("456 Test St");
       expect(addrEl).toBeDefined();
-      // Address should NOT be inside an <a> tag
-      expect(addrEl.closest("a")).toBeNull();
+      // Address should be inside an <a> tag pointing at Google Maps
+      const link = addrEl.closest("a");
+      expect(link).toBeDefined();
+      expect(link?.getAttribute("href")).toContain("google.com/maps");
+      expect(link?.getAttribute("target")).toBe("_blank");
     });
 
     it("renders distance", () => {
@@ -126,7 +129,7 @@ describe("POIDetailSheet", () => {
       expect(link?.getAttribute("href")).toBe("https://example.com");
     });
 
-    it("does not render website link when null", () => {
+    it("does not render website or tel links when null", () => {
       render(
         <POIDetailSheet
           poi={makePOI({ website: null, tel: null })}
@@ -142,9 +145,12 @@ describe("POIDetailSheet", () => {
           totalPois={1}
         />,
       );
-      // No <a> elements should exist (address is span, no photo, no website, no tel)
-      const links = document.querySelectorAll("a");
-      expect(links.length).toBe(0);
+      // No website or phone links should exist
+      expect(screen.queryByText("example.com")).toBeNull();
+      expect(screen.queryByText("+1 555-0199")).toBeNull();
+      // The address is still rendered as a link to Google Maps
+      const addressLink = screen.getByText("123 Rue de Rivoli, Paris").closest("a");
+      expect(addressLink?.getAttribute("href")).toContain("google.com/maps");
     });
 
     it("renders tel link when present", () => {
@@ -386,7 +392,7 @@ describe("POIDetailSheet", () => {
   });
 
   describe("counter position", () => {
-    it("renders counter in bottom section next to Create Event", () => {
+    it("renders counter in the header next to the close button", () => {
       render(
         <POIDetailSheet
           poi={makePOI()}
@@ -408,7 +414,7 @@ describe("POIDetailSheet", () => {
       expect(screen.getByRole("button", { name: /create event/i })).toBeDefined();
     });
 
-    it("does NOT render counter at the old top position", () => {
+    it("renders the counter exactly once", () => {
       render(
         <POIDetailSheet
           poi={makePOI()}
@@ -424,7 +430,7 @@ describe("POIDetailSheet", () => {
           totalPois={1}
         />,
       );
-      // "1 of 1" appears exactly once (in the bottom row), not twice
+      // "1 of 1" appears exactly once (in the header), not duplicated
       const matches = screen.getAllByText("1 of 1");
       expect(matches.length).toBe(1);
     });

--- a/apps/web/src/components/discover/__tests__/poi-detail-sheet.test.tsx
+++ b/apps/web/src/components/discover/__tests__/poi-detail-sheet.test.tsx
@@ -290,7 +290,11 @@ describe("POIDetailSheet", () => {
       );
       const heroLink = screen.getByLabelText(/Open Le Bistro Parisien in Google Maps/i);
       expect(heroLink).toBeDefined();
-      expect(heroLink.style.backgroundImage).toContain("/api/locations/photos/places%2Fx%2Fy");
+      const style = heroLink.style.backgroundImage;
+      expect(style).toContain("/locations/photos/");
+      expect(style).not.toContain("/api/api");
+      expect(style).toContain("maxWidthPx=600");
+      expect(style).toContain("maxHeightPx=400");
     });
 
     it("renders muted placeholder when photoName is null", () => {

--- a/apps/web/src/components/discover/discover-view.tsx
+++ b/apps/web/src/components/discover/discover-view.tsx
@@ -215,9 +215,9 @@ export function DiscoverView({ tripId, temperatureUnit }: DiscoverViewProps) {
       <div className="space-y-6">
         <Skeleton className="h-8 w-40" />
         <div className="flex gap-4 overflow-hidden">
-          <Skeleton className="h-36 w-[200px] shrink-0 rounded-md" />
-          <Skeleton className="h-36 w-[200px] shrink-0 rounded-md" />
-          <Skeleton className="h-36 w-[200px] shrink-0 rounded-md" />
+          <Skeleton className="aspect-square w-44 shrink-0 rounded-md" />
+          <Skeleton className="aspect-square w-44 shrink-0 rounded-md" />
+          <Skeleton className="aspect-square w-44 shrink-0 rounded-md" />
         </div>
       </div>
     );
@@ -314,7 +314,7 @@ export function DiscoverView({ tripId, temperatureUnit }: DiscoverViewProps) {
               {/* Horizontally scrollable row with peek + fade */}
               <div className="no-swipe flex gap-3 overflow-x-auto pb-2 pr-10 scrollbar-none snap-x snap-mandatory [mask-image:linear-gradient(to_right,black_calc(100%-56px),transparent_100%)]">
                 {pois.map((poi) => (
-                  <div key={poi.sourceId} className="snap-start">
+                  <div key={poi.sourceId} className="snap-start w-44 shrink-0">
                     <POICard poi={poi} onSelect={handlePOISelect} temperatureUnit={temperatureUnit} />
                   </div>
                 ))}

--- a/apps/web/src/components/discover/discover-view.tsx
+++ b/apps/web/src/components/discover/discover-view.tsx
@@ -6,6 +6,7 @@ import {
   AlertCircle,
   ChevronDown,
   Dumbbell,
+  Hotel,
   Palette,
   ShoppingBag,
   Sparkles,
@@ -38,6 +39,7 @@ const CATEGORY_ICONS: Record<POICategoryKey, typeof Utensils> = {
   nightlife: Sparkles,
   wellness: Dumbbell,
   shopping: ShoppingBag,
+  lodging: Hotel,
 };
 
 // ─── Location type ───────────────────────────────────────────────────────────
@@ -314,7 +316,10 @@ export function DiscoverView({ tripId, temperatureUnit }: DiscoverViewProps) {
               {/* Horizontally scrollable row with peek + fade */}
               <div className="no-swipe flex gap-3 overflow-x-auto pb-2 pr-10 scrollbar-none snap-x snap-mandatory [mask-image:linear-gradient(to_right,black_calc(100%-56px),transparent_100%)]">
                 {pois.map((poi) => (
-                  <div key={poi.sourceId} className="snap-start w-44 shrink-0">
+                  <div
+                    key={poi.sourceId}
+                    className="snap-start w-48 shrink-0 [content-visibility:auto] [contain-intrinsic-size:192px_136px]"
+                  >
                     <POICard poi={poi} onSelect={handlePOISelect} temperatureUnit={temperatureUnit} />
                   </div>
                 ))}

--- a/apps/web/src/components/discover/discover-view.tsx
+++ b/apps/web/src/components/discover/discover-view.tsx
@@ -5,10 +5,12 @@ import {
   Compass,
   AlertCircle,
   ChevronDown,
-  Utensils,
+  Dumbbell,
   Palette,
-  TreePine,
+  ShoppingBag,
   Sparkles,
+  TreePine,
+  Utensils,
 } from "lucide-react";
 import type { POISuggestion, POICategoryKey, TemperatureUnit, Event } from "@journiful/shared/types";
 import { POI_CATEGORIES } from "@journiful/shared/types";
@@ -34,6 +36,8 @@ const CATEGORY_ICONS: Record<POICategoryKey, typeof Utensils> = {
   arts_and_entertainment: Palette,
   outdoors: TreePine,
   nightlife: Sparkles,
+  wellness: Dumbbell,
+  shopping: ShoppingBag,
 };
 
 // ─── Location type ───────────────────────────────────────────────────────────

--- a/apps/web/src/components/discover/poi-card.tsx
+++ b/apps/web/src/components/discover/poi-card.tsx
@@ -3,21 +3,20 @@
 import { memo } from "react";
 import type { POISuggestion, POICategoryKey, TemperatureUnit } from "@journiful/shared/types";
 import { cn } from "@/lib/utils";
+import { API_URL } from "@/lib/api";
 
 /**
- * Tailwind border colour classes per category, matching the Vivid Capri event tokens.
- *
- * Each key uses the `border-l-event-{category}` tokens defined in globals.css so the
- * left accent bar is colour-coded consistently with events of the same type in the
- * itinerary.
+ * Tailwind background colour classes per category, matching the Vivid Capri
+ * event tokens. Used for the thin accent strip along the top of the photo well.
  */
-const CATEGORY_BORDER_COLORS: Record<POICategoryKey, string> = {
-  food_and_drink: "border-l-event-food_and_drink",
-  arts_and_entertainment: "border-l-event-arts_and_entertainment",
-  outdoors: "border-l-event-outdoors",
-  nightlife: "border-l-event-nightlife",
-  wellness: "border-l-event-wellness",
-  shopping: "border-l-event-shopping",
+const CATEGORY_ACCENT_COLORS: Record<POICategoryKey, string> = {
+  food_and_drink: "bg-event-food_and_drink",
+  arts_and_entertainment: "bg-event-arts_and_entertainment",
+  outdoors: "bg-event-outdoors",
+  nightlife: "bg-event-nightlife",
+  wellness: "bg-event-wellness",
+  shopping: "bg-event-shopping",
+  lodging: "bg-event-lodging",
 };
 
 /**
@@ -36,11 +35,6 @@ function formatDistance(meters: number, unit: TemperatureUnit): string {
   return `${(meters / 1000).toFixed(1)} km`;
 }
 
-const apiBase: string =
-  typeof process !== "undefined" && process.env?.NEXT_PUBLIC_API_URL
-    ? process.env.NEXT_PUBLIC_API_URL
-    : "";
-
 interface POICardProps {
   poi: POISuggestion;
   onSelect: (poi: POISuggestion) => void;
@@ -48,22 +42,21 @@ interface POICardProps {
 }
 
 /**
- * A background-image POI card with a gradient overlay.
+ * A postcard-styled POI card matching the vintage postcard frames used for trip
+ * cards on the trips page (.postcard / .postcard-mat / .postcard-image).
  *
- * When a Google Places photo is available (`poi.photoName`), it is loaded via the
- * backend photo proxy and rendered as a `background-image` on a full-bleed div behind
- * a gradient overlay. Without a photo the card falls back to `bg-card`.
- *
- * A colour-coded left accent bar, the place name, optional subcategory chip, distance
- * chip, business-status badge (non-OPERATIONAL only), and photo attribution are
- * layered on top.
+ * The card is a landscape 3:2 photo in a white mat inside a cardboard frame.
+ * When a Google Places photo is available (`poi.photoName`) it is loaded via the
+ * backend photo proxy as a background-image; otherwise a themed gradient fills
+ * the well. A thin category-coloured strip runs along the top of the image well,
+ * and the place name (Playfair) + subcategory/distance sit over a bottom scrim.
  */
 export const POICard = memo(function POICard({
   poi,
   onSelect,
   temperatureUnit,
 }: POICardProps) {
-  const borderColor = CATEGORY_BORDER_COLORS[poi.category];
+  const accentColor = CATEGORY_ACCENT_COLORS[poi.category];
 
   const ariaLabel = poi.photoAttribution
     ? `${poi.name} \u2014 Photo by ${poi.photoAttribution}`
@@ -78,58 +71,57 @@ export const POICard = memo(function POICard({
       onClick={() => onSelect(poi)}
       aria-label={ariaLabel}
       className={cn(
-        "relative w-full aspect-square overflow-hidden rounded-lg bg-card border border-border text-left cursor-pointer",
+        "postcard w-full text-left cursor-pointer",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
         "motion-safe:active:scale-[0.98]",
       )}
     >
-      {/* Photo background (only when photoName present) */}
-      {poi.photoName && (
-        <div
-          className="absolute inset-0 bg-cover bg-center"
-          style={{
-            backgroundImage: `url(${apiBase}/locations/photos/${encodeURIComponent(poi.photoName)}?maxWidthPx=400&maxHeightPx=280)`,
-          }}
-        />
-      )}
+      {/* Mat: white border around the photo */}
+      <div className="postcard-mat bg-card" style={{ padding: 8 }}>
+        <div className="postcard-image">
+          {/* Photo background (only when photoName present) */}
+          {poi.photoName ? (
+            <div
+              className="absolute inset-0 bg-cover bg-center"
+              style={{
+                backgroundImage: `url(${API_URL}/locations/photos/${encodeURIComponent(poi.photoName)}?maxWidthPx=400&maxHeightPx=280)`,
+              }}
+            />
+          ) : (
+            <div className="absolute inset-0 bg-gradient-to-br from-primary/20 via-accent/15 to-secondary/20" />
+          )}
 
-      {/* Gradient overlay — always renders so text stays readable with or without photo */}
-      <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
+          {/* Category accent strip */}
+          <div className={cn("absolute top-0 left-0 right-0 h-0.5 z-10", accentColor)} />
 
-      {/* Left accent border strip */}
-      <div className={cn("absolute left-0 top-0 bottom-0 w-1 border-l-4", borderColor)} />
+          {/* Scrim — always renders so text stays readable with or without photo */}
+          <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/20 to-transparent" />
 
-      {/* Foreground content */}
-      <div className="relative z-10 p-3 flex flex-col h-full justify-between">
-        {/* Top: name + businessStatus badge */}
-        <div className="flex items-start justify-between gap-2">
-          <h3 className="font-semibold text-sm text-white drop-shadow-md line-clamp-2">
-            {poi.name}
-          </h3>
+          {/* Top-left: business-status badge (non-OPERATIONAL only) */}
           {showBusinessStatus && (
-            <span className="shrink-0 text-xs bg-destructive/20 text-destructive rounded px-1.5 py-0.5 whitespace-nowrap">
+            <span className="absolute top-2 left-2 z-10 rounded bg-black/50 px-1.5 py-0.5 text-xs text-white border border-white/20 backdrop-blur-md">
               {poi.businessStatus}
             </span>
           )}
-        </div>
 
-        {/* Bottom: chips + attribution */}
-        <div className="mt-auto flex items-end justify-between gap-2">
-          <div className="flex flex-wrap gap-1">
-            {poi.subcategory && (
-              <span className="text-xs bg-black/40 text-white/90 rounded px-1.5 py-0.5">
-                {poi.subcategory}
-              </span>
-            )}
-            <span className="text-xs bg-black/40 text-white/90 rounded px-1.5 py-0.5">
-              {formatDistance(poi.distance, temperatureUnit)}
-            </span>
-          </div>
+          {/* Top-right: photo attribution (Google ToS requires credit per display) */}
           {poi.photoAttribution && (
-            <span className="shrink-0 text-[10px] text-white/70">
-              Photo: {poi.photoAttribution}
+            <span className="absolute top-2 right-2 z-10 text-[9px] text-white/60 drop-shadow">
+              {poi.photoAttribution}
             </span>
           )}
+
+          {/* Bottom: name + subcategory · distance */}
+          <div className="absolute bottom-0 left-0 right-0 p-2">
+            <h3 className="font-playfair text-sm font-semibold leading-snug text-white drop-shadow-md line-clamp-2">
+              {poi.name}
+            </h3>
+            <div className="mt-0.5 flex items-center gap-1 text-xs text-white/80">
+              {poi.subcategory && <span className="truncate">{poi.subcategory}</span>}
+              {poi.subcategory && <span className="shrink-0 text-white/50">·</span>}
+              <span className="shrink-0">{formatDistance(poi.distance, temperatureUnit)}</span>
+            </div>
+          </div>
         </div>
       </div>
     </button>

--- a/apps/web/src/components/discover/poi-card.tsx
+++ b/apps/web/src/components/discover/poi-card.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { memo } from "react";
-import { MapPin, Navigation } from "lucide-react";
 import type { POISuggestion, POICategoryKey, TemperatureUnit } from "@journiful/shared/types";
 import { cn } from "@/lib/utils";
 
@@ -17,6 +16,8 @@ const CATEGORY_BORDER_COLORS: Record<POICategoryKey, string> = {
   arts_and_entertainment: "border-l-event-arts_and_entertainment",
   outdoors: "border-l-event-outdoors",
   nightlife: "border-l-event-nightlife",
+  wellness: "border-l-event-wellness",
+  shopping: "border-l-event-shopping",
 };
 
 /**
@@ -35,6 +36,11 @@ function formatDistance(meters: number, unit: TemperatureUnit): string {
   return `${(meters / 1000).toFixed(1)} km`;
 }
 
+const apiBase: string =
+  typeof process !== "undefined" && process.env?.NEXT_PUBLIC_API_URL
+    ? process.env.NEXT_PUBLIC_API_URL
+    : "";
+
 interface POICardProps {
   poi: POISuggestion;
   onSelect: (poi: POISuggestion) => void;
@@ -42,12 +48,15 @@ interface POICardProps {
 }
 
 /**
- * A compact card that displays a single POI suggestion.
+ * A background-image POI card with a gradient overlay.
  *
- * Renders a colour-coded left accent bar, the place name (1-line truncated),
- * optional subcategory, truncated address, and distance from the trip
- * destination. Clicking the card invokes `onSelect` with the full POI
- * object so the parent can open the detail sheet or event creation dialog.
+ * When a Google Places photo is available (`poi.photoName`), it is loaded via the
+ * backend photo proxy and rendered as a `background-image` on a full-bleed div behind
+ * a gradient overlay. Without a photo the card falls back to `bg-card`.
+ *
+ * A colour-coded left accent bar, the place name, optional subcategory chip, distance
+ * chip, business-status badge (non-OPERATIONAL only), and photo attribution are
+ * layered on top.
  */
 export const POICard = memo(function POICard({
   poi,
@@ -56,43 +65,73 @@ export const POICard = memo(function POICard({
 }: POICardProps) {
   const borderColor = CATEGORY_BORDER_COLORS[poi.category];
 
+  const ariaLabel = poi.photoAttribution
+    ? `${poi.name} \u2014 Photo by ${poi.photoAttribution}`
+    : poi.name;
+
+  const showBusinessStatus =
+    poi.businessStatus !== null && poi.businessStatus !== "OPERATIONAL";
+
   return (
     <button
       type="button"
       onClick={() => onSelect(poi)}
+      aria-label={ariaLabel}
       className={cn(
-        "group flex flex-col gap-1 rounded-md p-2.5",
-        "bg-card text-left transition-all overflow-hidden",
-        "hover:border-primary/40 hover:shadow-sm hover:bg-accent/5",
+        "relative w-full overflow-hidden rounded-lg bg-card border border-border text-left cursor-pointer",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-        "cursor-pointer motion-safe:active:scale-[0.98]",
-        "w-[200px] shrink-0 border-l-2",
-        borderColor,
+        "motion-safe:active:scale-[0.98]",
       )}
     >
-      {/* Name — 1-line truncated */}
-      <span className="text-sm font-semibold text-foreground leading-tight truncate min-w-0">
-        {poi.name}
-      </span>
-
-      {/* Subcategory */}
-      {poi.subcategory && (
-        <span className="text-xs text-muted-foreground truncate min-w-0">
-          {poi.subcategory}
-        </span>
+      {/* Photo background (only when photoName present) */}
+      {poi.photoName && (
+        <div
+          className="absolute inset-0 bg-cover bg-center"
+          style={{
+            backgroundImage: `url(${apiBase}/api/locations/photos/${encodeURIComponent(poi.photoName)}?w=400&h=280)`,
+          }}
+        />
       )}
 
-      {/* Address — always rendered to maintain layout height */}
-      <span className="flex items-start gap-1 text-xs text-muted-foreground min-w-0">
-        <MapPin className="w-3 h-3 shrink-0 mt-0.5" aria-hidden="true" />
-        <span className="truncate min-w-0">{poi.address || "\u2014"}</span>
-      </span>
+      {/* Gradient overlay — always renders so text stays readable with or without photo */}
+      <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
 
-      {/* Distance */}
-      <span className="flex items-center gap-1 text-xs text-muted-foreground/70">
-        <Navigation className="w-3 h-3" aria-hidden="true" />
-        {formatDistance(poi.distance, temperatureUnit)}
-      </span>
+      {/* Left accent border strip */}
+      <div className={cn("absolute left-0 top-0 bottom-0 w-1 border-l-4", borderColor)} />
+
+      {/* Foreground content */}
+      <div className="relative z-10 p-3 flex flex-col h-full min-h-[140px]">
+        {/* Top: name + businessStatus badge */}
+        <div className="flex items-start justify-between gap-2">
+          <h3 className="font-semibold text-sm text-white drop-shadow-md line-clamp-2">
+            {poi.name}
+          </h3>
+          {showBusinessStatus && (
+            <span className="shrink-0 text-xs bg-destructive/20 text-destructive rounded px-1.5 py-0.5 whitespace-nowrap">
+              {poi.businessStatus}
+            </span>
+          )}
+        </div>
+
+        {/* Bottom: chips + attribution */}
+        <div className="mt-auto flex items-end justify-between gap-2">
+          <div className="flex flex-wrap gap-1">
+            {poi.subcategory && (
+              <span className="text-xs bg-black/40 text-white/90 rounded px-1.5 py-0.5">
+                {poi.subcategory}
+              </span>
+            )}
+            <span className="text-xs bg-black/40 text-white/90 rounded px-1.5 py-0.5">
+              {formatDistance(poi.distance, temperatureUnit)}
+            </span>
+          </div>
+          {poi.photoAttribution && (
+            <span className="shrink-0 text-[10px] text-white/70">
+              Photo: {poi.photoAttribution}
+            </span>
+          )}
+        </div>
+      </div>
     </button>
   );
 });

--- a/apps/web/src/components/discover/poi-card.tsx
+++ b/apps/web/src/components/discover/poi-card.tsx
@@ -78,7 +78,7 @@ export const POICard = memo(function POICard({
       onClick={() => onSelect(poi)}
       aria-label={ariaLabel}
       className={cn(
-        "relative w-full overflow-hidden rounded-lg bg-card border border-border text-left cursor-pointer",
+        "relative w-full aspect-square overflow-hidden rounded-lg bg-card border border-border text-left cursor-pointer",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
         "motion-safe:active:scale-[0.98]",
       )}
@@ -88,7 +88,7 @@ export const POICard = memo(function POICard({
         <div
           className="absolute inset-0 bg-cover bg-center"
           style={{
-            backgroundImage: `url(${apiBase}/api/locations/photos/${encodeURIComponent(poi.photoName)}?w=400&h=280)`,
+            backgroundImage: `url(${apiBase}/locations/photos/${encodeURIComponent(poi.photoName)}?maxWidthPx=400&maxHeightPx=280)`,
           }}
         />
       )}
@@ -100,7 +100,7 @@ export const POICard = memo(function POICard({
       <div className={cn("absolute left-0 top-0 bottom-0 w-1 border-l-4", borderColor)} />
 
       {/* Foreground content */}
-      <div className="relative z-10 p-3 flex flex-col h-full min-h-[140px]">
+      <div className="relative z-10 p-3 flex flex-col h-full justify-between">
         {/* Top: name + businessStatus badge */}
         <div className="flex items-start justify-between gap-2">
           <h3 className="font-semibold text-sm text-white drop-shadow-md line-clamp-2">

--- a/apps/web/src/components/discover/poi-detail-sheet.tsx
+++ b/apps/web/src/components/discover/poi-detail-sheet.tsx
@@ -163,7 +163,7 @@ function POIDetailBody({
               rel="noopener noreferrer"
               className="relative block w-full aspect-[3/2] bg-cover bg-center"
               style={{
-                backgroundImage: `url(${apiBase}/api/locations/photos/${encodeURIComponent(poi.photoName)}?w=600&h=400)`,
+                backgroundImage: `url(${apiBase}/locations/photos/${encodeURIComponent(poi.photoName)}?maxWidthPx=600&maxHeightPx=400)`,
               }}
               aria-label={`Open ${poi.name} in Google Maps`}
             >

--- a/apps/web/src/components/discover/poi-detail-sheet.tsx
+++ b/apps/web/src/components/discover/poi-detail-sheet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useEffect } from "react";
 import { VisuallyHidden } from "radix-ui";
 import { MapPin, Navigation, ExternalLink, Phone, XIcon, ChevronLeft, ChevronRight } from "lucide-react";
 import type { POISuggestion, POICategoryKey, TemperatureUnit } from "@journiful/shared/types";
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { API_URL } from "@/lib/api";
 
 interface POIDetailSheetProps {
   poi: POISuggestion | null;
@@ -36,15 +37,7 @@ const CATEGORY_ACCENT_COLORS: Record<POICategoryKey, string> = {
   nightlife: "bg-event-nightlife",
   wellness: "bg-event-wellness",
   shopping: "bg-event-shopping",
-};
-
-const CATEGORY_LABELS: Record<POICategoryKey, string> = {
-  food_and_drink: "Food & Drink",
-  arts_and_entertainment: "Arts & Leisure",
-  outdoors: "Outdoors",
-  nightlife: "Nightlife",
-  wellness: "Wellness & Fitness",
-  shopping: "Shopping",
+  lodging: "bg-event-lodging",
 };
 
 /**
@@ -78,6 +71,31 @@ export function POIDetailSheet({
 }: POIDetailSheetProps) {
   const accentColor = poi ? CATEGORY_ACCENT_COLORS[poi.category] : null;
 
+  // Keyboard arrow navigation between POIs while the sheet is open.
+  // Skipped when focus is in a form field (don't hijack text editing).
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      if (
+        target?.tagName === "INPUT" ||
+        target?.tagName === "TEXTAREA" ||
+        target?.tagName === "SELECT"
+      ) {
+        return;
+      }
+      if (e.key === "ArrowLeft" && hasPrev) {
+        e.preventDefault();
+        onPrev();
+      } else if (e.key === "ArrowRight" && hasNext) {
+        e.preventDefault();
+        onNext();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open, hasPrev, hasNext, onPrev, onNext]);
+
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent showCloseButton={false}>
@@ -90,8 +108,13 @@ export function POIDetailSheet({
           <div className={cn("h-1.5 w-full", accentColor)} />
         )}
 
-        {/* Header actions */}
-        <div className="flex items-center justify-end gap-1 px-4 pt-4">
+        {/* Header: counter (left) + close (right) */}
+        <div className="flex items-center justify-between gap-1 px-4 pt-4">
+          {poi && (
+            <span className="text-xs text-muted-foreground tabular-nums">
+              {poiIndex + 1} of {totalPois}
+            </span>
+          )}
           <SheetClose className="rounded-md p-2 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer">
             <XIcon className="w-4 h-4" />
             <span className="sr-only">Close</span>
@@ -108,8 +131,6 @@ export function POIDetailSheet({
               onNext={onNext}
               hasPrev={hasPrev}
               hasNext={hasNext}
-              poiIndex={poiIndex}
-              totalPois={totalPois}
             />
           )}
         </SheetBody>
@@ -126,8 +147,6 @@ function POIDetailBody({
   onNext,
   hasPrev,
   hasNext,
-  poiIndex,
-  totalPois,
 }: {
   poi: POISuggestion;
   onCreateEvent: (poi: POISuggestion) => void;
@@ -136,8 +155,6 @@ function POIDetailBody({
   onNext: () => void;
   hasPrev: boolean;
   hasNext: boolean;
-  poiIndex: number;
-  totalPois: number;
 }) {
   // Extract hostname from URL for clean display
   const websiteHostname = useMemo(() => {
@@ -149,7 +166,9 @@ function POIDetailBody({
     }
   }, [poi.website]);
 
-  const apiBase = process.env.NEXT_PUBLIC_API_URL ?? "";
+  const mapsHref =
+    poi.googleMapsUri ??
+    `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(poi.address ?? poi.name)}`;
 
   return (
     <div className="flex flex-col h-full">
@@ -158,12 +177,12 @@ function POIDetailBody({
         <div className="relative">
           {poi.photoName ? (
             <a
-              href={poi.googleMapsUri ?? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(poi.address ?? poi.name)}`}
+              href={mapsHref}
               target="_blank"
               rel="noopener noreferrer"
               className="relative block w-full aspect-[3/2] bg-cover bg-center"
               style={{
-                backgroundImage: `url(${apiBase}/locations/photos/${encodeURIComponent(poi.photoName)}?maxWidthPx=600&maxHeightPx=400)`,
+                backgroundImage: `url(${API_URL}/locations/photos/${encodeURIComponent(poi.photoName)}?maxWidthPx=600&maxHeightPx=400)`,
               }}
               aria-label={`Open ${poi.name} in Google Maps`}
             >
@@ -200,82 +219,79 @@ function POIDetailBody({
           </button>
         </div>
 
-        {/* Category label */}
-        <p className="text-sm text-muted-foreground">
-          {CATEGORY_LABELS[poi.category]}
-        </p>
-
         {/* POI name */}
-        <h3 className="font-playfair text-xl font-semibold text-center px-2 truncate min-w-0">
+        <h3 className="font-playfair text-xl font-semibold line-clamp-2 min-w-0">
           {poi.name}
         </h3>
 
-        {/* Non-clickable info: subcategory + distance */}
-        <div className="space-y-1.5">
-          {poi.subcategory && (
-            <p className="text-sm text-muted-foreground">
-              {poi.subcategory}
-            </p>
-          )}
-          <span className="flex items-center gap-1.5 text-sm text-muted-foreground/70">
+        {/* Subcategory · distance */}
+        <div className="flex items-center gap-1.5 text-sm text-muted-foreground/70 min-w-0">
+          {poi.subcategory && <span className="truncate">{poi.subcategory}</span>}
+          {poi.subcategory && <span className="shrink-0 text-muted-foreground/40">·</span>}
+          <span className="shrink-0 flex items-center gap-1">
             <Navigation className="w-3.5 h-3.5 shrink-0" />
             {formatDistance(poi.distance, temperatureUnit)}
           </span>
         </div>
 
-        {/* Address (plain text), website, phone */}
-        <div className="space-y-2">
+        {/* Address (link to Google Maps), website, phone */}
+        <div className="space-y-2 text-sm text-muted-foreground">
           {poi.address && (
-            <span className="flex items-center gap-1.5 text-sm text-muted-foreground min-w-0">
-              <MapPin className="w-3.5 h-3.5 text-muted-foreground shrink-0 mt-0.5" />
-              <span className="truncate min-w-0">{poi.address}</span>
-            </span>
-          )}
-
-          {websiteHostname && (
             <a
-              href={poi.website!}
+              href={mapsHref}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors min-w-0"
+              className="flex items-center gap-1.5 hover:text-primary transition-colors min-w-0"
             >
-              <ExternalLink className="w-3.5 h-3.5 shrink-0" />
-              <span className="truncate min-w-0">{websiteHostname}</span>
+              <MapPin className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+              <span className="truncate min-w-0">{poi.address}</span>
+              <ExternalLink className="w-3 h-3 shrink-0 text-muted-foreground/60" />
             </a>
           )}
 
-          {poi.tel && (
-            <a
-              href={`tel:${poi.tel}`}
-              className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors"
-            >
-              <Phone className="w-3.5 h-3.5 shrink-0" />
-              <span className="truncate">{poi.tel}</span>
-            </a>
+          {(websiteHostname || poi.tel) && (
+            <div className="flex flex-wrap gap-x-4 gap-y-1">
+              {websiteHostname && (
+                <a
+                  href={poi.website!}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1.5 hover:text-primary transition-colors min-w-0"
+                >
+                  <ExternalLink className="w-3.5 h-3.5 shrink-0" />
+                  <span className="truncate min-w-0">{websiteHostname}</span>
+                </a>
+              )}
+              {poi.tel && (
+                <a
+                  href={`tel:${poi.tel}`}
+                  className="flex items-center gap-1.5 hover:text-primary transition-colors"
+                >
+                  <Phone className="w-3.5 h-3.5 shrink-0" />
+                  <span className="truncate">{poi.tel}</span>
+                </a>
+              )}
+            </div>
           )}
         </div>
       </div>
 
-      {/* Bottom section: Create Event + counter + attribution */}
+      {/* Bottom section: Create Event + attribution */}
       <div className="pt-4 space-y-2">
-        <div className="flex items-center gap-2">
-          <Button
-            variant="gradient"
-            className="flex-1 h-12 rounded-md"
-            onClick={() => onCreateEvent(poi)}
-          >
-            Create Event
-          </Button>
-          <span className="text-xs text-muted-foreground shrink-0">
-            {poiIndex + 1} of {totalPois}
-          </span>
+        <Button
+          variant="gradient"
+          className="w-full h-12 rounded-md"
+          onClick={() => onCreateEvent(poi)}
+        >
+          Create Event
+        </Button>
+        <div className="flex items-center justify-center gap-1.5 text-xs text-muted-foreground">
+          {poi.photoAttribution && (
+            <span>Photo by {poi.photoAttribution}</span>
+          )}
+          {poi.photoAttribution && <span className="text-muted-foreground/40">·</span>}
+          <span>Powered by Google</span>
         </div>
-        {poi.photoAttribution && (
-          <p className="text-xs text-muted-foreground text-center">Photo by {poi.photoAttribution}</p>
-        )}
-        <p className="text-xs text-muted-foreground text-center">
-          Powered by Google
-        </p>
       </div>
     </div>
   );

--- a/apps/web/src/components/discover/poi-detail-sheet.tsx
+++ b/apps/web/src/components/discover/poi-detail-sheet.tsx
@@ -34,13 +34,17 @@ const CATEGORY_ACCENT_COLORS: Record<POICategoryKey, string> = {
   arts_and_entertainment: "bg-event-arts_and_entertainment",
   outdoors: "bg-event-outdoors",
   nightlife: "bg-event-nightlife",
+  wellness: "bg-event-wellness",
+  shopping: "bg-event-shopping",
 };
 
 const CATEGORY_LABELS: Record<POICategoryKey, string> = {
   food_and_drink: "Food & Drink",
-  arts_and_entertainment: "Arts & Entertainment",
+  arts_and_entertainment: "Arts & Leisure",
   outdoors: "Outdoors",
   nightlife: "Nightlife",
+  wellness: "Wellness & Fitness",
+  shopping: "Shopping",
 };
 
 /**
@@ -145,41 +149,66 @@ function POIDetailBody({
     }
   }, [poi.website]);
 
+  const apiBase = process.env.NEXT_PUBLIC_API_URL ?? "";
+
   return (
     <div className="flex flex-col h-full">
       <div className="space-y-4 flex-1">
-        {/* Category label */}
-        <p className="text-sm text-muted-foreground">
-          {CATEGORY_LABELS[poi.category]}
-        </p>
+        {/* Cover photo hero with chevron navigation */}
+        <div className="relative">
+          {poi.photoName ? (
+            <a
+              href={poi.googleMapsUri ?? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(poi.address ?? poi.name)}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="relative block w-full aspect-[3/2] bg-cover bg-center"
+              style={{
+                backgroundImage: `url(${apiBase}/api/locations/photos/${encodeURIComponent(poi.photoName)}?w=600&h=400)`,
+              }}
+              aria-label={`Open ${poi.name} in Google Maps`}
+            >
+              {/* Gradient overlay */}
+              <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent" />
+              {/* "Open in Google Maps" overlay */}
+              <span className="absolute bottom-2 right-2 inline-flex items-center gap-1 rounded-md bg-black/60 text-white text-xs px-2 py-1" aria-hidden="true">
+                <MapPin className="w-3 h-3" />
+                Google Maps
+              </span>
+            </a>
+          ) : (
+            <div className="w-full aspect-[3/2] bg-muted flex items-center justify-center">
+              <MapPin className="w-8 h-8 text-muted-foreground/50" />
+            </div>
+          )}
 
-        {/* POI name with navigation arrows (weather pattern) */}
-        <div className="flex items-center justify-between">
+          {/* Prev/Next chevrons as siblings */}
           <button
             onClick={onPrev}
             disabled={!hasPrev}
-            className="rounded-md p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default"
+            className="absolute z-20 rounded-full bg-black/50 text-white p-1 hover:bg-black/70 disabled:opacity-30 left-2 top-1/2 -translate-y-1/2"
             aria-label="Previous place"
           >
             <ChevronLeft className="w-5 h-5" />
           </button>
-          <h3 className="font-playfair text-xl font-semibold text-center px-2 truncate min-w-0">
-            {poi.name}
-          </h3>
           <button
             onClick={onNext}
             disabled={!hasNext}
-            className="rounded-md p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer disabled:opacity-30 disabled:cursor-default"
+            className="absolute z-20 rounded-full bg-black/50 text-white p-1 hover:bg-black/70 disabled:opacity-30 right-2 top-1/2 -translate-y-1/2"
             aria-label="Next place"
           >
             <ChevronRight className="w-5 h-5" />
           </button>
         </div>
 
-        {/* Position counter */}
-        <p className="text-xs text-muted-foreground text-center">
-          {poiIndex + 1} of {totalPois}
+        {/* Category label */}
+        <p className="text-sm text-muted-foreground">
+          {CATEGORY_LABELS[poi.category]}
         </p>
+
+        {/* POI name */}
+        <h3 className="font-playfair text-xl font-semibold text-center px-2 truncate min-w-0">
+          {poi.name}
+        </h3>
 
         {/* Non-clickable info: subcategory + distance */}
         <div className="space-y-1.5">
@@ -194,19 +223,13 @@ function POIDetailBody({
           </span>
         </div>
 
-        {/* Clickable links: address, website, phone */}
+        {/* Address (plain text), website, phone */}
         <div className="space-y-2">
           {poi.address && (
-            <a
-              href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(poi.address)}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-primary transition-colors min-w-0"
-            >
-              <MapPin className="w-3.5 h-3.5 shrink-0" />
+            <span className="flex items-center gap-1.5 text-sm text-muted-foreground min-w-0">
+              <MapPin className="w-3.5 h-3.5 text-muted-foreground shrink-0 mt-0.5" />
               <span className="truncate min-w-0">{poi.address}</span>
-              <span className="text-xs opacity-60 shrink-0">Google Maps</span>
-            </a>
+            </span>
           )}
 
           {websiteHostname && (
@@ -233,17 +256,25 @@ function POIDetailBody({
         </div>
       </div>
 
-      {/* Bottom section: Create Event + attribution */}
+      {/* Bottom section: Create Event + counter + attribution */}
       <div className="pt-4 space-y-2">
-        <Button
-          variant="gradient"
-          className="w-full h-12 rounded-md"
-          onClick={() => onCreateEvent(poi)}
-        >
-          Create Event
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="gradient"
+            className="flex-1 h-12 rounded-md"
+            onClick={() => onCreateEvent(poi)}
+          >
+            Create Event
+          </Button>
+          <span className="text-xs text-muted-foreground shrink-0">
+            {poiIndex + 1} of {totalPois}
+          </span>
+        </div>
+        {poi.photoAttribution && (
+          <p className="text-xs text-muted-foreground text-center">Photo by {poi.photoAttribution}</p>
+        )}
         <p className="text-xs text-muted-foreground text-center">
-          Added by Foursquare Places
+          Powered by Google
         </p>
       </div>
     </div>

--- a/apps/web/src/components/itinerary/create-event-dialog.tsx
+++ b/apps/web/src/components/itinerary/create-event-dialog.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Calendar, Car, Loader2, Plus, Palette, TreePine, Sparkles, Utensils, X } from "lucide-react";
+import { Calendar, Car, Loader2, Plus, Dumbbell, Palette, ShoppingBag, TreePine, Sparkles, Utensils, X } from "lucide-react";
 import { toast } from "sonner";
 import { parse, addHours } from "date-fns";
 import {
@@ -42,6 +42,8 @@ const EVENT_TYPES = [
   { value: "arts_and_entertainment", label: "Arts", icon: Palette },
   { value: "outdoors", label: "Outdoors", icon: TreePine },
   { value: "nightlife", label: "Nightlife", icon: Sparkles },
+  { value: "wellness", label: "Wellness & Fitness", icon: Dumbbell },
+  { value: "shopping", label: "Shopping", icon: ShoppingBag },
   { value: "travel", label: "Travel", icon: Car },
   { value: "misc", label: "Misc", icon: Calendar },
 ] as const;

--- a/apps/web/src/components/itinerary/create-event-dialog.tsx
+++ b/apps/web/src/components/itinerary/create-event-dialog.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Calendar, Car, Loader2, Plus, Dumbbell, Palette, ShoppingBag, TreePine, Sparkles, Utensils, X } from "lucide-react";
+import { Calendar, Car, Hotel, Loader2, Plus, Dumbbell, Palette, ShoppingBag, TreePine, Sparkles, Utensils, X } from "lucide-react";
 import { toast } from "sonner";
 import { parse, addHours } from "date-fns";
 import {
@@ -44,6 +44,7 @@ const EVENT_TYPES = [
   { value: "nightlife", label: "Nightlife", icon: Sparkles },
   { value: "wellness", label: "Wellness & Fitness", icon: Dumbbell },
   { value: "shopping", label: "Shopping", icon: ShoppingBag },
+  { value: "lodging", label: "Stays", icon: Hotel },
   { value: "travel", label: "Travel", icon: Car },
   { value: "misc", label: "Misc", icon: Calendar },
 ] as const;

--- a/apps/web/src/components/itinerary/edit-event-dialog.tsx
+++ b/apps/web/src/components/itinerary/edit-event-dialog.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useMemo, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Calendar, Car, Hotel, Loader2, Plus, Trash2, Palette, TreePine, Sparkles, ShoppingBag, Utensils, X } from "lucide-react";
+import { Calendar, Car, Hotel, Loader2, Plus, Dumbbell, Trash2, Palette, TreePine, Sparkles, ShoppingBag, Utensils, X } from "lucide-react";
 import { toast } from "sonner";
 import { parse, addHours } from "date-fns";
 import {
@@ -58,6 +58,7 @@ const EVENT_TYPES = [
   { value: "arts_and_entertainment", label: "Arts", icon: Palette },
   { value: "outdoors", label: "Outdoors", icon: TreePine },
   { value: "nightlife", label: "Nightlife", icon: Sparkles },
+  { value: "wellness", label: "Wellness & Fitness", icon: Dumbbell },
   { value: "shopping", label: "Shopping", icon: ShoppingBag },
   { value: "lodging", label: "Stays", icon: Hotel },
   { value: "travel", label: "Travel", icon: Car },

--- a/apps/web/src/components/itinerary/edit-event-dialog.tsx
+++ b/apps/web/src/components/itinerary/edit-event-dialog.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useMemo, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Calendar, Car, Loader2, Plus, Trash2, Palette, TreePine, Sparkles, Utensils, X } from "lucide-react";
+import { Calendar, Car, Hotel, Loader2, Plus, Trash2, Palette, TreePine, Sparkles, ShoppingBag, Utensils, X } from "lucide-react";
 import { toast } from "sonner";
 import { parse, addHours } from "date-fns";
 import {
@@ -58,6 +58,8 @@ const EVENT_TYPES = [
   { value: "arts_and_entertainment", label: "Arts", icon: Palette },
   { value: "outdoors", label: "Outdoors", icon: TreePine },
   { value: "nightlife", label: "Nightlife", icon: Sparkles },
+  { value: "shopping", label: "Shopping", icon: ShoppingBag },
+  { value: "lodging", label: "Stays", icon: Hotel },
   { value: "travel", label: "Travel", icon: Car },
   { value: "misc", label: "Misc", icon: Calendar },
 ] as const;

--- a/apps/web/src/components/itinerary/event-card.tsx
+++ b/apps/web/src/components/itinerary/event-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { memo } from "react";
-import { Calendar, Car, Utensils, Palette, TreePine, Sparkles, Dumbbell, ShoppingBag } from "lucide-react";
+import { Calendar, Car, Hotel, Utensils, Palette, TreePine, Sparkles, Dumbbell, ShoppingBag } from "lucide-react";
 import type { Event } from "@journiful/shared/types";
 import { formatInTimezone } from "@/lib/utils/timezone";
 
@@ -54,6 +54,12 @@ export const EVENT_TYPE_CONFIG = {
     accent: "border-l-event-shopping",
     bg: "bg-event-shopping-light",
     icon: ShoppingBag,
+  },
+  lodging: {
+    color: "text-event-lodging",
+    accent: "border-l-event-lodging",
+    bg: "bg-event-lodging-light",
+    icon: Hotel,
   },
   misc: {
     color: "text-event-misc",

--- a/apps/web/src/components/itinerary/event-card.tsx
+++ b/apps/web/src/components/itinerary/event-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { memo } from "react";
-import { Calendar, Car, Utensils, Palette, TreePine, Sparkles } from "lucide-react";
+import { Calendar, Car, Utensils, Palette, TreePine, Sparkles, Dumbbell, ShoppingBag } from "lucide-react";
 import type { Event } from "@journiful/shared/types";
 import { formatInTimezone } from "@/lib/utils/timezone";
 
@@ -42,6 +42,18 @@ export const EVENT_TYPE_CONFIG = {
     accent: "border-l-event-nightlife",
     bg: "bg-event-nightlife-light",
     icon: Sparkles,
+  },
+  wellness: {
+    color: "text-event-wellness",
+    accent: "border-l-event-wellness",
+    bg: "bg-event-wellness-light",
+    icon: Dumbbell,
+  },
+  shopping: {
+    color: "text-event-shopping",
+    accent: "border-l-event-shopping",
+    bg: "bg-event-shopping-light",
+    icon: ShoppingBag,
   },
   misc: {
     color: "text-event-misc",

--- a/shared/__tests__/event-schemas.test.ts
+++ b/shared/__tests__/event-schemas.test.ts
@@ -138,14 +138,14 @@ describe("createEventSchema", () => {
       expect(result.success).toBe(false);
       if (!result.success) {
         expect(result.error.issues[0]?.message).toContain(
-          "Event type must be one of: travel, food_and_drink, arts_and_entertainment, outdoors, nightlife, wellness, shopping, misc",
+          "Event type must be one of: travel, food_and_drink, arts_and_entertainment, outdoors, nightlife, wellness, shopping, lodging, misc",
         );
       }
     });
   });
 
   it("should accept valid event types", () => {
-    const validEventTypes: Array<"travel" | "food_and_drink" | "arts_and_entertainment" | "outdoors" | "nightlife" | "wellness" | "shopping" | "misc"> = [
+    const validEventTypes: Array<"travel" | "food_and_drink" | "arts_and_entertainment" | "outdoors" | "nightlife" | "wellness" | "shopping" | "lodging" | "misc"> = [
       "travel",
       "food_and_drink",
       "arts_and_entertainment",
@@ -153,6 +153,7 @@ describe("createEventSchema", () => {
       "nightlife",
       "wellness",
       "shopping",
+      "lodging",
       "misc",
     ];
 

--- a/shared/__tests__/event-schemas.test.ts
+++ b/shared/__tests__/event-schemas.test.ts
@@ -138,19 +138,21 @@ describe("createEventSchema", () => {
       expect(result.success).toBe(false);
       if (!result.success) {
         expect(result.error.issues[0]?.message).toContain(
-          "Event type must be one of: travel, food_and_drink, arts_and_entertainment, outdoors, nightlife, misc",
+          "Event type must be one of: travel, food_and_drink, arts_and_entertainment, outdoors, nightlife, wellness, shopping, misc",
         );
       }
     });
   });
 
   it("should accept valid event types", () => {
-    const validEventTypes: Array<"travel" | "food_and_drink" | "arts_and_entertainment" | "outdoors" | "nightlife" | "misc"> = [
+    const validEventTypes: Array<"travel" | "food_and_drink" | "arts_and_entertainment" | "outdoors" | "nightlife" | "wellness" | "shopping" | "misc"> = [
       "travel",
       "food_and_drink",
       "arts_and_entertainment",
       "outdoors",
       "nightlife",
+      "wellness",
+      "shopping",
       "misc",
     ];
 

--- a/shared/schemas/__tests__/poi.test.ts
+++ b/shared/schemas/__tests__/poi.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { poiSuggestionSchema } from "../poi.js";
+
+describe("poiSuggestionSchema", () => {
+  it("accepts null for photoName, photoAttribution, googleMapsUri, businessStatus", () => {
+    const result = poiSuggestionSchema.safeParse({
+      sourceId: "ChIJ123",
+      name: "Test Place",
+      address: null,
+      lat: 1,
+      lon: 2,
+      distance: 100,
+      category: "food_and_drink",
+      popularity: null,
+      price: null,
+      rating: null,
+      website: null,
+      tel: null,
+      subcategory: null,
+      eventId: null,
+      photoName: null,
+      photoAttribution: null,
+      googleMapsUri: null,
+      businessStatus: null,
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.photoName).toBeNull();
+      expect(result.data.photoAttribution).toBeNull();
+      expect(result.data.googleMapsUri).toBeNull();
+      expect(result.data.businessStatus).toBeNull();
+    }
+  });
+
+  it("accepts string values for photo fields", () => {
+    const result = poiSuggestionSchema.safeParse({
+      sourceId: "ChIJ123",
+      name: "Test Place",
+      address: "123 Main St",
+      lat: 1,
+      lon: 2,
+      distance: 100,
+      category: "food_and_drink",
+      popularity: null,
+      price: null,
+      rating: null,
+      website: null,
+      tel: null,
+      subcategory: null,
+      eventId: null,
+      photoName: "places/x/photos/y",
+      photoAttribution: "Jane Doe",
+      googleMapsUri: "https://maps.google.com/?cid=123",
+      businessStatus: "OPERATIONAL",
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects non-string photo fields", () => {
+    const result = poiSuggestionSchema.safeParse({
+      sourceId: "ChIJ123",
+      name: "Test Place",
+      address: null,
+      lat: 1,
+      lon: 2,
+      distance: 100,
+      category: "food_and_drink",
+      popularity: null,
+      price: null,
+      rating: null,
+      website: null,
+      tel: null,
+      subcategory: null,
+      eventId: null,
+      photoName: 123,
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/shared/schemas/event.ts
+++ b/shared/schemas/event.ts
@@ -24,8 +24,8 @@ const baseEventSchema = z.object({
       error: "Description must not exceed 2000 characters",
     })
     .optional(),
-  eventType: z.enum(["travel", "food_and_drink", "arts_and_entertainment", "outdoors", "nightlife", "wellness", "shopping", "misc"], {
-    error: "Event type must be one of: travel, food_and_drink, arts_and_entertainment, outdoors, nightlife, wellness, shopping, misc",
+  eventType: z.enum(["travel", "food_and_drink", "arts_and_entertainment", "outdoors", "nightlife", "wellness", "shopping", "lodging", "misc"], {
+    error: "Event type must be one of: travel, food_and_drink, arts_and_entertainment, outdoors, nightlife, wellness, shopping, lodging, misc",
   }),
   location: z.string().max(500).optional(),
   locationLat: z.number().nullable().optional(),
@@ -90,7 +90,7 @@ const eventEntitySchema = z.object({
   createdBy: z.string(),
   name: z.string(),
   description: z.string().nullable(),
-  eventType: z.enum(["travel", "food_and_drink", "arts_and_entertainment", "outdoors", "nightlife", "wellness", "shopping", "misc"]),
+  eventType: z.enum(["travel", "food_and_drink", "arts_and_entertainment", "outdoors", "nightlife", "wellness", "shopping", "lodging", "misc"]),
   location: z.string().nullable(),
   locationLat: z.number().nullable(),
   locationLon: z.number().nullable(),

--- a/shared/schemas/event.ts
+++ b/shared/schemas/event.ts
@@ -24,8 +24,8 @@ const baseEventSchema = z.object({
       error: "Description must not exceed 2000 characters",
     })
     .optional(),
-  eventType: z.enum(["travel", "food_and_drink", "arts_and_entertainment", "outdoors", "nightlife", "misc"], {
-    error: "Event type must be one of: travel, food_and_drink, arts_and_entertainment, outdoors, nightlife, misc",
+  eventType: z.enum(["travel", "food_and_drink", "arts_and_entertainment", "outdoors", "nightlife", "wellness", "shopping", "misc"], {
+    error: "Event type must be one of: travel, food_and_drink, arts_and_entertainment, outdoors, nightlife, wellness, shopping, misc",
   }),
   location: z.string().max(500).optional(),
   locationLat: z.number().nullable().optional(),
@@ -90,7 +90,7 @@ const eventEntitySchema = z.object({
   createdBy: z.string(),
   name: z.string(),
   description: z.string().nullable(),
-  eventType: z.enum(["travel", "food_and_drink", "arts_and_entertainment", "outdoors", "nightlife", "misc"]),
+  eventType: z.enum(["travel", "food_and_drink", "arts_and_entertainment", "outdoors", "nightlife", "wellness", "shopping", "misc"]),
   location: z.string().nullable(),
   locationLat: z.number().nullable(),
   locationLon: z.number().nullable(),

--- a/shared/schemas/poi.ts
+++ b/shared/schemas/poi.ts
@@ -19,6 +19,7 @@ export const poiSuggestionSchema = z.object({
     "nightlife",
     "wellness",
     "shopping",
+    "lodging",
   ]),
   popularity: z.number().nullable(),
   price: z.number().nullable(),
@@ -40,7 +41,7 @@ export const poiSuggestionsResponseSchema = z.object({
   destination: z.string().nullable(),
   source: z.string(),
   categories: z.record(
-    z.enum(["food_and_drink", "arts_and_entertainment", "outdoors", "nightlife", "wellness", "shopping"]),
+    z.enum(["food_and_drink", "arts_and_entertainment", "outdoors", "nightlife", "wellness", "shopping", "lodging"]),
     z.array(poiSuggestionSchema),
   ),
   partial: z.boolean().optional(),

--- a/shared/schemas/poi.ts
+++ b/shared/schemas/poi.ts
@@ -17,6 +17,8 @@ export const poiSuggestionSchema = z.object({
     "arts_and_entertainment",
     "outdoors",
     "nightlife",
+    "wellness",
+    "shopping",
   ]),
   popularity: z.number().nullable(),
   price: z.number().nullable(),
@@ -25,6 +27,10 @@ export const poiSuggestionSchema = z.object({
   tel: z.string().nullable(),
   subcategory: z.string().nullable(),
   eventId: z.string().nullable(),
+  photoName: z.string().nullable(),
+  photoAttribution: z.string().nullable(),
+  googleMapsUri: z.string().nullable(),
+  businessStatus: z.string().nullable(),
 });
 
 /**
@@ -34,7 +40,7 @@ export const poiSuggestionsResponseSchema = z.object({
   destination: z.string().nullable(),
   source: z.string(),
   categories: z.record(
-    z.enum(["food_and_drink", "arts_and_entertainment", "outdoors", "nightlife"]),
+    z.enum(["food_and_drink", "arts_and_entertainment", "outdoors", "nightlife", "wellness", "shopping"]),
     z.array(poiSuggestionSchema),
   ),
   partial: z.boolean().optional(),

--- a/shared/types/event.ts
+++ b/shared/types/event.ts
@@ -13,7 +13,7 @@ export interface Event {
   createdBy: string;
   name: string;
   description: string | null;
-  eventType: "travel" | "food_and_drink" | "arts_and_entertainment" | "outdoors" | "nightlife" | "misc";
+  eventType: "travel" | "food_and_drink" | "arts_and_entertainment" | "outdoors" | "nightlife" | "wellness" | "shopping" | "misc";
   location: string | null;
   locationLat: number | null;
   locationLon: number | null;

--- a/shared/types/event.ts
+++ b/shared/types/event.ts
@@ -13,7 +13,7 @@ export interface Event {
   createdBy: string;
   name: string;
   description: string | null;
-  eventType: "travel" | "food_and_drink" | "arts_and_entertainment" | "outdoors" | "nightlife" | "wellness" | "shopping" | "misc";
+  eventType: "travel" | "food_and_drink" | "arts_and_entertainment" | "outdoors" | "nightlife" | "wellness" | "shopping" | "lodging" | "misc";
   location: string | null;
   locationLat: number | null;
   locationLon: number | null;

--- a/shared/types/poi.ts
+++ b/shared/types/poi.ts
@@ -5,7 +5,8 @@ export type POICategoryKey =
   | "outdoors"
   | "nightlife"
   | "wellness"
-  | "shopping";
+  | "shopping"
+  | "lodging";
 
 /** A single POI suggestion stored in the poi_cache JSONB blob */
 export interface POISuggestion {
@@ -69,6 +70,14 @@ export const googleTypeLabels: Record<string, string> = {
   scenic_lookout: "Scenic Lookout",
   natural_feature: "Natural Feature",
   liquor_store: "Liquor Store",
+  supermarket: "Supermarket",
+  grocery_store: "Grocery Store",
+  lodging: "Lodging",
+  hotel: "Hotel",
+  motel: "Motel",
+  guest_house: "Guest House",
+  hostel: "Hostel",
+  bed_and_breakfast: "Bed & Breakfast",
   gym: "Gym",
   spa: "Spa",
   beauty_salon: "Beauty Salon",
@@ -130,7 +139,12 @@ export const POI_CATEGORIES: POICategoryConfig[] = [
     googleTypes: [
       "shopping_mall", "book_store", "clothing_store", "shoe_store",
       "department_store", "electronics_store", "jewelry_store", "florist",
-      "pet_store", "bicycle_store",
+      "pet_store", "bicycle_store", "supermarket", "grocery_store", "liquor_store",
     ],
+  },
+  {
+    id: "lodging",
+    label: "Stays",
+    googleTypes: ["lodging", "hotel", "motel", "guest_house", "hostel", "bed_and_breakfast"],
   },
 ];

--- a/shared/types/poi.ts
+++ b/shared/types/poi.ts
@@ -3,7 +3,9 @@ export type POICategoryKey =
   | "food_and_drink"
   | "arts_and_entertainment"
   | "outdoors"
-  | "nightlife";
+  | "nightlife"
+  | "wellness"
+  | "shopping";
 
 /** A single POI suggestion stored in the poi_cache JSONB blob */
 export interface POISuggestion {
@@ -21,6 +23,10 @@ export interface POISuggestion {
   tel: string | null;         // nullable
   subcategory: string | null; // categories[0].name (e.g. "Italian Restaurant")
   eventId: string | null;     // FK to events.id when converted to a trip event
+  photoName: string | null;
+  photoAttribution: string | null;
+  googleMapsUri: string | null;
+  businessStatus: string | null;
 }
 
 /** Response from GET /api/trips/:id/discover */
@@ -63,6 +69,19 @@ export const googleTypeLabels: Record<string, string> = {
   scenic_lookout: "Scenic Lookout",
   natural_feature: "Natural Feature",
   liquor_store: "Liquor Store",
+  gym: "Gym",
+  spa: "Spa",
+  beauty_salon: "Beauty Salon",
+  shopping_mall: "Shopping Mall",
+  book_store: "Bookstore",
+  clothing_store: "Clothing Store",
+  shoe_store: "Shoe Store",
+  department_store: "Department Store",
+  electronics_store: "Electronics Store",
+  jewelry_store: "Jewelry Store",
+  florist: "Florist",
+  pet_store: "Pet Store",
+  bicycle_store: "Bike Shop",
 };
 
 /** Category configuration with Google Places types */
@@ -76,56 +95,42 @@ export const POI_CATEGORIES: POICategoryConfig[] = [
   {
     id: "food_and_drink",
     label: "Food & Drink",
-    googleTypes: [
-      "restaurant",
-      "bar",
-      "cafe",
-      "bakery",
-      "meal_takeaway",
-      "meal_delivery",
-    ],
+    googleTypes: ["restaurant", "cafe", "bakery", "meal_takeaway", "meal_delivery"],
   },
   {
     id: "arts_and_entertainment",
-    label: "Arts & Entertainment",
+    label: "Arts & Leisure",
     googleTypes: [
-      "movie_theater",
-      "museum",
-      "art_gallery",
-      "performing_arts_theater",
-      "amusement_park",
-      "zoo",
-      "aquarium",
-      "casino",
-      "night_club",
-      "tourist_attraction",
-      "library",
-      "bowling_alley",
+      "movie_theater", "museum", "art_gallery", "performing_arts_theater",
+      "library", "bowling_alley", "casino",
     ],
   },
   {
     id: "outdoors",
     label: "Outdoors",
     googleTypes: [
-      "park",
-      "tourist_attraction",
-      "campground",
-      "hiking_area",
-      "beach",
-      "garden",
-      "plaza",
-      "marina",
-      "scenic_lookout",
-      "natural_feature",
+      "park", "tourist_attraction", "campground", "hiking_area", "beach",
+      "garden", "plaza", "marina", "scenic_lookout", "natural_feature",
+      "zoo", "aquarium", "amusement_park",
     ],
   },
   {
     id: "nightlife",
     label: "Nightlife",
+    googleTypes: ["night_club", "bar"],
+  },
+  {
+    id: "wellness",
+    label: "Wellness & Fitness",
+    googleTypes: ["gym", "spa", "beauty_salon"],
+  },
+  {
+    id: "shopping",
+    label: "Shopping",
     googleTypes: [
-      "night_club",
-      "bar",
-      "liquor_store",
+      "shopping_mall", "book_store", "clothing_store", "shoe_store",
+      "department_store", "electronics_store", "jewelry_store", "florist",
+      "pet_store", "bicycle_store",
     ],
   },
 ];


### PR DESCRIPTION
## Summary

Redesigns the Discover tab POI experience: background-image cards from Google Places photos, a 6-category disjoint taxonomy, distance-ascending sort, a backend photo proxy, and a cover-photo detail sheet with Maps deep-linking.

## Changes

### Shared (types + schemas)
- `POICategoryKey` expanded from 4 to 6: `food_and_drink`, `arts_and_entertainment`, `outdoors`, `nightlife`, `wellness`, `shopping`
- `POI_CATEGORIES` rewritten to **disjoint** mapping — no Google type appears in two categories
- `POISuggestion` extended with `photoName`, `photoAttribution`, `googleMapsUri`, `businessStatus` (all nullable)
- "Arts & Entertainment" label → "Arts & Leisure"

### Backend
- New photo proxy: `GET /api/locations/photos/:photoRef` — per-IP rate limit (60/min), streaming via `Readable.fromWeb`, 7d `Cache-Control: immutable`, 5s timeout, regex validation
- Nearby Search FieldMask extended: `places.photos,places.businessStatus,places.googleMapsUri` (Pro SKU, no cost change)
- `mapGoogleToSuggestion` populates photo fields from Google response
- `groupByCategoryOnly` sorts each category by distance ascending (nearest first)
- Seed: Can Paixano bar → nightlife

### Frontend
- **POI cards**: background-image with gradient overlay, left accent stripe, attribution chip, `businessStatus` badge (non-OPERATIONAL only), `aria-label` with photo credit
- **Detail sheet**: 3:2 cover photo hero with "Open in Google Maps" overlay, prev/next chevrons as siblings of hero (no nested-interactive), counter moved to bottom action row, "Powered by Google" replaces stale "Added by Foursquare Places", photo attribution line, address as plain text
- New CSS tokens for `wellness` (green family) and `shopping` (plum family)
- `CATEGORY_ICONS`: Dumbbell (wellness), ShoppingBag (shopping)

### What we are NOT doing (this PR)
- Atmosphere-tier enrichment (rating/price/hours/website/phone) — deferred
- Photo carousel or pinch-zoom in detail sheet
- Per-user sort preference UI

## Verification

| Check | Result |
|-------|--------|
| `pnpm test` | All discover tests pass (26 unit + 21 detail-sheet + poi-card + discover-view + schema tests) |
| `pnpm lint` | 0 errors |
| `pnpm typecheck` | Clean (shared, api, web) |

## Files Changed

23 files, +924/-166 lines across shared, api, and web packages.