### PR TITLE
fix(deps): dedupe baseline-browser-mapping@2.11.14 key in pnpm-lock.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4192,11 +4192,6 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  baseline-browser-mapping@2.11.14:
-    resolution: {integrity: sha512-JyJ954WzuIR8/FFzX0o5krdSTrBAkcCSRfWSleRsIHSWV+cZe2FI1PKggVkFke1hBldRs+LRxUczzE9iPmgZww==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
@@ -11381,8 +11376,6 @@ snapshots:
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
-
-  baseline-browser-mapping@2.11.14: {}
 
   baseline-browser-mapping@2.11.14: {}
 


### PR DESCRIPTION
## Problem

The last Railway deploy (built from `d4af6c0f`, dependabot PR #189) failed for both `api` and `web`:

```
ERR_PNPM_BROKEN_LOCKFILE  The lockfile at /app/pnpm-lock.yaml is broken:
duplicated mapping key (4195:3)
```

`baseline-browser-mapping@2.11.14` appeared twice in the `packages:` section and twice in the `snapshots:` section of `pnpm-lock.yaml`. Dependabot bumped two transitive versions (`2.10.43`, `2.11.12`) to `2.11.14`, colliding with an existing `2.11.14` entry without deduplicating.

## Fix

Manually removed the two duplicate blocks (identical content) — a 7-line deletion, no version/resolution drift.

## Verification

- `pnpm install --frozen-lockfile --lockfile-only` → exit 0
- `pnpm install --frozen-lockfile` (the exact Railway build gate) → exit 0

This will trigger a fresh Railway deploy on merge, unblocking both services from the currently-failing state.