### PR TITLE
fix(api): self-heal stale POI cache causing discover 500

### DIFF
--- a/apps/api/src/services/discover.service.ts
+++ b/apps/api/src/services/discover.service.ts
@@ -2,6 +2,8 @@ import { eq, sql } from "drizzle-orm";
 import { trips, poiCache } from "@/db/schema/index.js";
 import { POI_CATEGORIES, googleTypeLabels } from "@journiful/shared/types";
 import type { POISuggestion, POICategoryKey, POISuggestionsResponse } from "@journiful/shared/types";
+import { poiSuggestionSchema } from "@journiful/shared/schemas";
+import { z } from "zod";
 import type { AppDatabase } from "@/types/index.js";
 import type { FastifyBaseLogger } from "fastify";
 
@@ -67,7 +69,26 @@ export class DiscoverService implements IDiscoverService {
 
       if (cached.length > 0) {
         const row = cached[0]!;
-        const suggestions = row.suggestions as POISuggestion[];
+        let suggestions = row.suggestions as POISuggestion[];
+
+        // Validate cached blob against current schema — stale blobs (e.g. pre
+        // photo/background fields from commit dbc997ae) fail serialization and
+        // 500 the response. Detect here and self-heal instead.
+        const validation = z.array(poiSuggestionSchema).safeParse(suggestions);
+        if (!validation.success) {
+          if (this.googleApiKey) {
+            this.log.info(
+              { tripId, issues: validation.error.issues.slice(0, 3) },
+              "Stale POI cache schema, invalidating and refetching",
+            );
+            await this.db.delete(poiCache).where(eq(poiCache.tripId, tripId));
+            return this.fetchAndCache(tripId, location, lat, lon);
+          }
+          // No API key — can't refetch, normalize missing fields to null so
+          // the response still passes Zod serialization (degraded but not 500).
+          this.log.warn({ tripId }, "Stale POI cache schema but no API key, serving normalized cache");
+          suggestions = suggestions.map(normalizeSuggestion);
+        }
 
         // Stale cache detection: if destination coords changed, treat as cache miss
         const DEST_COORD_EPSILON = 0.001; // ~111 meters
@@ -364,6 +385,18 @@ export class DiscoverService implements IDiscoverService {
       };
     };
   }
+}
+
+// Normalize a possibly-stale cached POI (pre-dbc997ae blobs lack photo fields)
+function normalizeSuggestion(s: POISuggestion): POISuggestion {
+  const raw = s as unknown as Record<string, unknown>;
+  return {
+    ...s,
+    photoName: (raw.photoName as string | null | undefined) ?? null,
+    photoAttribution: (raw.photoAttribution as string | null | undefined) ?? null,
+    googleMapsUri: (raw.googleMapsUri as string | null | undefined) ?? null,
+    businessStatus: (raw.businessStatus as string | null | undefined) ?? null,
+  };
 }
 
 // Helpers

--- a/apps/api/tests/unit/discover.service.test.ts
+++ b/apps/api/tests/unit/discover.service.test.ts
@@ -51,6 +51,8 @@ interface MockDb {
   insert: ReturnType<typeof vi.fn>;
   values: ReturnType<typeof vi.fn>;
   onConflictDoUpdate: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  deleteWhere: ReturnType<typeof vi.fn>;
 }
 
 function createMockDb(): MockDb {
@@ -60,7 +62,9 @@ function createMockDb(): MockDb {
   const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
   const values = vi.fn().mockReturnValue({ onConflictDoUpdate });
   const insert = vi.fn().mockReturnValue({ values });
-  return { select, from, where, insert, values, onConflictDoUpdate };
+  const deleteWhere = vi.fn().mockResolvedValue(undefined);
+  const del = vi.fn().mockReturnValue({ where: deleteWhere });
+  return { select, from, where, insert, values, onConflictDoUpdate, delete: del, deleteWhere };
 }
 
 // ─── Mock logger ─────────────────────────────────────────────────────────────
@@ -202,6 +206,84 @@ describe("DiscoverService", () => {
       // Should have made 4 fetch calls (cache expired)
       expect(fetchSpy).toHaveBeenCalledTimes(7);
       expect(mockDb.onConflictDoUpdate).toHaveBeenCalled();
+    });
+  });
+
+  // ── Stale cache (pre-dbc997ae blobs missing photo fields) ─────────────────
+
+  describe("stale cache self-healing", () => {
+    function makeStaleSuggestion(): POISuggestion {
+      // Simulate a blob stored before photoName/photoAttribution/googleMapsUri/businessStatus existed
+      const full = makeSuggestion({ sourceId: "ChIJ-stale", name: "Stale Place" });
+      const { photoName: _photoName, photoAttribution: _photoAttribution, googleMapsUri: _googleMapsUri, businessStatus: _businessStatus, ...rest } =
+        full as unknown as Record<string, unknown> as POISuggestion & Record<string, unknown>;
+      return rest as unknown as POISuggestion;
+    }
+
+    it("invalidates stale cache and refetches when API key is present", async () => {
+      const stale = makeStaleSuggestion();
+
+      // Trip query
+      mockDb.where.mockResolvedValueOnce([{ id: TRIP_ID }]);
+      // Cache query — stale blob (missing the 4 photo fields)
+      mockDb.where.mockResolvedValueOnce([
+        {
+          tripId: TRIP_ID,
+          source: "google",
+          searchLat: 48.8566,
+          searchLon: 2.3522,
+          searchLocation: "Paris",
+          cachedAt: new Date(),
+          suggestions: [stale],
+        },
+      ]);
+      // fetchAndCache: existing cache read after delete (empty, since we deleted)
+      mockDb.where.mockResolvedValueOnce([]);
+      // fetchAndCache: re-read latest after fetch (also empty)
+      mockDb.where.mockResolvedValueOnce([]);
+      mockDb.deleteWhere.mockResolvedValueOnce(undefined);
+      mockDb.onConflictDoUpdate.mockResolvedValueOnce(undefined);
+
+      const result = await service.getDiscoverPOIs(TRIP_ID, 48.8566, 2.3522, "Paris");
+
+      expect(mockDb.deleteWhere).toHaveBeenCalled();
+      expect(fetchSpy).toHaveBeenCalledTimes(7);
+      expect(result.source).toBe("google");
+      expect(mockDb.onConflictDoUpdate).toHaveBeenCalled();
+    });
+
+    it("normalizes stale cache and serves it when no API key is configured", async () => {
+      const staleService = new DiscoverService(mockDb as never, "", mockLog as never);
+      const stale = makeStaleSuggestion();
+
+      // Mock fetch should NOT be called in this path
+      fetchSpy.mockClear();
+
+      // Trip query
+      mockDb.where.mockResolvedValueOnce([{ id: TRIP_ID }]);
+      // Cache query — stale blob
+      mockDb.where.mockResolvedValueOnce([
+        {
+          tripId: TRIP_ID,
+          source: "google",
+          searchLat: 48.8566,
+          searchLon: 2.3522,
+          searchLocation: "Paris",
+          cachedAt: new Date(),
+          suggestions: [stale],
+        },
+      ]);
+
+      const result = await staleService.getDiscoverPOIs(TRIP_ID, 48.8566, 2.3522, "Paris");
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(mockDb.deleteWhere).not.toHaveBeenCalled();
+      expect(result.categories.food_and_drink).toHaveLength(1);
+      const poi = result.categories.food_and_drink[0]!;
+      expect(poi.photoName).toBeNull();
+      expect(poi.photoAttribution).toBeNull();
+      expect(poi.googleMapsUri).toBeNull();
+      expect(poi.businessStatus).toBeNull();
     });
   });
 


### PR DESCRIPTION
Prod discover was 500ing for trip `db485d1e-0986-4a99-ab71-0d4dec738f4c` (`GET /api/trips/:id/discover?location=Sonoma`) with `FST_ERR_RESPONSE_SERIALIZATION` — every POI failed Zod validation for `photoName`/`photoAttribution`/`googleMapsUri`/`businessStatus` as `expected string, received undefined`.

**Root cause:** blobs cached before commit `dbc997ae` (Discover photo/background redesign, Aug 19) lack those 4 fields. Response schema `poiSuggestionSchema` (`z.string().nullable()`) rejects `undefined`, so a cache hit serializes to a 500. 30-day TTL means those trips 500 until natural expiry.

**Fix:** validate the cached `suggestions` array on read (`z.array(poiSuggestionSchema).safeParse`):
- **Key present:** `delete` the stale `poi_cache` row and fall through to `fetchAndCache` (rewrites blob with photo fields — one-time 6 Places calls per stale trip, then cached).
- **No key:** normalize missing fields to `null` and serve (degraded but not 500).

Adds unit tests for both branches (31/31 passing), `pnpm typecheck` and `pnpm lint` pass. Instant mitigation on prod is `?refresh=true` (forces rewrite); this fix makes refresh automatic for stale blobs.